### PR TITLE
Set to field when using merge_data

### DIFF
--- a/anymail/backends/sendgrid.py
+++ b/anymail/backends/sendgrid.py
@@ -100,6 +100,7 @@ class SendGridPayload(RequestsPayload):
             self.set_recipients('to', self.to_list)
         else:
             # Merge-friendly smtpapi 'to' field
+            self.set_recipients('to', self.to_list)
             self.smtpapi['to'] = [email.address for email in self.to_list]
             self.all_recipients += self.to_list
 

--- a/tests/test_sendgrid_backend.py
+++ b/tests/test_sendgrid_backend.py
@@ -432,7 +432,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
         data = self.get_api_call_data()
         smtpapi = self.get_smtpapi()
         self.assertEqual(data['toname'], [' ', 'Bob'])
-        self.assertEqual(data['to'], ['alice@example.com', 'Bob <bob@example.com>'])
+        self.assertEqual(data['to'], ['alice@example.com', 'bob@example.com'])
         self.assertEqual(smtpapi['to'], ['alice@example.com', 'Bob <bob@example.com>'])
         self.assertEqual(smtpapi['sub'], {
             ':name': ["Alice", "Bob"],

--- a/tests/test_sendgrid_backend.py
+++ b/tests/test_sendgrid_backend.py
@@ -431,7 +431,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
 
         data = self.get_api_call_data()
         smtpapi = self.get_smtpapi()
-        self.assertEqual(data['toname'], ['', 'Bob'])
+        self.assertEqual(data['toname'], [' ', 'Bob'])
         self.assertEqual(data['to'], ['alice@example.com', 'Bob <bob@example.com>'])
         self.assertEqual(smtpapi['to'], ['alice@example.com', 'Bob <bob@example.com>'])
         self.assertEqual(smtpapi['sub'], {

--- a/tests/test_sendgrid_backend.py
+++ b/tests/test_sendgrid_backend.py
@@ -431,8 +431,8 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
 
         data = self.get_api_call_data()
         smtpapi = self.get_smtpapi()
-        self.assertNotIn('to', data)  # recipients should be moved to smtpapi-to with merge_data
-        self.assertNotIn('toname', data)
+        self.assertEqual(data['toname'], ['', 'Bob'])
+        self.assertEqual(data['to'], ['alice@example.com', 'Bob <bob@example.com>'])
         self.assertEqual(smtpapi['to'], ['alice@example.com', 'Bob <bob@example.com>'])
         self.assertEqual(smtpapi['sub'], {
             ':name': ["Alice", "Bob"],


### PR DESCRIPTION
The `to` field is required even if providing recipient addresses in x-smtpapi. See https://sendgrid.com/docs/API_Reference/Web_API/mail.html#-send.