### PR TITLE
Un-hardcode message ID in test backend, and add console backend

### DIFF
--- a/anymail/backends/console.py
+++ b/anymail/backends/console.py
@@ -1,3 +1,4 @@
+import uuid
 from django.core.mail.backends.console import EmailBackend as DjangoConsoleBackend
 
 from ..exceptions import AnymailError
@@ -11,6 +12,10 @@ class EmailBackend(AnymailTestBackend, DjangoConsoleBackend):
     """
 
     esp_name = "Console"
+
+    def get_esp_message_id(self, message):
+        # Generate a guaranteed-unique ID for the message
+        return str(uuid.uuid4())
 
     def send_messages(self, email_messages):
         if not email_messages:

--- a/anymail/backends/console.py
+++ b/anymail/backends/console.py
@@ -1,0 +1,38 @@
+from django.core.mail.backends.console import EmailBackend as DjangoConsoleBackend
+
+from ..exceptions import AnymailError
+from .test import EmailBackend as AnymailTestBackend
+
+
+class EmailBackend(AnymailTestBackend, DjangoConsoleBackend):
+    """
+    Anymail backend that prints messages to the console, while retaining
+    anymail statuses and signals.
+    """
+
+    esp_name = "Console"
+
+    def send_messages(self, email_messages):
+        if not email_messages:
+            return
+        msg_count = 0
+        with self._lock:
+            try:
+                stream_created = self.open()
+                for message in email_messages:
+                    try:
+                        sent = self._send(message)
+                    except AnymailError:
+                        if self.fail_silently:
+                            sent = False
+                        else:
+                            raise
+                    if sent:
+                        self.write_message(message)
+                        self.stream.flush()  # flush after each message
+                        msg_count += 1
+            finally:
+                if stream_created:
+                    self.close()
+
+        return msg_count

--- a/anymail/backends/test.py
+++ b/anymail/backends/test.py
@@ -27,6 +27,11 @@ class EmailBackend(AnymailBaseBackend):
         if not hasattr(mail, 'outbox'):
             mail.outbox = []  # see django.core.mail.backends.locmem
 
+    def get_esp_message_id(self, message):
+        # Get a unique ID for the message.  The message must have been added to
+        # the outbox first.
+        return mail.outbox.index(message)
+
     def build_message_payload(self, message, defaults):
         return TestPayload(backend=self, message=message, defaults=defaults)
 
@@ -42,7 +47,7 @@ class EmailBackend(AnymailBaseBackend):
         except AttributeError:
             # Default is to return 'sent' for each recipient
             status = AnymailRecipientStatus(
-                message_id=message.message()['Message-ID'],
+                message_id=self.get_esp_message_id(message),
                 status='sent'
             )
             response = {

--- a/anymail/backends/test.py
+++ b/anymail/backends/test.py
@@ -41,7 +41,10 @@ class EmailBackend(AnymailBaseBackend):
                 raise response
         except AttributeError:
             # Default is to return 'sent' for each recipient
-            status = AnymailRecipientStatus(message_id=1, status='sent')
+            status = AnymailRecipientStatus(
+                message_id=message.message()['Message-ID'],
+                status='sent'
+            )
             response = {
                 'recipient_status': {email: status for email in payload.recipient_emails}
             }

--- a/tests/test_send_signals.py
+++ b/tests/test_send_signals.py
@@ -59,20 +59,23 @@ class TestPostSendSignal(TestBackendTestCase):
 
     def test_post_send(self):
         """Post-send receiver called for each message, after sending"""
+        message_id = 'asdf'
+
         @receiver(post_send, weak=False)
         def handle_post_send(sender, message, status, esp_name, **kwargs):
             self.assertEqual(self.get_send_count(), 1)  # already sent
             self.assertEqual(sender, TestEmailBackend)
             self.assertEqual(message, self.message)
             self.assertEqual(status.status, {'sent'})
-            self.assertEqual(status.message_id, 1)  # TestEmailBackend default message_id
+            self.assertEqual(status.message_id, message_id)
             self.assertEqual(status.recipients['to@example.com'].status, 'sent')
-            self.assertEqual(status.recipients['to@example.com'].message_id, 1)
+            self.assertEqual(status.recipients['to@example.com'].message_id, message_id)
             self.assertEqual(esp_name, "Test")  # the TestEmailBackend's ESP is named "Test"
             self.receiver_called = True
         self.addCleanup(post_send.disconnect, receiver=handle_post_send)
 
         self.receiver_called = False
+        self.message.extra_headers['Message-ID'] = message_id
         self.message.send()
         self.assertTrue(self.receiver_called)
 

--- a/tests/test_send_signals.py
+++ b/tests/test_send_signals.py
@@ -59,23 +59,20 @@ class TestPostSendSignal(TestBackendTestCase):
 
     def test_post_send(self):
         """Post-send receiver called for each message, after sending"""
-        message_id = 'asdf'
-
         @receiver(post_send, weak=False)
         def handle_post_send(sender, message, status, esp_name, **kwargs):
             self.assertEqual(self.get_send_count(), 1)  # already sent
             self.assertEqual(sender, TestEmailBackend)
             self.assertEqual(message, self.message)
             self.assertEqual(status.status, {'sent'})
-            self.assertEqual(status.message_id, message_id)
+            self.assertEqual(status.message_id, 0)
             self.assertEqual(status.recipients['to@example.com'].status, 'sent')
-            self.assertEqual(status.recipients['to@example.com'].message_id, message_id)
+            self.assertEqual(status.recipients['to@example.com'].message_id, 0)
             self.assertEqual(esp_name, "Test")  # the TestEmailBackend's ESP is named "Test"
             self.receiver_called = True
         self.addCleanup(post_send.disconnect, receiver=handle_post_send)
 
         self.receiver_called = False
-        self.message.extra_headers['Message-ID'] = message_id
         self.message.send()
         self.assertTrue(self.receiver_called)
 


### PR DESCRIPTION
Two commits to assist use in development: modify the test backend to use unique message ID's rather than a hardcoded `1`.  Also, add a console backend which provides anymail statuses and signal handling, while printing sent messages to the console.

Re Issue #85.