### PR TITLE
Mailjet: Upgrade to Send API v3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,11 @@ Breaking changes
   (For compatibility with Django 1.11, stay on the Anymail `v7.2 LTS`_
   extended support branch by setting your requirements to `django-anymail~=7.2`.)
 
+* **Mailjet:** Upgrade to Mailjet's newer v3.1 send API. This change should be
+  transparent to most users, but if you are using Anymail's `esp_extra` with Mailjet,
+  you will need to update it for compatibility with the new API. (See
+  `docs <https://anymail.readthedocs.io/en/latest/esps/mailjet/#esp-extra-support>`__.)
+
 * Remove Anymail internal code related to supporting Python 2 and older Django
   versions. This does not change the documented API, but may affect you if your
   code borrowed from Anymail's undocumented internals. (You should be able to switch

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,9 +37,10 @@ Breaking changes
   (For compatibility with Django 1.11, stay on the Anymail `v7.2 LTS`_
   extended support branch by setting your requirements to `django-anymail~=7.2`.)
 
-* **Mailjet:** Upgrade to Mailjet's newer v3.1 send API. This change should be
-  transparent to most users, but if you are using Anymail's `esp_extra` with Mailjet,
-  you will need to update it for compatibility with the new API. (See
+* **Mailjet:** Upgrade to Mailjet's newer v3.1 send API. Most Mailjet users will not
+  be affected by this change, with two exceptions: (1) Mailjet's v3.1 API does not allow
+  multiple reply-to addresses, and (2) if you are using Anymail's `esp_extra`, you will
+  need to update it for compatibility with the new API. (See
   `docs <https://anymail.readthedocs.io/en/latest/esps/mailjet/#esp-extra-support>`__.)
 
 * Remove Anymail internal code related to supporting Python 2 and older Django

--- a/anymail/backends/mailjet.py
+++ b/anymail/backends/mailjet.py
@@ -3,7 +3,7 @@ from requests.structures import CaseInsensitiveDict
 from .base_requests import AnymailRequestsBackend, RequestsPayload
 from ..exceptions import AnymailRequestsAPIError
 from ..message import AnymailRecipientStatus
-from ..utils import get_anymail_setting, parse_address_list
+from ..utils import get_anymail_setting, parse_address_list, update_deep
 
 
 class EmailBackend(AnymailRequestsBackend):
@@ -74,76 +74,38 @@ class MailjetPayload(RequestsPayload):
             'Content-Type': 'application/json',
         }
         self.recipients = []  # for backend parse_recipient_status
-        # Late binding of batch recipient variables:
         self.metadata = None
-        self.merge_data = {}
-        self.merge_metadata = {}
         super().__init__(message, defaults, backend, auth=auth, headers=http_headers, *args, **kwargs)
 
     def get_api_endpoint(self):
         return "send"
 
     def serialize_data(self):
-        headers = self.data["Headers"]
-        if "Reply-To" in headers:
-            # Reply-To must be in its own param
-            reply_to = headers.pop('Reply-To')
-            self.set_reply_to(parse_address_list([reply_to]))
-        if len(headers) > 0:
-            self.data["Headers"] = dict(headers)  # flatten to normal dict for json serialization
-        else:
-            del self.data["Headers"]  # don't send empty headers
-
-        payload = {}
-        if "SandboxMode" in self.data:
-            # hoist to payload root
-            payload["SandboxMode"] = self.data.pop("SandboxMode")
-
-        if self.is_batch():
-            to_recipients = self.data.pop("To", [])  # Mailjet {"Email", "Name"} dicts
-            payload["Messages"] = [
-                self._data_for_recipient(to_recipient)
-                for to_recipient in to_recipients]
-        else:
-            payload["Messages"] = [self.data]
-
-        return self.serialize_json(payload)
-
-    def _data_for_recipient(self, to_recipient):
-        # Return send data for single recipient, without modifying self.data
-        data = self.data.copy()
-        data["To"] = [to_recipient]
-        email_addr = to_recipient["Email"]
-
-        if email_addr in self.merge_data:
-            recipient_merge_data = self.merge_data[email_addr]
-            if "Variables" in data:
-                data["Variables"] = data["Variables"].copy()  # clone merge_global_data
-                data["Variables"].update(recipient_merge_data)
-            else:
-                data["Variables"] = recipient_merge_data
-            data["Variables"] = self._strip_none(data["Variables"])
-
-        if email_addr in self.merge_metadata:
-            recipient_metadata = self.merge_metadata[email_addr]
-            if self.metadata:
-                metadata = self.metadata.copy()  # clone toplevel metadata
-                metadata.update(recipient_metadata)
-            else:
-                metadata = recipient_metadata
-            data["EventPayload"] = self.serialize_json(metadata)
-
-        return data
+        return self.serialize_json(self.data)
 
     #
     # Payload construction
     #
 
     def init_payload(self):
-        # the single Messages item, or base to be replicated for merge/batch:
+        # The v3.1 Send payload. We use Globals for most parameters,
+        # which simplifies batch sending if it's used (and if not,
+        # still works as expected for ordinary send).
+        # https://dev.mailjet.com/email/reference/send-emails#v3_1_post_send
         self.data = {
-            "Headers": CaseInsensitiveDict()
+            "Globals": {},
+            "Messages": [],
         }
+
+    def _burst_for_batch_send(self):
+        """Expand the payload Messages into a separate object for each To address"""
+        # This can be called multiple times -- if the payload has already been burst,
+        # it will have no effect.
+        # For simplicity, this assumes that "To" is the only Messages param we use
+        # (because everything else goes in Globals).
+        if len(self.data["Messages"]) == 1:
+            to_recipients = self.data["Messages"][0].get("To", [])
+            self.data["Messages"] = [{"To": [to]} for to in to_recipients]
 
     @staticmethod
     def _mailjet_email(email):
@@ -162,37 +124,60 @@ class MailjetPayload(RequestsPayload):
         return {key: value for key, value in variables.items() if value is not None}
 
     def set_from_email(self, email):
-        self.data["From"] = self._mailjet_email(email)
+        self.data["Globals"]["From"] = self._mailjet_email(email)
 
-    def set_recipients(self, recipient_type, emails):
-        assert recipient_type in ["to", "cc", "bcc"]
-        if len(emails) > 0:
-            self.data[recipient_type.title()] = [self._mailjet_email(email) for email in emails]
+    def set_to(self, emails):
+        # "To" is the one non-batch param we transmit in Messages rather than Globals.
+        # (See also _burst_for_batch_send, set_merge_data, and set_merge_metadata.)
+        if len(self.data["Messages"]) > 0:
+            # This case shouldn't happen. Please file a bug report if it does.
+            raise AssertionError("set_to called with non-empty Messages list")
+        if emails:
+            self.data["Messages"].append({
+                "To": [self._mailjet_email(email) for email in emails]
+            })
+            self.recipients += emails
+        else:
+            # Mailjet requires a To list; cc-only messages aren't possible
+            self.unsupported_feature("messages without any `to` recipients")
+
+    def set_cc(self, emails):
+        if emails:
+            self.data["Globals"]["Cc"] = [self._mailjet_email(email) for email in emails]
+            self.recipients += emails
+
+    def set_bcc(self, emails):
+        if emails:
+            self.data["Globals"]["Bcc"] = [self._mailjet_email(email) for email in emails]
             self.recipients += emails
 
     def set_subject(self, subject):
-        self.data["Subject"] = subject
+        self.data["Globals"]["Subject"] = subject
 
     def set_reply_to(self, emails):
         if len(emails) > 0:
-            self.data["ReplyTo"] = self._mailjet_email(emails[0])
+            self.data["Globals"]["ReplyTo"] = self._mailjet_email(emails[0])
             if len(emails) > 1:
                 self.unsupported_feature("Multiple reply_to addresses")
 
     def set_extra_headers(self, headers):
-        self.data["Headers"].update(headers)
+        case_insensitive_headers = CaseInsensitiveDict(headers)
+        reply_to = case_insensitive_headers.pop("Reply-To", None)
+        if reply_to is not None:
+            self.set_reply_to(parse_address_list([reply_to]))
+        self.data["Globals"]["Headers"] = dict(case_insensitive_headers)
 
     def set_text_body(self, body):
         if body:  # Django's default empty text body confuses Mailjet (esp. templates)
-            self.data["TextPart"] = body
+            self.data["Globals"]["TextPart"] = body
 
     def set_html_body(self, body):
         if body is not None:
-            if "HTMLPart" in self.data:
+            if "HTMLPart" in self.data["Globals"]:
                 # second html body could show up through multiple alternatives, or html body + alternative
                 self.unsupported_feature("multiple html parts")
 
-            self.data["HTMLPart"] = body
+            self.data["Globals"]["HTMLPart"] = body
 
     def add_attachment(self, attachment):
         att = {
@@ -205,48 +190,56 @@ class MailjetPayload(RequestsPayload):
             att["ContentID"] = attachment.cid
         else:
             field = "Attachments"
-        self.data.setdefault(field, []).append(att)
+        self.data["Globals"].setdefault(field, []).append(att)
 
     def set_envelope_sender(self, email):
-        self.data["Sender"] = self._mailjet_email(email)
+        self.data["Globals"]["Sender"] = self._mailjet_email(email)
 
     def set_metadata(self, metadata):
         # Mailjet expects a single string payload
-        self.data["EventPayload"] = self.serialize_json(metadata)
+        self.data["Globals"]["EventPayload"] = self.serialize_json(metadata)
         self.metadata = metadata  # keep original in case we need to merge with merge_metadata
+
+    def set_merge_metadata(self, merge_metadata):
+        self._burst_for_batch_send()
+        for message in self.data["Messages"]:
+            email = message["To"][0]["Email"]
+            if email in merge_metadata:
+                if self.metadata:
+                    recipient_metadata = self.metadata.copy()
+                    recipient_metadata.update(merge_metadata[email])
+                else:
+                    recipient_metadata = merge_metadata[email]
+                message["EventPayload"] = self.serialize_json(recipient_metadata)
 
     def set_tags(self, tags):
         # The choices here are CustomID or Campaign, and Campaign seems closer
         # to how "tags" are handled by other ESPs -- e.g., you can view dashboard
         # statistics across all messages with the same Campaign.
         if len(tags) > 0:
-            self.data["CustomCampaign"] = tags[0]
+            self.data["Globals"]["CustomCampaign"] = tags[0]
             if len(tags) > 1:
                 self.unsupported_feature('multiple tags (%r)' % tags)
 
     def set_track_clicks(self, track_clicks):
-        self.data["TrackClicks"] = "enabled" if track_clicks else "disabled"
+        self.data["Globals"]["TrackClicks"] = "enabled" if track_clicks else "disabled"
 
     def set_track_opens(self, track_opens):
-        self.data["TrackOpens"] = "enabled" if track_opens else "disabled"
+        self.data["Globals"]["TrackOpens"] = "enabled" if track_opens else "disabled"
 
     def set_template_id(self, template_id):
-        self.data["TemplateID"] = int(template_id)  # Mailjet requires integer (not string)
-        self.data["TemplateLanguage"] = True
+        self.data["Globals"]["TemplateID"] = int(template_id)  # Mailjet requires integer (not string)
+        self.data["Globals"]["TemplateLanguage"] = True
 
     def set_merge_data(self, merge_data):
-        # Will be handled later in serialize_data
-        self.merge_data = merge_data
+        self._burst_for_batch_send()
+        for message in self.data["Messages"]:
+            email = message["To"][0]["Email"]
+            if email in merge_data:
+                message["Variables"] = self._strip_none(merge_data[email])
 
     def set_merge_global_data(self, merge_global_data):
-        self.data["Variables"] = self._strip_none(merge_global_data)
-
-    def set_merge_metadata(self, merge_metadata):
-        # Will be handled later in serialize_data
-        self.merge_metadata = merge_metadata
+        self.data["Globals"]["Variables"] = self._strip_none(merge_global_data)
 
     def set_esp_extra(self, extra):
-        # extra gets merged into the payload at the "Messages" item level
-        # (and will get replicated for each recipient in a batch send).
-        # (But note special handling for SandboxMode in serialize_data.)
-        self.data.update(extra)
+        update_deep(self.data, extra)

--- a/anymail/backends/mailjet.py
+++ b/anymail/backends/mailjet.py
@@ -1,9 +1,7 @@
-from requests.structures import CaseInsensitiveDict
-
 from .base_requests import AnymailRequestsBackend, RequestsPayload
 from ..exceptions import AnymailRequestsAPIError
 from ..message import AnymailRecipientStatus
-from ..utils import get_anymail_setting, parse_address_list, update_deep
+from ..utils import get_anymail_setting, update_deep
 
 
 class EmailBackend(AnymailRequestsBackend):
@@ -153,11 +151,7 @@ class MailjetPayload(RequestsPayload):
                 self.unsupported_feature("Multiple reply_to addresses")
 
     def set_extra_headers(self, headers):
-        case_insensitive_headers = CaseInsensitiveDict(headers)
-        reply_to = case_insensitive_headers.pop("Reply-To", None)
-        if reply_to is not None:
-            self.set_reply_to(parse_address_list([reply_to]))
-        self.data["Globals"]["Headers"] = dict(case_insensitive_headers)
+        self.data["Globals"]["Headers"] = headers
 
     def set_text_body(self, body):
         if body:  # Django's default empty text body confuses Mailjet (esp. templates)

--- a/anymail/backends/mailjet.py
+++ b/anymail/backends/mailjet.py
@@ -115,14 +115,6 @@ class MailjetPayload(RequestsPayload):
             result["Name"] = email.display_name
         return result
 
-    @staticmethod
-    def _strip_none(variables):
-        """Return dict `variables` omitting any keys with `None` value"""
-        # Works around an Mailjet API bug where a null personalization variable results in a message
-        # that appears to succeed (with a MessageHref and everything), but never actually gets sent.
-        # (Reported to Mailjet ticket #830569 1/2018)
-        return {key: value for key, value in variables.items() if value is not None}
-
     def set_from_email(self, email):
         self.data["Globals"]["From"] = self._mailjet_email(email)
 
@@ -236,10 +228,10 @@ class MailjetPayload(RequestsPayload):
         for message in self.data["Messages"]:
             email = message["To"][0]["Email"]
             if email in merge_data:
-                message["Variables"] = self._strip_none(merge_data[email])
+                message["Variables"] = merge_data[email]
 
     def set_merge_global_data(self, merge_global_data):
-        self.data["Globals"]["Variables"] = self._strip_none(merge_global_data)
+        self.data["Globals"]["Variables"] = merge_global_data
 
     def set_esp_extra(self, extra):
         update_deep(self.data, extra)

--- a/docs/esps/mailjet.rst
+++ b/docs/esps/mailjet.rst
@@ -3,23 +3,18 @@
 Mailjet
 =======
 
-Anymail integrates with the `Mailjet`_ email service, using their transactional `Send API`_ (v3).
+Anymail integrates with the `Mailjet`_ email service, using their transactional `Send API v3.1`_.
 
-.. _mailjet-v31-api:
+.. versionchanged:: 8.0
 
-.. note::
-
-    Mailjet has released a newer `v3.1 Send API`_, but due to mismatches between its
-    documentation and actual behavior, Anymail has been unable to switch to it.
-    Anymail's maintainers have reported the problems to Mailjet, and if and when they
-    are resolved, Anymail will switch to the v3.1 API. This change should be largely
-    transparent to your code, unless you are using Anymail's
+    Earlier Anymail versions used Mailjet's older `Send API v3`_. The change to v3.1 fixes
+    some limitations of the earlier API, and should only affect your code if you use Anymail's
     :ref:`esp_extra <mailjet-esp-extra>` feature to set API-specific options.
 
 
 .. _Mailjet: https://www.mailjet.com/
-.. _Send API: https://dev.mailjet.com/guides/#choose-sending-method
-.. _v3.1 Send API: https://dev.mailjet.com/guides/#send-api-v3-1-beta
+.. _Send API v3.1: https://dev.mailjet.com/guides/#send-api-v3-1
+.. _Send API v3: https://dev.mailjet.com/guides/#send-api-v3
 
 
 Settings
@@ -68,9 +63,8 @@ nor ``ANYMAIL_MAILJET_API_KEY`` is set.
 
 The base url for calling the Mailjet API.
 
-The default is ``MAILJET_API_URL = "https://api.mailjet.com/v3"``
-(It's unlikely you would need to change this. This setting cannot be used
-to opt into a newer API version; the parameters are not backwards compatible.)
+The default is ``MAILJET_API_URL = "https://api.mailjet.com/v3.1/"``
+(It's unlikely you would need to change this.)
 
 
 .. _mailjet-esp-extra:
@@ -80,24 +74,20 @@ esp_extra support
 
 To use Mailjet features not directly supported by Anymail, you can
 set a message's :attr:`~anymail.message.AnymailMessage.esp_extra` to
-a `dict` of Mailjet's `Send API json properties`_.
-Your :attr:`esp_extra` dict will be merged into the
-parameters Anymail has constructed for the send, with `esp_extra`
+a `dict` of Mailjet's `Send API message json properties`_.
+Your :attr:`esp_extra` dict will be merged into each of the ``Messages``
+JSON objects Anymail has constructed for the send, with `esp_extra`
 having precedence in conflicts.
-
-.. note::
-
-    Any ``esp_extra`` settings will need to be updated when Anymail changes
-    to use Mailjet's upcoming v3.1 API. (See :ref:`note above <mailjet-v31-api>`.)
 
 Example:
 
     .. code-block:: python
 
         message.esp_extra = {
-            # Mailjet v3.0 Send API options:
-            "Mj-prio": 3,  # Use Mailjet critically-high priority queue
-            "Mj-CustomID": my_event_tracking_id,
+            # Some Mailjet v3.1 Send API message options:
+            "Priority": 3,  # Use Mailjet critically-high priority queue
+            "CustomID": my_event_tracking_id,
+            "TemplateErrorReporting": "dev+mailtemplatebug@example.com",
         }
 
 
@@ -105,13 +95,19 @@ Example:
 :ref:`global send defaults <send-defaults>` to apply it to all
 messages.)
 
-
-.. _Send API json properties: https://dev.mailjet.com/guides/#send-api-json-properties
+.. _Send API message json properties:
+   https://dev.mailjet.com/email/reference/send-emails#v3_1_post_send
 
 
 
 Limitations and quirks
 ----------------------
+
+**Single reply_to**
+  Mailjet's API only supports a single Reply-To email address. If your message
+  has two or more, you'll get an :exc:`~anymail.exceptions.AnymailUnsupportedFeature`
+  error---or if you've enabled :setting:`ANYMAIL_IGNORE_UNSUPPORTED_FEATURES`,
+  Anymail will use only the first `reply_to` address.
 
 **Single tag**
   Anymail uses Mailjet's `campaign`_ option for tags, and Mailjet allows
@@ -131,27 +127,27 @@ Limitations and quirks
   Mailjet, but this may result in an API error if you have not received
   special approval from Mailjet support to use custom senders.
 
-**Commas in recipient names**
-  Mailjet's v3 API does not properly handle commas in recipient display-names.
-  (Tested July, 2017, and confirmed with Mailjet API support.)
+**message_id is MessageID (not MessageUUID)**
+  Mailjet's Send API v3.1 returns both a "legacy" MessageID and a newer
+  MessageUUID for each successfully sent message. Anymail uses the MessageID
+  as the :attr:`~anymail.message.AnymailStatus.message_id` when reporting
+  :ref:`esp-send-status`, because Mailjet's other (statistics, event tracking)
+  APIs don't yet support MessageUUID.
 
-  If your message would be affected, Anymail attempts to work around
-  the problem by switching to `MIME encoded-word`_ syntax where needed.
-
-  Most modern email clients should support this syntax, but if you run
-  into issues, you might want to strip commas from all
-  recipient names (in ``to``, ``cc``, *and* ``bcc``) before sending.
-
-  (This should be resolved in a future release when
-  Anymail :ref:`switches <mailjet-v31-api>` to Mailjet's upcoming v3.1 API.)
-
-.. _MIME encoded-word: https://en.wikipedia.org/wiki/MIME#Encoded-Word
+**Older limitations**
 
 .. versionchanged:: 6.0
 
   Earlier versions of Anymail were unable to mix ``cc`` or ``bcc`` fields
   and :attr:`~anymail.message.AnymailMessage.merge_data` in the same Mailjet message.
   This limitation was removed in Anymail 6.0.
+
+.. versionchanged:: 8.0
+
+    Earlier Anymail versions used Mailjet's older v3 API, which had problems
+    with commas in recipient display names, and which didn't support cc or
+    bcc when using :attr:`~anymail.message.AnymailMessage.merge_data`. These
+    limitations have been removed in Mailjet's newer v3.1 API.
 
 
 .. _mailjet-templates:
@@ -161,6 +157,17 @@ Batch sending/merge and ESP templates
 
 Mailjet offers both :ref:`ESP stored templates <esp-stored-templates>`
 and :ref:`batch sending <batch-send>` with per-recipient merge data.
+
+When you send a message with multiple ``to`` addresses, the
+:attr:`~anymail.message.AnymailMessage.merge_data` determines how many
+distinct messages are sent:
+
+* If :attr:`~anymail.message.AnymailMessage.merge_data` is *not* set (the default),
+  Anymail will tell Mailjet to send a single message, and all recipients will see
+  the complete list of To addresses.
+* If :attr:`~anymail.message.AnymailMessage.merge_data` *is* set---even to an empty
+  `{}` dict, Anymail will tell Mailjet to send a separate message for each ``to``
+  address, and the recipients won't see the other To addresses.
 
 You can use a Mailjet stored transactional template by setting a message's
 :attr:`~anymail.message.AnymailMessage.template_id` to the

--- a/docs/esps/mailjet.rst
+++ b/docs/esps/mailjet.rst
@@ -74,28 +74,36 @@ esp_extra support
 
 To use Mailjet features not directly supported by Anymail, you can
 set a message's :attr:`~anymail.message.AnymailMessage.esp_extra` to
-a `dict` of Mailjet's `Send API message json properties`_.
-Your :attr:`esp_extra` dict will be merged into each of the ``Messages``
-JSON objects Anymail has constructed for the send, with `esp_extra`
-having precedence in conflicts.
+a `dict` of Mailjet's `Send API body parameters`_.
+Your :attr:`esp_extra` dict will be deeply merged into the Mailjet
+API payload, with `esp_extra` having precedence in conflicts.
+
+(Note that it's *not* possible to merge into the ``"Messages"`` key;
+any value you supply would override ``"Messages"`` completely. Use ``"Globals"``
+for options to apply to all messages.)
 
 Example:
 
     .. code-block:: python
 
         message.esp_extra = {
-            # Some Mailjet v3.1 Send API message options:
-            "Priority": 3,  # Use Mailjet critically-high priority queue
-            "CustomID": my_event_tracking_id,
-            "TemplateErrorReporting": "dev+mailtemplatebug@example.com",
+            # Most "Messages" options can be included under Globals:
+            "Globals": {
+              "Priority": 3,  # Use Mailjet critically-high priority queue
+              "TemplateErrorReporting": {"Email": "dev+mailtemplatebug@example.com"},
+            },
+            # A few options must be at the root:
+            "SandboxMode": True,
+            "AdvanceErrorHandling": True,
+            # *Don't* try to set Messages:
+            # "Messages": [... this would override *all* recipients, not be merged ...]
         }
 
 
-(You can also set `"esp_extra"` in Anymail's
-:ref:`global send defaults <send-defaults>` to apply it to all
-messages.)
+(You can also set `"esp_extra"` in Anymail's :ref:`global send defaults <send-defaults>`
+to apply it to all messages.)
 
-.. _Send API message json properties:
+.. _Send API body parameters:
    https://dev.mailjet.com/email/reference/send-emails#v3_1_post_send
 
 

--- a/docs/esps/mailjet.rst
+++ b/docs/esps/mailjet.rst
@@ -9,7 +9,8 @@ Anymail integrates with the `Mailjet`_ email service, using their transactional 
 
     Earlier Anymail versions used Mailjet's older `Send API v3`_. The change to v3.1 fixes
     some limitations of the earlier API, and should only affect your code if you use Anymail's
-    :ref:`esp_extra <mailjet-esp-extra>` feature to set API-specific options.
+    :ref:`esp_extra <mailjet-esp-extra>` feature to set API-specific options or if you are
+    trying to send messages with :ref:`multiple reply-to addresses <mailjet-quirks>`.
 
 
 .. _Mailjet: https://www.mailjet.com/
@@ -107,6 +108,7 @@ to apply it to all messages.)
    https://dev.mailjet.com/email/reference/send-emails#v3_1_post_send
 
 
+.. _mailjet-quirks:
 
 Limitations and quirks
 ----------------------
@@ -146,16 +148,15 @@ Limitations and quirks
 
 .. versionchanged:: 6.0
 
-  Earlier versions of Anymail were unable to mix ``cc`` or ``bcc`` fields
-  and :attr:`~anymail.message.AnymailMessage.merge_data` in the same Mailjet message.
-  This limitation was removed in Anymail 6.0.
+    Earlier versions of Anymail were unable to mix ``cc`` or ``bcc`` fields
+    and :attr:`~anymail.message.AnymailMessage.merge_data` in the same Mailjet message.
+    This limitation was removed in Anymail 6.0.
 
 .. versionchanged:: 8.0
 
-    Earlier Anymail versions used Mailjet's older v3 API, which had problems
-    with commas in recipient display names, and which didn't support cc or
-    bcc when using :attr:`~anymail.message.AnymailMessage.merge_data`. These
-    limitations have been removed in Mailjet's newer v3.1 API.
+    Earlier Anymail versions had special handling to work around a Mailjet v3 API bug
+    with commas in recipient display names. Anymail 8.0 uses Mailjet's v3.1 API, which
+    does not have the bug.
 
 
 .. _mailjet-templates:

--- a/tests/test_mailjet_backend.py
+++ b/tests/test_mailjet_backend.py
@@ -79,9 +79,9 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
         self.assertEqual(message['To'], [{"Email": "to1@example.com", "Name": "Recipient, #1"},
                                          {"Email": "to2@example.com"}])
         self.assertEqual(data['Globals']['Cc'], [{"Email": "cc1@example.com", "Name": "Carbon Copy"},
-                                         {"Email": "cc2@example.com"}])
+                                                 {"Email": "cc2@example.com"}])
         self.assertEqual(data['Globals']['Bcc'], [{"Email": "bcc1@example.com", "Name": "Blind Copy"},
-                                          {"Email": "bcc2@example.com"}])
+                                                  {"Email": "bcc2@example.com"}])
 
     def test_email_message(self):
         email = mail.EmailMessage(
@@ -101,10 +101,11 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
         self.assertEqual(message['To'], [{"Email": "to1@example.com"},
                                          {"Email": "to2@example.com", "Name": "Also To"}])
         self.assertEqual(data['Globals']['Cc'], [{"Email": "cc1@example.com"},
-                                         {"Email": "cc2@example.com", "Name": "Also CC"}])
+                                                 {"Email": "cc2@example.com", "Name": "Also CC"}])
         self.assertEqual(data['Globals']['Bcc'], [{"Email": "bcc1@example.com"},
-                                          {"Email": "bcc2@example.com", "Name": "Also BCC"}])
-        self.assertEqual(data['Globals']['Headers'], {'X-MyHeader': 'my value'})  # Reply-To should be moved to own param
+                                                  {"Email": "bcc2@example.com", "Name": "Also BCC"}])
+        self.assertEqual(data['Globals']['Headers'],
+                         {'X-MyHeader': 'my value'})  # Reply-To should be moved to own param
         self.assertEqual(data['Globals']['ReplyTo'], {"Email": "another@example.com"})
 
     def test_html_message(self):
@@ -117,7 +118,6 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
 
         data = self.get_api_call_json()
         self.assertEqual(len(data['Messages']), 1)
-        message = data['Messages'][0]
         self.assertEqual(data['Globals']['TextPart'], text_content)
         self.assertEqual(data['Globals']['HTMLPart'], html_content)
         # Don't accidentally send the html part as an attachment:
@@ -470,7 +470,6 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
         # Make sure the backend params are also still there
         self.assertEqual(data["Globals"]['Subject'], "Subject")
 
-
     # noinspection PyUnresolvedReferences
     def test_send_attaches_anymail_status(self):
         """ The anymail_status should be attached to the message when it is sent """
@@ -486,7 +485,7 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
             }]
         }).encode('utf-8')
         self.set_mock_response(raw=response_content)
-        msg = mail.EmailMessage('Subject', 'Message', 'from@example.com', ['to1@example.com'],)
+        msg = mail.EmailMessage('Subject', 'Message', 'from@example.com', ['to1@example.com'])
         sent = msg.send()
 
         self.assertEqual(sent, 1)

--- a/tests/test_mailjet_backend.py
+++ b/tests/test_mailjet_backend.py
@@ -412,16 +412,6 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
         self.assertEqual(messages[0]['Variables'], {'name': "Alice", 'group': "Developers"})
         self.assertEqual(messages[1]['Variables'], {'name': "Bob"})
 
-    def test_merge_data_strips_none(self):
-        """Work around a Mailjet API bug that silently fails to send when any Variables have null values"""
-        self.message.merge_global_data = {"global_good": "good", "global_bad": None, "override": "global"}
-        self.message.merge_data = {"to@example.com": {"local_bad": None, "local_good": "good", "override": None}}
-        self.message.send()
-        data = self.get_api_call_json()
-        # None (json null) should just get stripped, using the template default
-        self.assertEqual(data["Globals"]["Variables"], {"global_good": "good", "override": "global"})
-        self.assertEqual(data["Messages"][0]["Variables"], {"local_good": "good"})
-
     def test_merge_metadata(self):
         self.message.to = ['alice@example.com', 'Bob <bob@example.com>']
         self.message.merge_metadata = {

--- a/tests/test_mailjet_backend.py
+++ b/tests/test_mailjet_backend.py
@@ -1,3 +1,4 @@
+import json
 from base64 import b64encode
 from decimal import Decimal
 from email.mime.base import MIMEBase
@@ -7,9 +8,7 @@ from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase, override_settings, tag
 
-from anymail.exceptions import (AnymailAPIError, AnymailSerializationError,
-                                AnymailUnsupportedFeature,
-                                AnymailRequestsAPIError)
+from anymail.exceptions import AnymailAPIError, AnymailSerializationError, AnymailUnsupportedFeature
 from anymail.message import attach_inline_image_file
 
 from .mock_requests_backend import RequestsBackendMockAPITestCase, SessionSharingTestCases
@@ -19,47 +18,26 @@ from .utils import sample_image_content, sample_image_path, SAMPLE_IMAGE_FILENAM
 @tag('mailjet')
 @override_settings(EMAIL_BACKEND='anymail.backends.mailjet.EmailBackend',
                    ANYMAIL={
-                       'MAILJET_API_KEY': '',
-                       'MAILJET_SECRET_KEY': ''
+                       'MAILJET_API_KEY': 'API KEY HERE',
+                       'MAILJET_SECRET_KEY': 'SECRET KEY HERE'
                    })
 class MailjetBackendMockAPITestCase(RequestsBackendMockAPITestCase):
     DEFAULT_RAW_RESPONSE = b"""{
-        "Sent": [{
-            "Email": "to@example.com",
-            "MessageID": 12345678901234567
+        "Messages": [{
+            "Status": "success",
+            "To": [{
+                "Email": "to@example.com",
+                "MessageUUID": "cb927469-36fd-4c02-bce4-0d199929a207",
+                "MessageID": 70650219165027410,
+                "MessageHref": "https://api.mailjet.com/v3/message/70650219165027410"
+            }]
         }]
-    }"""
-
-    DEFAULT_TEMPLATE_RESPONSE = b"""{
-        "Count": 1,
-        "Data": [{
-            "Text-part": "text body",
-            "Html-part": "html body",
-            "MJMLContent": "",
-            "Headers": {
-                "Subject": "Hello World!",
-                "SenderName": "Friendly Tester",
-                "SenderEmail": "some@example.com",
-                "ReplyEmail": ""
-            }
-        }],
-        "Total": 1
     }"""
 
     def setUp(self):
         super().setUp()
         # Simple message useful for many tests
         self.message = mail.EmailMultiAlternatives('Subject', 'Text Body', 'from@example.com', ['to@example.com'])
-
-    def set_template_response(self, status_code=200, raw=None):
-        """Sets an expectation for a template and populate its response."""
-        if raw is None:
-            raw = self.DEFAULT_TEMPLATE_RESPONSE
-        template_response = RequestsBackendMockAPITestCase.MockResponse(status_code, raw)
-        self.mock_request.side_effect = iter([
-            template_response,
-            self.mock_request.return_value
-        ])
 
 
 @tag('mailjet')
@@ -70,12 +48,18 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
         """Test basic API for simple send"""
         mail.send_mail('Subject here', 'Here is the message.',
                        'from@sender.example.com', ['to@example.com'], fail_silently=False)
-        self.assert_esp_called('/v3/send')
+        self.assert_esp_called('/v3.1/send')
+
+        auth = self.get_api_call_auth()
+        self.assertEqual(auth, ('API KEY HERE', 'SECRET KEY HERE'))
+
         data = self.get_api_call_json()
-        self.assertEqual(data['Subject'], "Subject here")
-        self.assertEqual(data['Text-part'], "Here is the message.")
-        self.assertEqual(data['FromEmail'], "from@sender.example.com")
-        self.assertEqual(data['To'], "to@example.com")
+        self.assertEqual(len(data['Messages']), 1)
+        message = data['Messages'][0]
+        self.assertEqual(message['Subject'], "Subject here")
+        self.assertEqual(message['TextPart'], "Here is the message.")
+        self.assertEqual(message['From'], {"Email": "from@sender.example.com"})
+        self.assertEqual(message['To'], [{"Email": "to@example.com"}])
 
     def test_name_addr(self):
         """Make sure RFC2822 name-addr format (with display-name) is allowed
@@ -84,39 +68,20 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
         """
         msg = mail.EmailMessage(
             'Subject', 'Message', 'From Name <from@example.com>',
-            ['Recipient #1 <to1@example.com>', 'to2@example.com'],
+            ['"Recipient, #1" <to1@example.com>', 'to2@example.com'],
             cc=['Carbon Copy <cc1@example.com>', 'cc2@example.com'],
             bcc=['Blind Copy <bcc1@example.com>', 'bcc2@example.com'])
         msg.send()
         data = self.get_api_call_json()
-        # See https://dev.mailjet.com/guides/#sending-a-basic-email
-        self.assertEqual(data['FromName'], 'From Name')
-        self.assertEqual(data['FromEmail'], 'from@example.com')
-        self.assertEqual(data['To'], 'Recipient #1 <to1@example.com>, to2@example.com')
-        self.assertEqual(data['Cc'], 'Carbon Copy <cc1@example.com>, cc2@example.com')
-        self.assertEqual(data['Bcc'], 'Blind Copy <bcc1@example.com>, bcc2@example.com')
-
-    def test_comma_in_display_name(self):
-        # Mailjet 3.0 API doesn't properly parse RFC-2822 quoted display-names from To/Cc/Bcc:
-        # `To: "Recipient, Ltd." <to@example.com>` tries to send messages to `"Recipient`
-        # and to `Ltd.` (neither of which are actual email addresses).
-        # As a workaround, force MIME "encoded-word" utf-8 encoding, which gets past Mailjet's broken parsing.
-        # (This shouldn't be necessary in Mailjet 3.1, where Name becomes a separate json field for Cc/Bcc.)
-        msg = mail.EmailMessage(
-            'Subject', 'Message', '"Example, Inc." <from@example.com>',
-            ['"Recipient, Ltd." <to@example.com>'],
-            cc=['"This is a very long display name, intended to test our workaround does not insert carriage returns'
-                ' or newlines into the encoded value, which would cause other problems" <long@example.com']
-        )
-        msg.send()
-        data = self.get_api_call_json()
-        self.assertEqual(data['FromName'], 'Example, Inc.')
-        self.assertEqual(data['FromEmail'], 'from@example.com')
-        # self.assertEqual(data['To'], '"Recipient, Ltd." <to@example.com>')  # this doesn't work
-        self.assertEqual(data['To'], '=?utf-8?q?Recipient=2C_Ltd=2E?= <to@example.com>')  # workaround
-        self.assertEqual(data['Cc'], '=?utf-8?q?This_is_a_very_long_display_name=2C_intended_to_test_our_workaround'
-                                     '_does_not_insert_carriage_returns_or_newlines_into_the_encoded_value=2C_which'
-                                     '_would_cause_other_problems?= <long@example.com>')
+        self.assertEqual(len(data['Messages']), 1)
+        message = data['Messages'][0]
+        self.assertEqual(message['From'], {"Email": "from@example.com", "Name": "From Name"})
+        self.assertEqual(message['To'], [{"Email": "to1@example.com", "Name": "Recipient, #1"},
+                                         {"Email": "to2@example.com"}])
+        self.assertEqual(message['Cc'], [{"Email": "cc1@example.com", "Name": "Carbon Copy"},
+                                         {"Email": "cc2@example.com"}])
+        self.assertEqual(message['Bcc'], [{"Email": "bcc1@example.com", "Name": "Blind Copy"},
+                                          {"Email": "bcc2@example.com"}])
 
     def test_email_message(self):
         email = mail.EmailMessage(
@@ -128,16 +93,19 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
                      'X-MyHeader': 'my value'})
         email.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Subject'], "Subject")
-        self.assertEqual(data['Text-part'], "Body goes here")
-        self.assertEqual(data['FromEmail'], "from@example.com")
-        self.assertEqual(data['To'], 'to1@example.com, Also To <to2@example.com>')
-        self.assertEqual(data['Bcc'], 'bcc1@example.com, Also BCC <bcc2@example.com>')
-        self.assertEqual(data['Cc'], 'cc1@example.com, Also CC <cc2@example.com>')
-        self.assertCountEqual(data['Headers'], {
-            'Reply-To': 'another@example.com',
-            'X-MyHeader': 'my value',
-        })
+        self.assertEqual(len(data['Messages']), 1)
+        message = data['Messages'][0]
+        self.assertEqual(message['Subject'], "Subject")
+        self.assertEqual(message['TextPart'], "Body goes here")
+        self.assertEqual(message['From'], {"Email": "from@example.com"})
+        self.assertEqual(message['To'], [{"Email": "to1@example.com"},
+                                         {"Email": "to2@example.com", "Name": "Also To"}])
+        self.assertEqual(message['Cc'], [{"Email": "cc1@example.com"},
+                                         {"Email": "cc2@example.com", "Name": "Also CC"}])
+        self.assertEqual(message['Bcc'], [{"Email": "bcc1@example.com"},
+                                          {"Email": "bcc2@example.com", "Name": "Also BCC"}])
+        self.assertEqual(message['Headers'], {'X-MyHeader': 'my value'})  # Reply-To should be moved to own param
+        self.assertEqual(message['ReplyTo'], {"Email": "another@example.com"})
 
     def test_html_message(self):
         text_content = 'This is an important message.'
@@ -146,26 +114,32 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
                                             'from@example.com', ['to@example.com'])
         email.attach_alternative(html_content, "text/html")
         email.send()
+
         data = self.get_api_call_json()
-        self.assertEqual(data['Text-part'], text_content)
-        self.assertEqual(data['Html-part'], html_content)
+        self.assertEqual(len(data['Messages']), 1)
+        message = data['Messages'][0]
+        self.assertEqual(message['TextPart'], text_content)
+        self.assertEqual(message['HTMLPart'], html_content)
         # Don't accidentally send the html part as an attachment:
-        self.assertNotIn('Attachments', data)
+        self.assertNotIn('Attachments', message)
 
     def test_html_only_message(self):
         html_content = '<p>This is an <strong>important</strong> message.</p>'
         email = mail.EmailMessage('Subject', html_content, 'from@example.com', ['to@example.com'])
         email.content_subtype = "html"  # Main content is now text/html
         email.send()
+
         data = self.get_api_call_json()
-        self.assertNotIn('Text-part', data)
-        self.assertEqual(data['Html-part'], html_content)
+        self.assertEqual(len(data['Messages']), 1)
+        message = data['Messages'][0]
+        self.assertNotIn('TextPart', message)
+        self.assertEqual(message['HTMLPart'], html_content)
 
     def test_extra_headers(self):
         self.message.extra_headers = {'X-Custom': 'string', 'X-Num': 123}
         self.message.send()
         data = self.get_api_call_json()
-        self.assertCountEqual(data['Headers'], {
+        self.assertEqual(data['Messages'][0]['Headers'], {
             'X-Custom': 'string',
             'X-Num': 123,
         })
@@ -175,14 +149,16 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailSerializationError, "Decimal"):
             self.message.send()
 
+    @override_settings(ANYMAIL_IGNORE_UNSUPPORTED_FEATURES=True)  # Mailjet only allows single reply-to
     def test_reply_to(self):
         email = mail.EmailMessage('Subject', 'Body goes here', 'from@example.com', ['to1@example.com'],
                                   reply_to=['reply@example.com', 'Other <reply2@example.com>'],
                                   headers={'X-Other': 'Keep'})
         email.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Headers'], {
-            'Reply-To': 'reply@example.com, Other <reply2@example.com>',
+        message = data['Messages'][0]
+        self.assertEqual(message['ReplyTo'], {"Email": "reply@example.com"})  # only the first reply_to
+        self.assertEqual(message['Headers'], {
             'X-Other': 'Keep'
         })  # don't lose other headers
 
@@ -202,31 +178,35 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
 
         self.message.send()
         data = self.get_api_call_json()
-        attachments = data['Attachments']
+        self.assertEqual(len(data), 1)
+        message = data['Messages'][0]
+        attachments = message['Attachments']
         self.assertEqual(len(attachments), 3)
         self.assertEqual(attachments[0]["Filename"], "test.txt")
-        self.assertEqual(attachments[0]["Content-type"], "text/plain")
-        self.assertEqual(decode_att(attachments[0]["content"]).decode('ascii'), text_content)
+        self.assertEqual(attachments[0]["ContentType"], "text/plain")
+        self.assertEqual(decode_att(attachments[0]["Base64Content"]).decode('ascii'), text_content)
         self.assertNotIn('ContentID', attachments[0])
 
-        self.assertEqual(attachments[1]["Content-type"], "image/png")  # inferred from filename
+        self.assertEqual(attachments[1]["ContentType"], "image/png")  # inferred from filename
         self.assertEqual(attachments[1]["Filename"], "test.png")
-        self.assertEqual(decode_att(attachments[1]["content"]), png_content)
+        self.assertEqual(decode_att(attachments[1]["Base64Content"]), png_content)
         self.assertNotIn('ContentID', attachments[1])  # make sure image not treated as inline
 
-        self.assertEqual(attachments[2]["Content-type"], "application/pdf")
+        self.assertEqual(attachments[2]["ContentType"], "application/pdf")
         self.assertEqual(attachments[2]["Filename"], "")  # none
-        self.assertEqual(decode_att(attachments[2]["content"]), pdf_content)
+        self.assertEqual(decode_att(attachments[2]["Base64Content"]), pdf_content)
         self.assertNotIn('ContentID', attachments[2])
+
+        self.assertNotIn('InlinedAttachments', message)
 
     def test_unicode_attachment_correctly_decoded(self):
         self.message.attach("Une pièce jointe.html", '<p>\u2019</p>', mimetype='text/html')
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Attachments'], [{
+        self.assertEqual(data['Messages'][0]['Attachments'], [{
             'Filename': 'Une pièce jointe.html',
-            'Content-type': 'text/html',
-            'content': b64encode('<p>\u2019</p>'.encode('utf-8')).decode('ascii')
+            'ContentType': 'text/html',
+            'Base64Content': b64encode('<p>\u2019</p>'.encode('utf-8')).decode('ascii')
         }])
 
     def test_embedded_images(self):
@@ -240,13 +220,17 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
 
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Html-part'], html_content)
+        message = data['Messages'][0]
+        self.assertEqual(message['HTMLPart'], html_content)
 
-        attachments = data['Inline_attachments']
+        attachments = message['InlinedAttachments']
         self.assertEqual(len(attachments), 1)
-        self.assertEqual(attachments[0]['Filename'], cid)
-        self.assertEqual(attachments[0]['Content-type'], 'image/png')
-        self.assertEqual(decode_att(attachments[0]["content"]), image_data)
+        self.assertEqual(attachments[0]['Filename'], image_filename)
+        self.assertEqual(attachments[0]['ContentID'], cid)
+        self.assertEqual(attachments[0]['ContentType'], 'image/png')
+        self.assertEqual(decode_att(attachments[0]["Base64Content"]), image_data)
+
+        self.assertNotIn('Attachments', message)
 
     def test_attached_images(self):
         image_filename = SAMPLE_IMAGE_FILENAME
@@ -262,16 +246,16 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
 
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Attachments'], [
+        self.assertEqual(data['Messages'][0]['Attachments'], [
             {
                 'Filename': image_filename,  # the named one
-                'Content-type': 'image/png',
-                'content': image_data_b64,
+                'ContentType': 'image/png',
+                'Base64Content': image_data_b64,
             },
             {
                 'Filename': '',  # the unnamed one
-                'Content-type': 'image/png',
-                'content': image_data_b64,
+                'ContentType': 'image/png',
+                'Base64Content': image_data_b64,
             },
         ])
 
@@ -299,17 +283,19 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
         """Empty to, cc, bcc, and reply_to shouldn't generate empty fields"""
         self.message.send()
         data = self.get_api_call_json()
-        self.assertNotIn('Cc', data)
-        self.assertNotIn('Bcc', data)
-        self.assertNotIn('ReplyTo', data)
+        message = data['Messages'][0]
+        self.assertNotIn('Cc', message)
+        self.assertNotIn('Bcc', message)
+        self.assertNotIn('ReplyTo', message)
 
         # Test empty `to` -- but send requires at least one recipient somewhere (like cc)
         self.message.to = []
         self.message.cc = ['cc@example.com']
         self.message.send()
         data = self.get_api_call_json()
-        self.assertNotIn('To', data)
-        self.assertEqual(data['Cc'], 'cc@example.com')
+        message = data['Messages'][0]
+        self.assertNotIn('To', message)
+        self.assertEqual(message['Cc'], [{'Email': 'cc@example.com'}])
 
     def test_api_failure(self):
         self.set_mock_response(status_code=500)
@@ -323,12 +309,14 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
 
     def test_api_error_includes_details(self):
         """AnymailAPIError should include ESP's error message"""
-        # JSON error response:
-        error_response = b"""{
-            "ErrorCode": 451,
-            "Message": "Helpful explanation from Mailjet."
-        }"""
-        self.set_mock_response(status_code=200, raw=error_response)
+        # JSON error response - global error:
+        error_response = json.dumps({
+            "ErrorIdentifier": "06df1144-c6f3-4ca7-8885-7ec5d4344113",
+            "ErrorCode": "mj-0002",
+            "ErrorMessage": "Helpful explanation from Mailjet.",
+            "StatusCode": 400
+        }).encode('utf-8')
+        self.set_mock_response(status_code=400, raw=error_response)
         with self.assertRaisesMessage(AnymailAPIError, "Helpful explanation from Mailjet"):
             self.message.send()
 
@@ -342,15 +330,6 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
         with self.assertRaises(AnymailAPIError):
             self.message.send()
 
-    def test_invalid_api_key(self):
-        """Anymail should add a helpful message for an invalid API key"""
-        # Mailjet just returns a 401 error -- without additional explanation --
-        # for invalid keys. We want to provide users something more helpful
-        # than just "Mailjet API response 401:
-        self.set_mock_response(status_code=401, reason="Unauthorized", raw=None)
-        with self.assertRaisesMessage(AnymailAPIError, "Invalid Mailjet API key or secret"):
-            self.message.send()
-
 
 @tag('mailjet')
 class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
@@ -360,7 +339,7 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
         self.message.envelope_sender = "bounce-handler@bounces.example.com"
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Sender'], "bounce-handler@bounces.example.com")
+        self.assertEqual(data['Messages'][0]['Sender'], {"Email": "bounce-handler@bounces.example.com"})
 
     def test_metadata(self):
         # Mailjet expects the payload to be a single string
@@ -368,7 +347,7 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
         self.message.metadata = {'user_id': "12345", 'items': 6}
         self.message.send()
         data = self.get_api_call_json()
-        self.assertJSONEqual(data['Mj-EventPayLoad'], {"user_id": "12345", "items": 6})
+        self.assertJSONEqual(data['Messages'][0]['EventPayload'], {"user_id": "12345", "items": 6})
 
     def test_send_at(self):
         self.message.send_at = 1651820889  # 2022-05-06 07:08:09 UTC
@@ -379,7 +358,7 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
         self.message.tags = ["receipt"]
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Mj-campaign'], "receipt")
+        self.assertEqual(data['Messages'][0]['CustomCampaign'], "receipt")
 
         self.message.tags = ["receipt", "repeat-user"]
         with self.assertRaisesMessage(AnymailUnsupportedFeature, 'multiple tags'):
@@ -389,19 +368,18 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
         self.message.track_opens = True
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Mj-trackopen'], 2)
+        self.assertEqual(data['Messages'][0]['TrackOpens'], 'enabled')
 
     def test_track_clicks(self):
         self.message.track_clicks = True
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Mj-trackclick'], 2)
+        self.assertEqual(data['Messages'][0]['TrackClicks'], 'enabled')
 
-        # Also explicit "None" for False (to override server default)
         self.message.track_clicks = False
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Mj-trackclick'], 1)
+        self.assertEqual(data['Messages'][0]['TrackClicks'], 'disabled')
 
     def test_template(self):
         # template_id can be str or int (but must be numeric ID -- not the template's name)
@@ -409,110 +387,53 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
         self.message.merge_global_data = {'name': "Alice", 'group': "Developers"}
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Mj-TemplateID'], '1234567')
-        self.assertEqual(data['Vars'], {'name': "Alice", 'group': "Developers"})
+        message = data['Messages'][0]
+        self.assertEqual(message['TemplateID'], 1234567)  # must be integer
+        self.assertEqual(message['TemplateLanguage'], True)  # required to use variables
+        self.assertEqual(message['Variables'], {'name': "Alice", 'group': "Developers"})
 
     def test_template_populate_from_sender(self):
-        self.set_template_response()
+        # v3.1 API allows omitting From param to use template's sender
         self.message.template_id = '1234567'
-        self.message.from_email = None
+        self.message.from_email = None  # must set to None after constructing EmailMessage
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['Mj-TemplateID'], '1234567')
-        self.assertEqual(data['FromName'], 'Friendly Tester')
-        self.assertEqual(data['FromEmail'], 'some@example.com')
-
-    def test_template_populate_from(self):
-        # Note: Mailjet fails to properly quote the From field's display-name
-        # if the template sender name contains commas (as shown here):
-        template_response_content = b'''{
-            "Count": 1,
-            "Data": [{
-                "Text-part": "text body",
-                "Html-part": "html body",
-                "MJMLContent": "",
-                "Headers": {
-                    "Subject": "Hello World!!",
-                    "From": "Widgets, Inc. <noreply@example.com>",
-                    "Reply-To": ""
-                }
-            }],
-            "Total": 1
-        }'''
-        self.set_template_response(raw=template_response_content)
-        self.message.template_id = '1234568'
-        self.message.from_email = None
-        self.message.send()
-        data = self.get_api_call_json()
-        self.assertEqual(data['Mj-TemplateID'], '1234568')
-        self.assertEqual(data['FromName'], 'Widgets, Inc.')
-        self.assertEqual(data['FromEmail'], 'noreply@example.com')
-
-    def test_template_not_found(self):
-        template_response_content = b'''{
-            "ErrorInfo": "",
-            "ErrorMessage": "Object not found",
-            "StatusCode": 404
-        }'''
-        self.set_template_response(status_code=404, raw=template_response_content)
-        self.message.template_id = '1234560'
-        self.message.from_email = None
-        with self.assertRaises(AnymailRequestsAPIError):
-            self.message.send()
-
-    def test_template_unexpected_response(self):
-        # Missing headers (not sure if possible though).
-        template_response_content = b'''{
-            "Count": 1,
-            "Data": [{
-                "Text-part": "text body",
-                "Html-part": "html body",
-                "MJMLContent": "",
-                "Headers": {
-                }
-            }],
-            "Total": 1
-        }'''
-        self.set_template_response(raw=template_response_content)
-        self.message.template_id = '1234561'
-        self.message.from_email = None
-        with self.assertRaisesMessage(AnymailRequestsAPIError, "template API"):
-            self.message.send()
-
-    def test_template_invalid_response(self):
-        """Test scenario when MJ service returns no JSON for some reason."""
-        template_response_content = b'''total garbage'''
-        self.set_template_response(raw=template_response_content)
-        self.message.template_id = '1234562'
-        self.message.from_email = None
-        with self.assertRaisesMessage(AnymailRequestsAPIError, "Invalid JSON"):
-            self.message.send()
+        message = data['Messages'][0]
+        self.assertNotIn('From', message)  # use template's sender as From
 
     def test_merge_data(self):
         self.message.to = ['alice@example.com', 'Bob <bob@example.com>']
         self.message.cc = ['cc@example.com']
-        self.message.template_id = '1234567'
         self.message.merge_data = {
             'alice@example.com': {'name': "Alice", 'group': "Developers"},
             'bob@example.com': {'name': "Bob"},
         }
-        self.message.merge_global_data = {'group': "Users", 'site': "ExampleCo"}
+        self.message.merge_global_data = {'group': "Default Group", 'global': "Global value"}
         self.message.send()
-
         data = self.get_api_call_json()
         messages = data['Messages']
-        self.assertEqual(len(messages), 2)
-        self.assertEqual(messages[0]['To'], 'alice@example.com')
-        self.assertEqual(messages[0]['Cc'], 'cc@example.com')
-        self.assertEqual(messages[0]['Mj-TemplateID'], '1234567')
-        self.assertEqual(messages[0]['Vars'],
-                         {'name': "Alice", 'group': "Developers", 'site': "ExampleCo"})
+        self.assertEqual(len(messages), 2)  # with merge_data, each 'to' gets separate message
 
-        self.assertEqual(messages[1]['To'], 'Bob <bob@example.com>')
-        self.assertEqual(messages[1]['Cc'], 'cc@example.com')
-        self.assertEqual(messages[1]['Mj-TemplateID'], '1234567')
-        self.assertEqual(messages[1]['Vars'],
-                         {'name': "Bob", 'group': "Users", 'site': "ExampleCo"})
+        self.assertEqual(messages[0]['To'], [{"Email": "alice@example.com"}])
+        self.assertEqual(messages[1]['To'], [{"Email": "bob@example.com", "Name": "Bob"}])
+
+        # cc gets copied to all recipients
+        self.assertEqual(messages[0]['Cc'], [{"Email": "cc@example.com"}])
+        self.assertEqual(messages[1]['Cc'], [{"Email": "cc@example.com"}])
+
+        # per-recipient merge_data gets merged with globals
+        self.assertEqual(messages[0]['Variables'], {'name': "Alice", 'group': "Developers", 'global': "Global value"})
+        self.assertEqual(messages[1]['Variables'], {'name': "Bob", 'group': "Default Group", 'global': "Global value"})
+
+    def test_merge_data_strips_none(self):
+        """Work around a Mailjet API bug that silently fails to send when any Variables have null values"""
+        self.message.merge_global_data = {"global_good": "good", "global_bad": None, "override": "global"}
+        self.message.merge_data = {"to@example.com": {"local_bad": None, "local_good": "good", "override": None}}
+        self.message.send()
+        data = self.get_api_call_json()
+        # None (json null) should just get stripped, using the template default
+        self.assertEqual(data["Messages"][0]["Variables"],
+                         {"global_good": "good", "local_good": "good"})
 
     def test_merge_metadata(self):
         self.message.to = ['alice@example.com', 'Bob <bob@example.com>']
@@ -526,12 +447,12 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
         data = self.get_api_call_json()
         messages = data['Messages']
         self.assertEqual(len(messages), 2)
-        self.assertEqual(messages[0]['To'], 'alice@example.com')
+        self.assertEqual(messages[0]['To'][0]['Email'], "alice@example.com")
         # metadata and merge_metadata[recipient] are combined:
-        self.assertJSONEqual(messages[0]['Mj-EventPayLoad'],
+        self.assertJSONEqual(messages[0]['EventPayload'],
                              {'order_id': 123, 'tier': 'premium', 'notification_batch': 'zx912'})
-        self.assertEqual(messages[1]['To'], 'Bob <bob@example.com>')
-        self.assertJSONEqual(messages[1]['Mj-EventPayLoad'],
+        self.assertEqual(messages[1]['To'][0]['Email'], "bob@example.com")
+        self.assertJSONEqual(messages[1]['EventPayload'],
                              {'order_id': 678, 'notification_batch': 'zx912'})
 
     def test_default_omits_options(self):
@@ -543,35 +464,54 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
         """
         self.message.send()
         data = self.get_api_call_json()
-        self.assertNotIn('Mj-campaign', data)
-        self.assertNotIn('Mj-EventPayLoad', data)
-        self.assertNotIn('Mj-TemplateID', data)
-        self.assertNotIn('Vars', data)
-        self.assertNotIn('Mj-trackopen', data)
-        self.assertNotIn('Mj-trackclick', data)
+        message = data['Messages'][0]
+        self.assertNotIn('CustomCampaign', message)
+        self.assertNotIn('EventPayload', message)
+        self.assertNotIn('HTMLPart', message)
+        self.assertNotIn('TemplateID', message)
+        self.assertNotIn('TemplateLanguage', message)
+        self.assertNotIn('Variables', message)
+        self.assertNotIn('TrackOpens', message)
+        self.assertNotIn('TrackClicks', message)
 
     def test_esp_extra(self):
+        # Anymail merges Mailjet esp_extra into message properties.
+        # (Not at the Send payload root, except for the special case "SandboxMode".)
         self.message.esp_extra = {
-            'MJ-TemplateErrorDeliver': True,
-            'MJ-TemplateErrorReporting': 'bugs@example.com'
+            'Sender': {'Email': 'sender@example.com', 'Name': 'sender name'},
+            'TemplateErrorDeliver': True,
+            'TemplateErrorReporting': 'bugs@example.com',
+            'SandboxMode': True,
         }
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(data['MJ-TemplateErrorDeliver'], True)
-        self.assertEqual(data['MJ-TemplateErrorReporting'], 'bugs@example.com')
+        message = data['Messages'][0]
+        self.assertEqual(message['Sender'], {'Email': 'sender@example.com', 'Name': 'sender name'})
+        self.assertEqual(message['TemplateErrorDeliver'], True)
+        self.assertEqual(message['TemplateErrorReporting'], 'bugs@example.com')
+
+        # SandboxMode gets hoisted to the payload root
+        self.assertIs(data['SandboxMode'], True)
+        self.assertNotIn('SandboxMode', message)
 
     # noinspection PyUnresolvedReferences
     def test_send_attaches_anymail_status(self):
         """ The anymail_status should be attached to the message when it is sent """
-        response_content = b"""{
-            "Sent": [{
-                "Email": "to1@example.com",
-                "MessageID": 12345678901234500
+        response_content = json.dumps({
+            "Messages": [{
+                "Status": "success",
+                "To": [{
+                    "Email": "to1@example.com",
+                    "MessageUUID": "cb927469-36fd-4c02-bce4-0d199929a207",
+                    "MessageID": 12345678901234500,
+                    "MessageHref": "https://api.mailjet.com/v3/message/12345678901234500"
+                }]
             }]
-        }"""
+        }).encode('utf-8')
         self.set_mock_response(raw=response_content)
         msg = mail.EmailMessage('Subject', 'Message', 'from@example.com', ['to1@example.com'],)
         sent = msg.send()
+
         self.assertEqual(sent, 1)
         self.assertEqual(msg.anymail_status.status, {'sent'})
         self.assertEqual(msg.anymail_status.message_id, "12345678901234500")
@@ -580,34 +520,45 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
         self.assertEqual(msg.anymail_status.esp_response.content, response_content)
 
     # noinspection PyUnresolvedReferences
-    def test_status_includes_all_recipients(self):
+    def test_mixed_status(self):
         """The status should include an entry for each recipient"""
-        # Note that Mailjet's response only communicates "Sent" status; not failed addresses.
-        # (This is an example response from before the workaround for commas in display-names...)
-        response_content = b"""{
-            "Sent": [{
-                "Email": "to1@example.com",
-                "MessageID": 12345678901234500
+        # Mailjet's v3.1 API will partially fail a batch send, allowing valid emails to go out.
+        # The API response doesn't identify the failed email addresses; make sure we represent
+        # them correctly in the anymail_status.
+        response_content = json.dumps({
+            "Messages": [{
+                "Status": "success",
+                "CustomID": "",
+                "To": [{
+                    "Email": "to-good@example.com",
+                    "MessageUUID": "556e896a-e041-4836-bb35-8bb75ee308c5",
+                    "MessageID": 12345678901234500,
+                    "MessageHref": "https://api.mailjet.com/v3/REST/message/12345678901234500"
+                }],
+                "Cc": [],
+                "Bcc": []
             }, {
-                "Email": "\\"Recipient",
-                "MessageID": 12345678901234501
-            }, {
-                "Email": "Also",
-                "MessageID": 12345678901234502
+                "Errors": [{
+                    "ErrorIdentifier": "f480a5a2-0334-4e08-b2b7-f372ce5669e0",
+                    "ErrorCode": "mj-0013",
+                    "StatusCode": 400,
+                    "ErrorMessage": "\"invalid@123.4\" is an invalid email address.",
+                    "ErrorRelatedTo": ["To[0].Email"]
+                }],
+                "Status": "error"
             }]
-        }"""
-        self.set_mock_response(raw=response_content)
-        msg = mail.EmailMessage('Subject', 'Message', 'from@example.com',
-                                ['to1@example.com', '"Recipient, Also" <to2@example.com>'],)
+        }).encode('utf-8')
+        self.set_mock_response(raw=response_content, status_code=400)  # Mailjet uses 400 for partial success
+        msg = mail.EmailMessage('Subject', 'Message', 'from@example.com', ['to-good@example.com', 'invalid@123.4'])
         sent = msg.send()
+
         self.assertEqual(sent, 1)
-        self.assertEqual(msg.anymail_status.status, {'sent', 'unknown'})
-        self.assertEqual(msg.anymail_status.recipients['to1@example.com'].status, 'sent')
-        self.assertEqual(msg.anymail_status.recipients['to1@example.com'].message_id, "12345678901234500")
-        self.assertEqual(msg.anymail_status.recipients['to2@example.com'].status, 'unknown')  # because, whoops
-        self.assertEqual(msg.anymail_status.recipients['to2@example.com'].message_id, None)
-        self.assertEqual(msg.anymail_status.message_id,
-                         {"12345678901234500", "12345678901234501", "12345678901234502", None})
+        self.assertEqual(msg.anymail_status.status, {'sent', 'failed'})
+        self.assertEqual(msg.anymail_status.recipients['to-good@example.com'].status, 'sent')
+        self.assertEqual(msg.anymail_status.recipients['to-good@example.com'].message_id, "12345678901234500")
+        self.assertEqual(msg.anymail_status.recipients['invalid@123.4'].status, 'failed')
+        self.assertEqual(msg.anymail_status.recipients['invalid@123.4'].message_id, None)
+        self.assertEqual(msg.anymail_status.message_id, {"12345678901234500", None})
         self.assertEqual(msg.anymail_status.esp_response.content, response_content)
 
     # noinspection PyUnresolvedReferences

--- a/tests/test_mailjet_integration.py
+++ b/tests/test_mailjet_integration.py
@@ -18,6 +18,7 @@ MAILJET_TEST_SECRET_KEY = os.getenv('MAILJET_TEST_SECRET_KEY')
                      "environment variables to run Mailjet integration tests")
 @override_settings(ANYMAIL_MAILJET_API_KEY=MAILJET_TEST_API_KEY,
                    ANYMAIL_MAILJET_SECRET_KEY=MAILJET_TEST_SECRET_KEY,
+                   ANYMAIL_MAILJET_ESP_EXTRA={"SandboxMode": True},  # don't actually send mail
                    EMAIL_BACKEND="anymail.backends.mailjet.EmailBackend")
 class MailjetBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """Mailjet API integration tests
@@ -27,12 +28,11 @@ class MailjetBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     as the API key and API secret key, respectively.
     If those variables are not set, these tests won't run.
 
-    Mailjet doesn't (in v3.0) offer a test/sandbox mode -- it tries to send everything
-    you ask.
+    These tests enable Mailjet's SandboxMode to avoid sending any email;
+    remove the esp_extra setting above if you are trying to actually send test messages.
 
     Mailjet also doesn't support unverified senders (so no from@example.com).
     We've set up @test-mj.anymail.info as a validated sending domain for these tests.
-
     """
 
     def setUp(self):
@@ -63,7 +63,7 @@ class MailjetBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             to=['test+to1@anymail.info', '"Recipient, 2nd" <test+to2@anymail.info>'],
             cc=['test+cc1@anymail.info', 'Copy 2 <test+cc1@anymail.info>'],
             bcc=['test+bcc1@anymail.info', 'Blind Copy 2 <test+bcc2@anymail.info>'],
-            reply_to=['reply1@example.com', '"Reply, 2nd" <reply2@example.com>'],
+            reply_to=['"Reply, To" <reply2@example.com>'],  # Mailjet only supports single reply_to
             headers={"X-Anymail-Test": "value"},
 
             metadata={"meta1": "simple string", "meta2": 2},
@@ -126,4 +126,4 @@ class MailjetBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             self.message.send()
         err = cm.exception
         self.assertEqual(err.status_code, 401)
-        self.assertIn("Invalid Mailjet API key or secret", str(err))
+        self.assertIn("API key authentication/authorization failure", str(err))

--- a/tests/test_mailjet_integration.py
+++ b/tests/test_mailjet_integration.py
@@ -16,9 +16,10 @@ MAILJET_TEST_SECRET_KEY = os.getenv('MAILJET_TEST_SECRET_KEY')
 @unittest.skipUnless(MAILJET_TEST_API_KEY and MAILJET_TEST_SECRET_KEY,
                      "Set MAILJET_TEST_API_KEY and MAILJET_TEST_SECRET_KEY "
                      "environment variables to run Mailjet integration tests")
-@override_settings(ANYMAIL_MAILJET_API_KEY=MAILJET_TEST_API_KEY,
-                   ANYMAIL_MAILJET_SECRET_KEY=MAILJET_TEST_SECRET_KEY,
-                   ANYMAIL_MAILJET_ESP_EXTRA={"SandboxMode": True},  # don't actually send mail
+@override_settings(ANYMAIL={"MAILJET_API_KEY": MAILJET_TEST_API_KEY,
+                            "MAILJET_SECRET_KEY": MAILJET_TEST_SECRET_KEY,
+                            "MAILJET_SEND_DEFAULTS": {"esp_extra": {"SandboxMode": True}},  # don't actually send mail
+                            },
                    EMAIL_BACKEND="anymail.backends.mailjet.EmailBackend")
 class MailjetBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """Mailjet API integration tests
@@ -120,7 +121,8 @@ class MailjetBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         recipient_status = message.anymail_status.recipients
         self.assertEqual(recipient_status['test+to1@anymail.info'].status, 'sent')
 
-    @override_settings(ANYMAIL_MAILJET_API_KEY="Hey, that's not an API key!")
+    @override_settings(ANYMAIL={"MAILJET_API_KEY": "Hey, that's not an API key!",
+                                "MAILJET_SECRET_KEY": "and this isn't the secret for it"})
     def test_invalid_api_key(self):
         with self.assertRaises(AnymailAPIError) as cm:
             self.message.send()


### PR DESCRIPTION
[On hold awaiting Mailjet fix for v3.1 Send API regression in template From handling: Mailjet ticket # 830935 2018-01-22.]

Breaking change for `esp_extra` with Mailjet.

Switch from Mailjet's older v3.0 Send API to the latest v3.1 version.

The v3.1 API resolves some limitations/quirks of older API:
* Mailjet now correctly handles commas in recipient display names;
  Anymail no longer works around this using MIME encoded-word syntax.
* Mailjet now supports mixing cc/bcc with merge_data; Anymail no longer
  errors on this case.
* Mailjet now supports using a template's From email and name without
  making an additional API call to retrieve them. (Not currently working
  as documented; awaiting info from Mailjet before releasing.)

But v3.1 adds a new limitation:
* Mailjet supports only a single `reply_to` address.

Closes #81 