### PR TITLE
Add automatic routing for Mandrill. Closes #86

### DIFF
--- a/anymail/urls.py
+++ b/anymail/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from .webhooks.mailgun import MailgunInboundWebhookView, MailgunTrackingWebhookView
 from .webhooks.mailjet import MailjetInboundWebhookView, MailjetTrackingWebhookView
-from .webhooks.mandrill import MandrillInboundWebhookView, MandrillTrackingWebhookView
+from .webhooks.mandrill import MandrillInboundWebhookView, MandrillTrackingWebhookView, MandrillAutomaticWebhookView
 from .webhooks.postmark import PostmarkInboundWebhookView, PostmarkTrackingWebhookView
 from .webhooks.sendgrid import SendGridInboundWebhookView, SendGridTrackingWebhookView
 from .webhooks.sparkpost import SparkPostInboundWebhookView, SparkPostTrackingWebhookView
@@ -23,4 +23,6 @@ urlpatterns = [
     url(r'^postmark/tracking/$', PostmarkTrackingWebhookView.as_view(), name='postmark_tracking_webhook'),
     url(r'^sendgrid/tracking/$', SendGridTrackingWebhookView.as_view(), name='sendgrid_tracking_webhook'),
     url(r'^sparkpost/tracking/$', SparkPostTrackingWebhookView.as_view(), name='sparkpost_tracking_webhook'),
+
+    url(r'^mandrill/$', MandrillAutomaticWebhookView.as_view(), name='mandrill_automatic_webhook'),
 ]

--- a/anymail/webhooks/base.py
+++ b/anymail/webhooks/base.py
@@ -130,4 +130,4 @@ class AnymailBaseWebhookView(AnymailBasicAuthMixin, View):
 
         (E.g., MailgunTrackingWebhookView will return "Mailgun")
         """
-        return re.sub(r'(Tracking|Inbound)WebhookView$', "", self.__class__.__name__)
+        return re.sub(r'(Tracking|Inbound|Automatic)WebhookView$', "", self.__class__.__name__)

--- a/anymail/webhooks/mandrill.py
+++ b/anymail/webhooks/mandrill.py
@@ -184,3 +184,18 @@ class MandrillInboundWebhookView(MandrillBaseWebhookView):
             esp_event=esp_event,
             message=message,
         )
+
+
+class MandrillAutomaticWebhookView(MandrillBaseWebhookView):
+    """Base view class for Mandrill webhooks"""
+
+    def esp_to_anymail_event(self, esp_event):
+        """Automatically route requests to the inbound or tracking views"""
+        esp_type = getfirst(esp_event, ['event', 'type'], 'unknown')
+
+        if esp_type == 'inbound':
+            self.signal = inbound
+            return MandrillInboundWebhookView().esp_to_anymail_event(esp_event)
+
+        self.signal = tracking
+        return MandrillTrackingWebhookView().esp_to_anymail_event(esp_event)

--- a/docs/esps/mandrill.rst
+++ b/docs/esps/mandrill.rst
@@ -263,6 +263,22 @@ Mandrill, we'd appreciate any information that would improve this section.)
    https://mandrill.zendesk.com/hc/en-us/articles/205583197-Inbound-Email-Processing-Overview
 
 
+.. _mandrill-combined:
+
+Combined webhook
+----------------
+
+Some Mandrill users will have combined webhooks configured which use the same `MANDRILL_WEBHOOK_KEY`
+and `MANDRILL_WEBHOOK_URL` to receive email and tracking events.
+
+The url for the combined routing will be:
+
+   :samp:`https://{random}:{random}@{yoursite.example.com}/anymail/mandrill/`
+
+     * *random:random* is an :setting:`ANYMAIL_WEBHOOK_AUTHORIZATION` shared secret
+     * *yoursite.example.com* is your Django site
+
+
 .. _migrating-from-djrill:
 
 Migrating from Djrill

--- a/tests/test_mandrill_webhooks.py
+++ b/tests/test_mandrill_webhooks.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 # noinspection PyUnresolvedReferences
 from six.moves.urllib.parse import urljoin
+from textwrap import dedent
 
 import hashlib
 import hmac
@@ -9,10 +10,10 @@ from base64 import b64encode
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 from django.utils.timezone import utc
-from mock import ANY
+from mock import ANY, patch
 
 from anymail.signals import AnymailTrackingEvent
-from anymail.webhooks.mandrill import MandrillTrackingWebhookView
+from anymail.webhooks.mandrill import MandrillTrackingWebhookView, MandrillInboundWebhookView
 
 from .webhook_cases import WebhookTestCase, WebhookBasicAuthTestsMixin
 
@@ -247,3 +248,78 @@ class MandrillTrackingTestCase(WebhookTestCase):
         self.assertEqual(event.event_type, "unknown")
         self.assertEqual(event.recipient, "recipient@example.com")
         self.assertEqual(event.description, "manual edit")
+
+
+@override_settings(ANYMAIL_MANDRILL_WEBHOOK_KEY=TEST_WEBHOOK_KEY)
+class MandrillAutmaticTestCase(WebhookTestCase):
+
+    def test_head_request(self):
+        # Mandrill verifies webhooks at config time with a HEAD request
+        response = self.client.head('/anymail/mandrill/')
+        self.assertEqual(response.status_code, 200)
+
+    @patch("anymail.webhooks.mandrill.MandrillTrackingWebhookView.esp_to_anymail_event")
+    def test_rerouting_hard_bounce(self, esp_to_anymail_event):
+        # MandrillAutomaticWebhookView should utilize MandrillTrackingWebhookView for tracking requests
+        raw_events = [{
+            "event": "hard_bounce",
+            "msg": {
+                "ts": 1461095211,  # time send called
+                "subject": "Webhook Test",
+                "email": "bounce@example.com",
+                "sender": "sender@example.com",
+                "bounce_description": "bad_mailbox",
+                "bgtools_code": 10,
+                "diag": "smtp;550 5.1.1 The email account that you tried to reach does not exist.",
+                "_id": "abcdef012345789abcdef012345789"
+            },
+            "_id": "abcdef012345789abcdef012345789",
+            "ts": 1461095246  # time of event
+        }]
+        response = self.client.post(**mandrill_args(events=raw_events, path='/anymail/mandrill/'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(esp_to_anymail_event.called)
+
+    @patch("anymail.webhooks.mandrill.MandrillInboundWebhookView.esp_to_anymail_event")
+    def test_rerouting_tracking(self, esp_to_anymail_event):
+        # MandrillAutomaticWebhookView should utilize MandrillTrackingWebhookView for inbound requests
+        raw_event = {
+            "event": "inbound",
+            "ts": 1507856722,
+            "msg": {
+                "raw_msg": dedent("""\
+                    From: A tester <test@example.org>
+                    Date: Thu, 12 Oct 2017 18:03:30 -0700
+                    Message-ID: <CAEPk3RKEx@mail.example.org>
+                    Subject: Test subject
+                    To: "Test, Inbound" <test@inbound.example.com>, other@example.com
+                    MIME-Version: 1.0
+                    Content-Type: multipart/alternative; boundary="94eb2c05e174adb140055b6339c5"
+
+                    --94eb2c05e174adb140055b6339c5
+                    Content-Type: text/plain; charset="UTF-8"
+                    Content-Transfer-Encoding: quoted-printable
+
+                    It's a body=E2=80=A6
+
+                    --94eb2c05e174adb140055b6339c5
+                    Content-Type: text/html; charset="UTF-8"
+                    Content-Transfer-Encoding: quoted-printable
+
+                    <div dir=3D"ltr">It's a body=E2=80=A6</div>
+
+                    --94eb2c05e174adb140055b6339c5--
+                    """),
+                "email": "delivered-to@example.com",
+                "sender": None,  # Mandrill populates "sender" only for outbound message events
+                "spam_report": {
+                    "score": 1.7,
+                },
+                # Anymail ignores Mandrill's other inbound event fields
+                # (which are all redundant with raw_msg)
+            },
+        }
+
+        response = self.client.post(**mandrill_args(events=[raw_event], path='/anymail/mandrill/'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(esp_to_anymail_event.called)

--- a/tests/test_mandrill_webhooks.py
+++ b/tests/test_mandrill_webhooks.py
@@ -13,7 +13,7 @@ from django.utils.timezone import utc
 from mock import ANY, patch
 
 from anymail.signals import AnymailTrackingEvent
-from anymail.webhooks.mandrill import MandrillTrackingWebhookView, MandrillInboundWebhookView
+from anymail.webhooks.mandrill import MandrillTrackingWebhookView
 
 from .webhook_cases import WebhookTestCase, WebhookBasicAuthTestsMixin
 


### PR DESCRIPTION
* Added MandrillAutomaticWebhookView which updates signals and returns esp_to_anymail_event for the proper view based on the esp_type
* Three test cases which verifies the correct esp_to_anymail_event is called for hard_bounce and inbound