### PR TITLE
Fixed crasher when sending rfc822 messages as attachments.

### DIFF
--- a/anymail/utils.py
+++ b/anymail/utils.py
@@ -171,6 +171,12 @@ class Attachment(object):
         if isinstance(attachment, MIMEBase):
             self.name = attachment.get_filename()
             self.content = attachment.get_payload(decode=True)
+            if self.content is None:
+                if hasattr(attachment, 'as_bytes'):
+                    self.content = attachment.as_bytes()
+                else:
+                    # Python 2.7 fallback
+                    self.content = attachment.as_string().encode(self.encoding)
             self.mimetype = attachment.get_content_type()
 
             if get_content_disposition(attachment) == 'inline':

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,6 +52,9 @@ def sample_image_content(filename=SAMPLE_IMAGE_FILENAME):
         return f.read()
 
 
+SAMPLE_FORWARDED_EMAIL = b'Received: by luna.mailgun.net with SMTP mgrt 8734663311733; Fri, 03 May 2013\n 18:26:27 +0000\nContent-Type: multipart/alternative; boundary="eb663d73ae0a4d6c9153cc0aec8b7520"\nMime-Version: 1.0\nSubject: Test email\nFrom: Someone <someone@example.com>\nTo: someoneelse@example.com\nReply-To: reply.to@example.com\nMessage-Id: <20130503182626.18666.16540@example.com>\nList-Unsubscribe: <mailto:u+na6tmy3ege4tgnldmyytqojqmfsdembyme3tmy3cha4wcndbgaydqyrgoi6wszdpovrhi5dinfzw63tfmv4gs43uomstimdhnvqws3bomnxw2jtuhusteqjgmq6tm@example.com>\nX-Mailgun-Sid: WyIwNzI5MCIsICJhbGljZUBleGFtcGxlLmNvbSIsICI2Il0=\nX-Mailgun-Variables: {"my_var_1": "Mailgun Variable #1", "my-var-2": "awesome"}\nDate: Fri, 03 May 2013 18:26:27 +0000\nSender: someone@example.com\n\n--eb663d73ae0a4d6c9153cc0aec8b7520\nMime-Version: 1.0\nContent-Type: text/plain; charset="ascii"\nContent-Transfer-Encoding: 7bit\n\nHi Bob, This is a message. Thanks!\n\n--eb663d73ae0a4d6c9153cc0aec8b7520\nMime-Version: 1.0\nContent-Type: text/html; charset="ascii"\nContent-Transfer-Encoding: 7bit\n\n<html>\n                            <body>Hi Bob, This is a message. Thanks!\n                            <br>\n</body></html>\n--eb663d73ae0a4d6c9153cc0aec8b7520--\n'
+
+
 # noinspection PyUnresolvedReferences
 class AnymailTestMixin:
     """Helpful additional methods for Anymail tests"""


### PR DESCRIPTION
The comment in `MIMEBase.get_payload()` explains that it can return `None` when it is a multi-part message. In this case we need to convert the whole thing to bytes.

Without this patch, in production you get a crasher like the following:

      File "/home/luke/.virtualenvs/cciw/lib/python3.5/site-packages/django/core/mail/message.py", line 342, in send
        return self.get_connection(fail_silently).send_messages([self])
      File "/home/luke/.virtualenvs/cciw/lib/python3.5/site-packages/anymail/backends/base.py", line 88, in send_messages
        sent = self._send(message)
      File "/home/luke/.virtualenvs/cciw/lib/python3.5/site-packages/anymail/backends/base_requests.py", line 56, in _send
        return super(AnymailRequestsBackend, self)._send(message)
      File "/home/luke/.virtualenvs/cciw/lib/python3.5/site-packages/anymail/backends/base.py", line 118, in _send
        response = self.post_to_esp(payload, message)
      File "/home/luke/.virtualenvs/cciw/lib/python3.5/site-packages/anymail/backends/base_requests.py", line 70, in post_to_esp
        except requests.RequestException as err:
      File "/home/luke/.virtualenvs/cciw/lib/python3.5/site-packages/requests/sessions.py", line 474, in request
        prep = self.prepare_request(req)
      File "/home/luke/.virtualenvs/cciw/lib/python3.5/site-packages/requests/sessions.py", line 407, in prepare_request
        hooks=merge_hooks(request.hooks, self.hooks),
      File "/home/luke/.virtualenvs/cciw/lib/python3.5/site-packages/requests/models.py", line 305, in prepare
        self.prepare_body(data, files, json)
      File "/home/luke/.virtualenvs/cciw/lib/python3.5/site-packages/requests/models.py", line 499, in prepare_body
        (body, content_type) = self._encode_files(files, data)
      File "/home/luke/.virtualenvs/cciw/lib/python3.5/site-packages/requests/models.py", line 158, in _encode_files
        fdata = fp.read()
    AttributeError: 'NoneType' object has no attribute 'read'


This exception doesn't show up so easily in the test because the `requests` calls are mocked out.