### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/tests/test_mailgun_backend.py
+++ b/tests/test_mailgun_backend.py
@@ -146,7 +146,7 @@ class MailgunBackendStandardEmailTests(MailgunBackendMockAPITestCase):
 
     def test_unicode_attachment_correctly_decoded(self):
         # Slight modification from the Django unicode docs:
-        # http://django.readthedocs.org/en/latest/ref/unicode.html#email
+        # https://django.readthedocs.io/en/latest/ref/unicode.html#email
         self.message.attach("Une pièce jointe.html", '<p>\u2019</p>', mimetype='text/html')
         self.message.send()
         files = self.get_api_call_files()

--- a/tests/test_mandrill_backend.py
+++ b/tests/test_mandrill_backend.py
@@ -172,7 +172,7 @@ class MandrillBackendStandardEmailTests(MandrillBackendMockAPITestCase):
 
     def test_unicode_attachment_correctly_decoded(self):
         # Slight modification from the Django unicode docs:
-        # http://django.readthedocs.org/en/latest/ref/unicode.html#email
+        # https://django.readthedocs.io/en/latest/ref/unicode.html#email
         self.message.attach("Une pièce jointe.html", '<p>\u2019</p>', mimetype='text/html')
         self.message.send()
         data = self.get_api_call_json()

--- a/tests/test_postmark_backend.py
+++ b/tests/test_postmark_backend.py
@@ -173,7 +173,7 @@ class PostmarkBackendStandardEmailTests(PostmarkBackendMockAPITestCase):
 
     def test_unicode_attachment_correctly_decoded(self):
         # Slight modification from the Django unicode docs:
-        # http://django.readthedocs.org/en/latest/ref/unicode.html#email
+        # https://django.readthedocs.io/en/latest/ref/unicode.html#email
         self.message.attach("Une pièce jointe.html", '<p>\u2019</p>', mimetype='text/html')
         self.message.send()
         data = self.get_api_call_json()

--- a/tests/test_sendgrid_backend.py
+++ b/tests/test_sendgrid_backend.py
@@ -221,7 +221,7 @@ class SendGridBackendStandardEmailTests(SendGridBackendMockAPITestCase):
 
     def test_unicode_attachment_correctly_decoded(self):
         # Slight modification from the Django unicode docs:
-        # http://django.readthedocs.org/en/latest/ref/unicode.html#email
+        # https://django.readthedocs.io/en/latest/ref/unicode.html#email
         self.message.attach("Une pièce jointe.html", '<p>\u2019</p>', mimetype='text/html')
         self.message.send()
         files = self.get_api_call_files()


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.