### PR TITLE
[WIP] Amazon SES integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Anymail integrates several transactional email service providers (ESPs) into Dja
 with a consistent API that lets you use ESP-added features without locking your code
 to a particular ESP.
 
-It currently fully supports **Mailgun, Mailjet, Postmark, SendinBlue, SendGrid,**
+It currently fully supports **Amazon SES, Mailgun, Mailjet, Postmark, SendinBlue, SendGrid,**
 and **SparkPost,** and has limited support for **Mandrill.**
 
 Anymail normalizes ESP functionality so it "just works" with Django's

--- a/anymail/backends/amazon_ses.py
+++ b/anymail/backends/amazon_ses.py
@@ -1,0 +1,179 @@
+from __future__ import absolute_import
+
+from .base import AnymailBaseBackend, BasePayload
+from ..exceptions import AnymailAPIError, AnymailImproperlyInstalled
+from ..message import AnymailRecipientStatus
+from ..utils import get_anymail_setting
+
+try:
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError, ConnectionError
+except ImportError:
+    raise AnymailImproperlyInstalled(missing_package='boto3', backend='amazon_ses')
+
+
+# boto3 has several root exception classes; this is meant to cover all of them
+BOTO_BASE_ERRORS = (BotoCoreError, ClientError, ConnectionError)
+
+
+class EmailBackend(AnymailBaseBackend):
+    """
+    Amazon SES Email Backend (using boto3)
+    """
+
+    esp_name = "Amazon SES"
+
+    def __init__(self, **kwargs):
+        """Init options from Django settings"""
+        super(EmailBackend, self).__init__(**kwargs)
+        # AMAZON_SES_CLIENT_PARAMS is optional - boto3 can find credentials several other ways
+        self.client_params = get_anymail_setting("client_params", esp_name=self.esp_name,
+                                                 kwargs=kwargs, allow_bare=False, default={})
+        # TODO: maybe add a setting for default configuration set?
+        #       (otherwise must use "AMAZON_SES_ESP_EXTRA": {"ConfigurationSetName": "my-default-set"})
+        self.client = None
+
+    def open(self):
+        if self.client:
+            return False  # already exists
+        try:
+            self.client = boto3.client("ses", **self.client_params)
+        except BOTO_BASE_ERRORS:
+            if not self.fail_silently:
+                raise
+
+    def close(self):
+        if self.client is None:
+            return
+        # There's actually no (supported) close method for a boto3 client/session.
+        # boto3 just relies on garbage collection (and we're probably using a shared session anyway).
+        self.client = None
+
+    def build_message_payload(self, message, defaults):
+        return AmazonSESPayload(message, defaults, self)
+
+    def post_to_esp(self, payload, message):
+        params = payload.get_api_params()
+        try:
+            response = self.client.send_raw_email(**params)
+        except BOTO_BASE_ERRORS as err:
+            # ClientError has a response attr with parsed json error response (other errors don't)
+            raise AnymailAPIError(str(err), backend=self, email_message=message, payload=payload,
+                                  response=getattr(err, 'response', None))
+        return response
+
+    def parse_recipient_status(self, response, payload, message):
+        # response is the parsed (dict) JSON returned the API call
+        try:
+            message_id = response["MessageId"]
+        except (KeyError, TypeError) as err:
+            raise AnymailAPIError(
+                "%s parsing Amazon SES send result %r" % (str(err), response),
+                backend=self, email_message=message, payload=payload)
+
+        recipient_status = AnymailRecipientStatus(message_id=message_id, status="queued")
+        return {recipient.addr_spec: recipient_status for recipient in payload.all_recipients}
+
+
+class AmazonSESPayload(BasePayload):
+    def init_payload(self):
+        self.mime_message = self.message.message()
+        self.params = {}
+        self.all_recipients = []
+
+    def get_api_params(self):
+        self.params["RawMessage"] = {
+            # Note: "Destinations" is determined from message headers if not provided
+            # "Destinations": [email.addr_spec for email in self.all_recipients],
+            "Data": self.mime_message.as_string()
+        }
+        return self.params
+
+    # Standard EmailMessage attrs...
+    # These all get rolled into the RFC-5322 raw mime directly via EmailMessage.message()
+
+    def _no_send_defaults(self, attr):
+        # Anymail global send defaults don't work for standard attrs, because the
+        # merged/computed value isn't forced back into the EmailMessage.
+        if attr in self.defaults:
+            self.unsupported_feature("Anymail send defaults for '%s' with Amazon SES" % attr)
+
+    # def set_from_email_list(self, emails):
+    #   Multiple values in From header will result in "An error occurred (InvalidParameterValue)
+    #   when calling the SendRawEmail operation: Illegal address" (without mentioning which field
+    #   has the illegal address). Better to just use Anymail's base unsupported_feature warning.
+
+    def set_from_email(self, email):
+        # included in mime_message
+        self._no_send_defaults("from_email")
+
+    def set_recipients(self, recipient_type, emails):
+        self.all_recipients += emails
+        # included in mime_message
+        assert recipient_type in ("to", "cc", "bcc")
+        self._no_send_defaults(recipient_type)
+
+    def set_subject(self, subject):
+        # included in mime_message
+        self._no_send_defaults("subject")
+
+    def set_reply_to(self, emails):
+        # included in mime_message
+        self._no_send_defaults("reply_to")
+
+    def set_extra_headers(self, headers):
+        # included in mime_message
+        self._no_send_defaults("extra_headers")
+
+    def set_text_body(self, body):
+        # included in mime_message
+        self._no_send_defaults("body")
+
+    def set_html_body(self, body):
+        # included in mime_message
+        self._no_send_defaults("body")
+
+    def set_alternatives(self, alternatives):
+        # included in mime_message
+        self._no_send_defaults("alternatives")
+
+    def set_attachments(self, attachments):
+        # included in mime_message
+        self._no_send_defaults("attachments")
+
+    # Anymail-specific payload construction
+    def set_envelope_sender(self, email):
+        self.params["Source"] = email.addr_spec
+
+    def set_spoofed_to_header(self, header_to):
+        # django.core.mail.EmailMessage.message() has already set
+        #   self.mime_message["To"] = header_to
+        # and performed any necessary header sanitization
+        self.params["Destinations"] = [email.addr_spec for email in self.all_recipients]
+
+    def set_metadata(self, metadata):
+        # Anymail metadata dict becomes individual SES name:value Tags
+        # TODO: AWS Tags are very restrictive on values (e.g., no spaces or commas); should we offer optional encoding?
+        self.params.setdefault("Tags", []).extend(
+            {"Name": key, "Value": str(value)} for key, value in metadata.items())
+
+    def set_tags(self, tags):
+        # Anymail tags list becomes SES Tags["TagN"] values
+        self.params.setdefault("Tags", []).extend(
+            {"Name": "Tag%d" % n, "Value": tags[n]} for n in range(len(tags)))
+
+    def set_template_id(self, template_id):
+        # TODO: implement send_templated_email (uses different payload format; can't support attachments, etc.)
+        # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-advanced.html
+        self.unsupported_feature("template_id")
+
+    def set_merge_data(self, merge_data):
+        self.unsupported_feature("merge_data without template_id")
+
+    def set_merge_global_data(self, merge_global_data):
+        self.unsupported_feature("global_merge_data without template_id")
+
+    # ESP-specific payload construction
+    def set_esp_extra(self, extra):
+        # e.g., ConfigurationSetName, FromArn, SourceArn, ReturnPathArn
+        self.params.update(extra)

--- a/anymail/backends/amazon_ses.py
+++ b/anymail/backends/amazon_ses.py
@@ -134,7 +134,7 @@ class AmazonSESSendRawEmailPayload(AmazonSESBasePayload):
         self.params["RawMessage"] = {
             # Note: "Destinations" is determined from message headers if not provided
             # "Destinations": [email.addr_spec for email in self.all_recipients],
-            "Data": self.mime_message.as_string()
+            "Data": self.mime_message.as_bytes()
         }
         return ses_client.send_raw_email(**self.params)
 

--- a/anymail/backends/amazon_ses.py
+++ b/anymail/backends/amazon_ses.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .base import AnymailBaseBackend, BasePayload
 from ..exceptions import AnymailAPIError, AnymailImproperlyInstalled
 from ..message import AnymailRecipientStatus
@@ -98,14 +96,12 @@ class AmazonSESPayload(BasePayload):
         if attr in self.defaults:
             self.unsupported_feature("Anymail send defaults for '%s' with Amazon SES" % attr)
 
-    # def set_from_email_list(self, emails):
-    #   Multiple values in From header will result in "An error occurred (InvalidParameterValue)
-    #   when calling the SendRawEmail operation: Illegal address" (without mentioning which field
-    #   has the illegal address). Better to just use Anymail's base unsupported_feature warning.
-
-    def set_from_email(self, email):
-        # included in mime_message
-        self._no_send_defaults("from_email")
+    def set_from_email_list(self, emails):
+        # Although Amazon SES will send messages with any From header, it can only parse Source
+        # if the From header is a single email. Explicit Source avoids an "Illegal address" error:
+        if len(emails) > 1:
+            self.params["Source"] = emails[0].addr_spec
+        # (else SES will look at the (single) address in the From header)
 
     def set_recipients(self, recipient_type, emails):
         self.all_recipients += emails

--- a/anymail/urls.py
+++ b/anymail/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import url
 
+from .webhooks.amazon_ses import AmazonSESTrackingWebhookView
 from .webhooks.mailgun import MailgunInboundWebhookView, MailgunTrackingWebhookView
 from .webhooks.mailjet import MailjetInboundWebhookView, MailjetTrackingWebhookView
 from .webhooks.mandrill import MandrillCombinedWebhookView
@@ -17,6 +18,7 @@ urlpatterns = [
     url(r'^sendgrid/inbound/$', SendGridInboundWebhookView.as_view(), name='sendgrid_inbound_webhook'),
     url(r'^sparkpost/inbound/$', SparkPostInboundWebhookView.as_view(), name='sparkpost_inbound_webhook'),
 
+    url(r'^amazon_ses/tracking/$', AmazonSESTrackingWebhookView.as_view(), name='amazon_ses_tracking_webhook'),
     url(r'^mailgun/tracking/$', MailgunTrackingWebhookView.as_view(), name='mailgun_tracking_webhook'),
     url(r'^mailjet/tracking/$', MailjetTrackingWebhookView.as_view(), name='mailjet_tracking_webhook'),
     url(r'^postmark/tracking/$', PostmarkTrackingWebhookView.as_view(), name='postmark_tracking_webhook'),

--- a/anymail/urls.py
+++ b/anymail/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 
-from .webhooks.amazon_ses import AmazonSESTrackingWebhookView
+from .webhooks.amazon_ses import AmazonSESInboundWebhookView, AmazonSESTrackingWebhookView
 from .webhooks.mailgun import MailgunInboundWebhookView, MailgunTrackingWebhookView
 from .webhooks.mailjet import MailjetInboundWebhookView, MailjetTrackingWebhookView
 from .webhooks.mandrill import MandrillCombinedWebhookView
@@ -12,6 +12,7 @@ from .webhooks.sparkpost import SparkPostInboundWebhookView, SparkPostTrackingWe
 
 app_name = 'anymail'
 urlpatterns = [
+    url(r'^amazon_ses/inbound/$', AmazonSESInboundWebhookView.as_view(), name='amazon_ses_inbound_webhook'),
     url(r'^mailgun/inbound(_mime)?/$', MailgunInboundWebhookView.as_view(), name='mailgun_inbound_webhook'),
     url(r'^mailjet/inbound/$', MailjetInboundWebhookView.as_view(), name='mailjet_inbound_webhook'),
     url(r'^postmark/inbound/$', PostmarkInboundWebhookView.as_view(), name='postmark_inbound_webhook'),

--- a/anymail/utils.py
+++ b/anymail/utils.py
@@ -349,7 +349,7 @@ def get_anymail_setting(name, default=UNSET, esp_name=None, kwargs=None, allow_b
         pass
 
     if esp_name is not None:
-        setting = "{}_{}".format(esp_name.upper(), name.upper())
+        setting = "{}_{}".format(esp_name.upper().replace(" ", "_"), name.upper())
     else:
         setting = name.upper()
     anymail_setting = "ANYMAIL_%s" % setting

--- a/anymail/webhooks/amazon_ses.py
+++ b/anymail/webhooks/amazon_ses.py
@@ -7,6 +7,7 @@ from django.http import HttpResponse
 from django.utils.dateparse import parse_datetime
 
 from .base import AnymailBaseWebhookView
+from ..backends.amazon_ses import _get_anymail_boto3_client_params
 from ..exceptions import AnymailConfigurationError, AnymailImproperlyInstalled, AnymailWebhookValidationFailure
 from ..inbound import AnymailInboundMessage
 from ..signals import AnymailInboundEvent, AnymailTrackingEvent, EventType, RejectReason, inbound, tracking
@@ -29,8 +30,7 @@ class AmazonSESBaseWebhookView(AnymailBaseWebhookView):
         self.auto_confirm_enabled = get_anymail_setting(
             "auto_confirm_sns_subscriptions", esp_name=self.esp_name, kwargs=kwargs, default=True)
         # boto3 client params for connecting to s3 (inbound downloads):
-        self.client_params = get_anymail_setting(
-            "client_params", esp_name=self.esp_name, kwargs=kwargs, allow_bare=False, default={})
+        self.client_params = _get_anymail_boto3_client_params(kwargs=kwargs)
         super(AmazonSESBaseWebhookView, self).__init__(**kwargs)
 
     @staticmethod

--- a/anymail/webhooks/amazon_ses.py
+++ b/anymail/webhooks/amazon_ses.py
@@ -126,7 +126,7 @@ class AmazonSESBaseWebhookView(AnymailBaseWebhookView):
 
         # WEBHOOK_SECRET *is* set, so the request's basic auth has been verified by now (in run_validators).
         # We're good to confirm...
-        boto3.client('sns').confirm_subscription(
+        boto3.client('sns', **self.client_params).confirm_subscription(
             TopicArn=sns_message["TopicArn"], Token=sns_message["Token"], AuthenticateOnUnsubscribe='true')
 
 

--- a/anymail/webhooks/amazon_ses.py
+++ b/anymail/webhooks/amazon_ses.py
@@ -1,0 +1,133 @@
+import json
+
+import requests
+from django.http import HttpResponse
+from django.utils.dateparse import parse_datetime
+
+from .base import AnymailBaseWebhookView
+from ..exceptions import AnymailWebhookValidationFailure
+from ..signals import tracking, AnymailTrackingEvent, EventType, RejectReason
+from ..utils import get_anymail_setting
+
+
+class AmazonSESBaseWebhookView(AnymailBaseWebhookView):
+    """Base view class for Amazon SES webhooks (SNS Notifications)"""
+
+    esp_name = "Amazon SES"
+
+    def __init__(self, **kwargs):
+        # whether to automatically respond to SNS SubscriptionConfirmation requests; default True
+        # (Future: could also take a TopicArn or list to auto-confirm)
+        self.auto_confirm_enabled = get_anymail_setting(
+            "auto_confirm_sns_subscriptions", esp_name=self.esp_name, kwargs=kwargs, default=True)
+        super(AmazonSESBaseWebhookView, self).__init__(**kwargs)
+
+    @staticmethod
+    def _parse_sns_message(request):
+        # cache so we don't have to parse the json multiple times
+        if not hasattr(request, '_sns_message'):
+            try:
+                body = request.body.decode(request.encoding or 'utf-8')
+                request._sns_message = json.loads(body)
+            except (TypeError, ValueError, UnicodeDecodeError) as err:
+                raise AnymailWebhookValidationFailure("Malformed SNS message body %r" % request.body,
+                                                      raised_from=err)
+        return request._sns_message
+
+    def validate_request(self, request):
+        # Block random posts that don't even have matching SNS headers
+        sns_message = self._parse_sns_message(request)
+        header_type = request.META.get("HTTP_X_AMZ_SNS_MESSAGE_TYPE", "<<missing>>")
+        body_type = sns_message.get("Type", "<<missing>>")
+        if header_type != body_type:
+            raise AnymailWebhookValidationFailure(
+                'SNS header "x-amz-sns-message-type: %s" doesn\'t match body "Type": "%s"'
+                % (header_type, body_type))
+
+        if header_type not in ["Notification", "SubscriptionConfirmation", "UnsubscribeConfirmation"]:
+            raise AnymailWebhookValidationFailure("Unknown SNS message type '%s'" % header_type)
+
+        header_id = request.META.get("HTTP_X_AMZ_SNS_MESSAGE_ID", "<<missing>>")
+        body_id = sns_message.get("MessageId", "<<missing>>")
+        if header_id != body_id:
+            raise AnymailWebhookValidationFailure(
+                'SNS header "x-amz-sns-message-id: %s" doesn\'t match body "MessageId": "%s"'
+                % (header_id, body_id))
+
+        # TODO: Verify SNS message signature
+        # https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.verify.signature.html
+        # Requires ability to public-key-decrypt signature with Amazon-supplied X.509 cert
+        # (which isn't in Python standard lib; need pyopenssl or pycryptodome, e.g.)
+
+    def post(self, request, *args, **kwargs):
+        # request has *not* yet been validated at this point
+        if self.basic_auth and not request.META.get("HTTP_AUTHORIZATION"):
+            # Amazon SNS requires a proper 401 response before it will attempt to send basic auth
+            response = HttpResponse(status=401)
+            response["WWW-Authenticate"] = 'Basic realm="Anymail WEBHOOK_SECRET"'
+            return response
+        return super(AmazonSESBaseWebhookView, self).post(request, *args, **kwargs)
+
+    def parse_events(self, request):
+        # request *has* been validated by now
+        events = []
+        sns_message = self._parse_sns_message(request)
+        sns_type = sns_message.get("Type")
+        if sns_type == "Notification":
+            message_string = sns_message.get("Message")
+            try:
+                ses_event = json.loads(message_string)
+            except (TypeError, ValueError):
+                if message_string == "Successfully validated SNS topic for Amazon SES event publishing.":
+                    pass  # this Notification is generated after SubscriptionConfirmation
+                else:
+                    raise AnymailWebhookValidationFailure("Unparsable SNS Message %r" % message_string)
+            else:
+                events = self.esp_to_anymail_events(ses_event, sns_message)
+        elif sns_type == "SubscriptionConfirmation":
+            self.auto_confirm_sns_subscription(sns_message)
+        # else: just ignore other SNS messages (e.g., "UnsubscribeConfirmation")
+        return events
+
+    def esp_to_anymail_events(self, ses_event, sns_message):
+        raise NotImplementedError()
+
+    def auto_confirm_sns_subscription(self, sns_message):
+        """Automatically accept a subscription to Amazon SNS topics, if the request is expected.
+
+        If an SNS SubscriptionConfirmation arrives with HTTP basic auth proving it is meant for us,
+        automatically load the SubscribeURL to confirm the subscription.
+        """
+        if not self.auto_confirm_enabled:
+            return
+
+        if not self.basic_auth:
+            # Note: basic_auth (shared secret) confirms the notification was meant for us.
+            # If WEBHOOK_SECRET isn't set, Anymail logs a warning but allows the request.
+            # (Also, verifying the SNS message signature would be insufficient here:
+            # if someone else tried to point their own SNS topic at our webhook url,
+            # SNS would send a SubscriptionConfirmation with a valid Amazon signature.)
+            raise AnymailWebhookValidationFailure(
+                "Anymail received an unexpected SubscriptionConfirmation request for Amazon SNS topic "
+                "'{topic_arn!s}'. (Anymail can automatically confirm SNS subscriptions if you set a "
+                "WEBHOOK_SECRET and use that in your SNS notification url. Or you can manually confirm "
+                "this subscription in the SNS dashboard with token '{token!s}'.)"
+                "".format(topic_arn=sns_message.get('TopicArn'), token=sns_message.get('Token')))
+
+        # WEBHOOK_SECRET *is* set, so the request's basic auth has been verified by now (in run_validators)
+        response = requests.get(sns_message["SubscribeURL"])
+        if not response.ok:
+            raise AnymailWebhookValidationFailure(
+                "Anymail received a {status_code} error trying to automatically confirm a subscription "
+                "to Amazon SNS topic '{topic_arn!s}'. The response was '{text!s}'."
+                "".format(status_code=response.status_code, text=response.text,
+                          topic_arn=sns_message.get('TopicArn')))
+
+
+class AmazonSESTrackingWebhookView(AmazonSESBaseWebhookView):
+    """Handler for Amazon SES tracking notifications"""
+
+    signal = tracking
+
+    def esp_to_anymail_events(self, ses_event, sns_message):
+        return []  # TODO

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -91,7 +91,7 @@ Or:
 
     .. code-block:: console
 
-        $ pip install mock sparkpost  # install test dependencies
+        $ pip install mock boto3 sparkpost  # install test dependencies
         $ python runtests.py
 
         ## this command can also run just a few test cases, e.g.:

--- a/docs/esps/amazon_ses.rst
+++ b/docs/esps/amazon_ses.rst
@@ -451,9 +451,9 @@ To use Anymail's inbound webhook with Amazon SES:
    in the last step, "Creating Receipt Rules."
 
 5. Anymail supports two SES receipt actions: S3 and SNS. (Both actually use SNS.)
-   You can choose either one: the SNS action is easier to set up, but the S3 action allows
-   you to receive larger messages. (If you aren't sure, start with SNS and change to S3
-   later if needed. Don't use both at the same time.)
+   You can choose either one: the SNS action is easier to set up, but the S3 action
+   allows you to receive larger messages and can be more robust.
+   (You can change at any time, but don't use both simultaneously.)
 
    * **For the SNS action:** choose the SNS Topic you created in step 2. Anymail will handle
      either Base64 or UTF-8 encoding; use Base64 if you're not sure.
@@ -468,7 +468,9 @@ after you complete the last step.
 
 If you are using the S3 receipt action, note that Anymail does not delete the S3 object.
 You can delete it from your code after successful processing, or set up S3 bucket policies
-to automatically delete older messages.
+to automatically delete older messages. In your inbound handler, you can retrieve the S3
+object key by prepending the "object key prefix" (if any) from your receipt rule to Anymail's
+:attr:`event.event_id <anymail.signals.AnymailInboundEvent.event_id>`.
 
 Amazon SNS imposes a 15 second limit on all notifications. This includes time to download
 the message (if you are using the S3 receipt action) and any processing in your

--- a/docs/esps/amazon_ses.rst
+++ b/docs/esps/amazon_ses.rst
@@ -13,6 +13,8 @@ AWS SDK for Python, and includes sending, tracking, and inbound receiving capabi
     Depending on your needs, one of them may be more appropriate than Anymail.
 
 
+.. versionadded:: 2.1
+
 .. _Amazon Simple Email Service: https://aws.amazon.com/ses/
 .. _Boto 3: https://boto3.readthedocs.io/en/stable/
 

--- a/docs/esps/amazon_ses.rst
+++ b/docs/esps/amazon_ses.rst
@@ -218,18 +218,47 @@ to apply it to all messages.)
 Batch sending/merge and ESP templates
 -------------------------------------
 
-[SendBulkTemplatedEmail implementation coming soon]
+Amazon SES offers :ref:`ESP stored templates <esp-stored-templates>`
+and :ref:`batch sending <batch-send>` with per-recipient merge data.
+See Amazon's `Sending personalized email`_ guide for more information.
 
-Additional limitations when sending with a template:
+When you set a message's :attr:`~anymail.message.AnymailMessage.template_id`
+to the name of one of your SES templates, Anymail will use the SES
+`SendBulkTemplatedEmail`_ call to send template messages personalized with data
+from Anymail's normalized :attr:`~anymail.message.AnymailMessage.merge_data`
+and :attr:`~anymail.message.AnymailMessage.merge_global_data`
+message attributes.
+
+  .. code-block:: python
+
+      message = EmailMessage(
+          from_email="shipping@example.com",
+          # you must omit subject and body (or set to None) with Amazon SES templates
+          to=["alice@example.com", "Bob <bob@example.com>"]
+      )
+      message.template_id = "MyTemplateName"  # Amazon SES TemplateName
+      message.merge_data = {
+          'alice@example.com': {'name': "Alice", 'order_no': "12345"},
+          'bob@example.com': {'name': "Bob", 'order_no': "54321"},
+      }
+      message.merge_global_data = {
+          'ship_date': "May 15",
+      }
+
+Amazon's templated email APIs don't support several features available for regular email.
+When :attr:`~anymail.message.AnymailMessage.template_id` is used:
 
 * Attachments are not supported
 * Extra headers are not supported
-* Overriding the message's subject or body is not supported
+* Overriding the template's subject or body is not supported
 * Anymail's :attr:`~anymail.message.AnymailMessage.metadata` is not supported
 * Anymail's :attr:`~anymail.message.AnymailMessage.tags` are only supported
   with the :setting:`AMAZON_SES_MESSAGE_TAG_NAME <ANYMAIL_AMAZON_SES_MESSAGE_TAG_NAME>`
   setting; only a single tag is allowed, and the tag is not directly available
   to webhooks. (See :ref:`amazon-ses-tags` above.)
+
+.. _Sending personalized email:
+   https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html
 
 
 .. _amazon-ses-webhooks:

--- a/docs/esps/amazon_ses.rst
+++ b/docs/esps/amazon_ses.rst
@@ -492,7 +492,7 @@ Additional Anymail settings for use with Amazon SES:
 
 .. rubric:: AMAZON_SES_CLIENT_PARAMS
 
-Optional. Additional `session parameters`_ Anymail should use to create the boto3 client. Example:
+Optional. Additional `client parameters`_ Anymail should use to create the boto3 session client. Example:
 
   .. code-block:: python
 
@@ -515,7 +515,7 @@ In most cases, it's better to let Boto obtain its own credentials through one of
 mechanisms: an IAM role for EC2 instances, standard AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 and AWS_SESSION_TOKEN environment variables, or a shared AWS credentials file.
 
-.. _session parameters:
+.. _client parameters:
     https://boto3.readthedocs.io/en/stable/reference/core/session.html#boto3.session.Session.client
 
 

--- a/docs/esps/amazon_ses.rst
+++ b/docs/esps/amazon_ses.rst
@@ -548,6 +548,25 @@ and AWS_SESSION_TOKEN environment variables, or a shared AWS credentials file.
     https://boto3.readthedocs.io/en/stable/reference/core/session.html#boto3.session.Session.client
 
 
+.. setting:: ANYMAIL_AMAZON_SES_SESSION_PARAMS
+
+.. rubric:: AMAZON_SES_SESSION_PARAMS
+
+Optional. Additional `session parameters`_ Anymail should use to create the boto3 Session. Example:
+
+  .. code-block:: python
+
+      ANYMAIL = {
+          ...
+          "AMAZON_SES_SESSION_PARAMS": {
+              "profile_name": "anymail-testing",
+          },
+      }
+
+.. _session parameters:
+    https://boto3.readthedocs.io/en/stable/reference/core/session.html#boto3.session.Session
+
+
 .. setting:: ANYMAIL_AMAZON_SES_CONFIGURATION_SET_NAME
 
 .. rubric:: AMAZON_SES_CONFIGURATION_SET_NAME

--- a/docs/esps/amazon_ses.rst
+++ b/docs/esps/amazon_ses.rst
@@ -1,0 +1,623 @@
+.. _amazon-ses-backend:
+
+Amazon SES
+==========
+
+Anymail integrates with `Amazon Simple Email Service`_ (SES) using the `Boto 3`_
+AWS SDK for Python, and includes sending, tracking, and inbound receiving capabilities.
+
+.. sidebar:: Alternatives
+
+    At least two other packages offer Django integration with
+    Amazon SES: :pypi:`django-amazon-ses` and :pypi:`django-ses`.
+    Depending on your needs, one of them may be more appropriate than Anymail.
+
+
+.. _Amazon Simple Email Service: https://aws.amazon.com/ses/
+.. _Boto 3: https://boto3.readthedocs.io/en/stable/
+
+
+Installation
+------------
+
+You must ensure the :pypi:`boto3` package is installed to use Anymail's Amazon SES
+backend. Either include the "amazon_ses" option when you install Anymail:
+
+    .. code-block:: console
+
+        $ pip install django-anymail[amazon_ses]
+
+or separately run `pip install boto3`.
+
+To send mail with Anymail's Amazon SES backend, set:
+
+  .. code-block:: python
+
+      EMAIL_BACKEND = "anymail.backends.amazon_ses.EmailBackend"
+
+in your settings.py.
+
+In addition, you must make sure boto3 is configured with AWS credentials having the
+necessary :ref:`amazon-ses-iam-permissions`.
+There are several ways to do this; see `Credentials`_ in the Boto docs for options.
+Usually, an IAM role for EC2 instances, standard Boto environment variables,
+or a shared AWS credentials file will be appropriate. For more complex cases,
+use Anymail's :setting:`AMAZON_SES_CLIENT_PARAMS <ANYMAIL_AMAZON_SES_CLIENT_PARAMS>`
+setting to customize the Boto session.
+
+
+.. _Credentials: https://boto3.readthedocs.io/en/stable/guide/configuration.html#configuring-credentials
+
+
+.. _amazon-ses-quirks:
+
+Limitations and quirks
+----------------------
+
+**Hard throttling**
+  Like most ESPs, Amazon SES `throttles sending`_ for new customers. But unlike
+  most ESPs, SES does not queue and slowly release throttled messages. Instead, it
+  hard-fails the send API call. A strategy for :ref:`retrying errors <transient-errors>`
+  is required with any ESP; you're likely to run into it right away with Amazon SES.
+
+**Tags limitations**
+  Amazon SES's handling for tags is a bit different from other ESPs.
+  Anymail tries to provide a useful, portable default behavior for its
+  :attr:`~anymail.message.AnymailMessage.tags` feature. See :ref:`amazon-ses-tags`
+  below for more information and additional options.
+
+**Open and click tracking overrides**
+  Anymail's :attr:`~anymail.message.AnymailMessage.track_opens` and
+  :attr:`~anymail.message.AnymailMessage.track_clicks` are not supported.
+  Although Amazon SES *does* support open and click tracking, it doesn't offer
+  a simple mechanism to override the settings for individual messages. If you
+  need this feature, provide a custom ConfigurationSetName in Anymail's
+  :ref:`esp_extra <amazon-ses-esp-extra>`.
+
+**No delayed sending**
+  Amazon SES does not support :attr:`~anymail.message.AnymailMessage.send_at`.
+
+**No global send defaults for non-Anymail options**
+  With the Amazon SES backend, Anymail's :ref:`global send defaults <send-defaults>`
+  are only supported for Anymail's added message options (like
+  :attr:`~anymail.message.AnymailMessage.metadata` and
+  :attr:`~anymail.message.AnymailMessage.esp_extra`), not for standard EmailMessage
+  attributes like `bcc` or `from_email`.
+
+**Arbitrary alternative parts allowed**
+  Amazon SES is one of the few ESPs that *does* support sending arbitrary alternative
+  message parts (beyond just a single text/plain and text/html part).
+
+**Spoofed To header and multiple From emails allowed**
+  Amazon SES is one of the few ESPs that supports spoofing the :mailheader:`To` header
+  (see :ref:`message-headers`) and supplying multiple addresses in a message's `from_email`.
+  (Most ISPs consider these to be very strong spam signals, and using either them will almost
+  certainly prevent delivery of your mail.)
+
+**Template limitations**
+  Messages sent with templates have a number of additional limitations, such as not
+  supporting attachments. See :ref:`amazon-ses-templates` below.
+
+
+.. _throttles sending:
+   https://docs.aws.amazon.com/ses/latest/DeveloperGuide/manage-sending-limits.html
+
+.. _amazon-ses-tags:
+
+Tags and metadata
+-----------------
+
+Amazon SES provides two mechanisms for associating additional data with sent messages,
+which Anymail uses to implement its :attr:`~anymail.message.AnymailMessage.tags`
+and :attr:`~anymail.message.AnymailMessage.metadata` features:
+
+* **SES Message Tags** can be used for filtering or segmenting CloudWatch metrics and
+  dashboards, and are available to Kinesis Firehose streams. (See "How do message
+  tags work?" in the Amazon blog post `Introducing Sending Metrics`_.)
+
+  By default, Anymail does *not* use SES Message Tags. They have strict limitations
+  on characters allowed, and are not consistently available to tracking webhooks.
+  (They may be included in `SES Event Publishing`_ but not `SES Notifications`_.)
+
+* **Custom Email Headers** are available to all SNS notifications (webhooks), but
+  not to CloudWatch or Kinesis.
+
+  These are ordinary extension headers included in the sent message (and visible to
+  recipients who view the full headers). There are no restrictions on characters allowed.
+
+By default, Anymail uses only custom email headers. A message's
+:attr:`~anymail.message.AnymailMessage.metadata` is sent JSON-encoded in a custom
+:mailheader:`X-Metadata` header, and a message's :attr:`~anymail.message.AnymailMessage.tags`
+are sent in custom :mailheader:`X-Tag` headers. Both are available in Anymail's
+:ref:`tracking webhooks <amazon-ses-webhooks>`.
+
+Because Anymail :attr:`~anymail.message.AnymailMessage.tags` are often used for
+segmenting reports, Anymail has an option to easily send an Anymail tag
+as an SES Message Tag that can be used in CloudWatch. Set the Anymail setting
+:setting:`AMAZON_SES_MESSAGE_TAG_NAME <ANYMAIL_AMAZON_SES_MESSAGE_TAG_NAME>`
+to the name of an SES Message Tag whose value will be the *single* Anymail tag
+on the message. For example, with this setting:
+
+  .. code-block:: python
+
+      ANYMAIL = {
+          ...
+          "AMAZON_SES_MESSAGE_TAG_NAME": "Type",
+      }
+
+this send will appear in CloudWatch with the SES Message Tag `"Type": "Marketing"`:
+
+  .. code-block:: python
+
+      message = EmailMessage(...)
+      message.tags = ["Marketing"]
+      message.send()
+
+Anymail's :setting:`AMAZON_SES_MESSAGE_TAG_NAME <ANYMAIL_AMAZON_SES_MESSAGE_TAG_NAME>`
+setting is disabled by default. If you use it, then only a single tag is supported,
+and both the tag and the name must be limited to alphanumeric, hyphen, and underscore
+characters.
+
+For more complex use cases, set the SES `Tags` parameter directly in Anymail's
+:ref:`esp_extra <amazon-ses-esp-extra>`. See the example below. (Because custom headers do not
+work with SES's SendBulkTemplatedEmail call, esp_extra Tags is the only way to attach
+data to SES messages also using Anymail's :attr:`~anymail.message.AnymailMessage.template_id`
+and :attr:`~anymail.message.AnymailMessage.merge_data` features.)
+
+
+.. _Introducing Sending Metrics:
+    https://aws.amazon.com/blogs/ses/introducing-sending-metrics/
+.. _SES Event Publishing:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-using-event-publishing.html
+.. _SES Notifications:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-using-notifications.html
+
+
+.. _amazon-ses-esp-extra:
+
+esp_extra support
+-----------------
+
+To use Amazon SES features not directly supported by Anymail, you can
+set a message's :attr:`~anymail.message.AnymailMessage.esp_extra` to
+a `dict` that will be merged into the params for the `SendRawEmail`_
+or `SendBulkTemplatedEmail`_ SES API call.
+
+Example:
+
+    .. code-block:: python
+
+        message.esp_extra = {
+            # Override AMAZON_SES_CONFIGURATION_SET_NAME for this message
+            'ConfigurationSetName': 'NoOpenOrClickTrackingConfigSet',
+            # Authorize a custom sender
+            'SourceArn': 'arn:aws:ses:us-east-1:123456789012:identity/example.com',
+            # Set Amazon SES Message Tags
+            'Tags': [
+                # (Names and values must be A-Z a-z 0-9 - and _ only)
+                {'Name': 'UserID', 'Value': str(user_id)},
+                {'Name': 'TestVariation', 'Value': 'Subject-Emoji-Trial-A'},
+            ],
+        }
+
+
+(You can also set `"esp_extra"` in Anymail's :ref:`global send defaults <send-defaults>`
+to apply it to all messages.)
+
+.. _SendRawEmail:
+    https://docs.aws.amazon.com/ses/latest/APIReference/API_SendRawEmail.html
+
+.. _SendBulkTemplatedEmail:
+    https://docs.aws.amazon.com/ses/latest/APIReference/API_SendBulkTemplatedEmail.html
+
+
+.. _amazon-ses-templates:
+
+Batch sending/merge and ESP templates
+-------------------------------------
+
+[SendBulkTemplatedEmail implementation coming soon]
+
+Additional limitations when sending with a template:
+
+* Attachments are not supported
+* Extra headers are not supported
+* Overriding the message's subject or body is not supported
+* Anymail's :attr:`~anymail.message.AnymailMessage.metadata` is not supported
+* Anymail's :attr:`~anymail.message.AnymailMessage.tags` are only supported
+  with the :setting:`AMAZON_SES_MESSAGE_TAG_NAME <ANYMAIL_AMAZON_SES_MESSAGE_TAG_NAME>`
+  setting; only a single tag is allowed, and the tag is not directly available
+  to webhooks. (See :ref:`amazon-ses-tags` above.)
+
+
+.. _amazon-ses-webhooks:
+
+Status tracking webhooks
+------------------------
+
+Anymail can provide normalized :ref:`status tracking <event-tracking>` notifications
+for messages sent through Amazon SES. SES offers two (confusingly) similar kinds of
+tracking, and Anymail supports both:
+
+* `SES Notifications`_ include delivered, bounced, and complained (spam) Anymail
+  :attr:`~anymail.signals.AnymailTrackingEvent.event_type`\s. (Enabling these
+  notifications may allow you to disable SES "email feedback forwarding.")
+
+* `SES Event Publishing`_ also includes delivered, bounced and complained events,
+  as well as sent, rejected, opened, clicked, and (template rendering) failed.
+
+Both types of tracking events are delivered to Anymail's webhook URL through
+Amazon Simple Notification Service (SNS) subscriptions.
+
+Amazon's naming here can be really confusing. We'll try to be clear about "SES Notifications"
+vs. "SES Event Publishing" as the two different kinds of SES tracking events.
+And then distinguish all of that from "SNS"---the publish/subscribe service
+used to notify Anymail's tracking webhooks about *both* kinds of SES tracking event.
+
+To use Anymail's status tracking webhooks with Amazon SES:
+
+1. First, :ref:`configure Anymail webhooks <webhooks-configuration>` and deploy your
+   Django project. (Deploying allows Anymail to confirm the SNS subscription for you
+   in step 3.)
+
+Then in Amazon's **Simple Notification Service** console:
+
+2. `Create an SNS Topic`_ to receive Amazon SES tracking events.
+   The exact topic name is up to you; choose something meaningful like *SES_Tracking_Events*.
+
+3. Subscribe Anymail's tracking webhook to the SNS Topic you just created. In the SNS
+   console, click into the topic from step 2, then click the "Create subscription" button.
+   For protocol choose HTTPS. For endpoint enter:
+
+   :samp:`https://{random}:{random}@{yoursite.example.com}/anymail/amazon_ses/tracking/`
+
+     * *random:random* is an :setting:`ANYMAIL_WEBHOOK_SECRET` shared secret
+     * *yoursite.example.com* is your Django site
+
+   Anymail will automatically confirm the SNS subscription. (For other options, see
+   :ref:`amazon-ses-confirm-sns-subscriptions` below.)
+
+Finally, switch to Amazon's **Simple Email Service** console:
+
+4. **If you want to use SES Notifications:** Follow Amazon's guide to
+   `configure SES notifications through SNS`_, using the SNS Topic you created above.
+   Choose any event types you want to receive. Be sure to choose "Include original headers"
+   if you need access to Anymail's :attr:`~anymail.message.AnymailMessage.metadata` or
+   :attr:`~anymail.message.AnymailMessage.tags` in your webhook handlers.
+
+5. **If you want to use SES Event Publishing:**
+
+    a. Follow Amazon's guide to `create an SES "Configuration Set"`_. Name it something meaningful,
+       like *TrackingConfigSet.*
+
+    b. Follow Amazon's guide to `add an SNS event destination for SES event publishing`_, using the
+       SNS Topic you created above. Choose any event types you want to receive.
+
+    c. Update your Anymail settings to send using this Configuration Set by default:
+
+        .. code-block:: python
+
+            ANYMAIL = {
+                ...
+                "AMAZON_SES_CONFIGURATION_SET_NAME": "TrackingConfigSet",
+            }
+
+.. caution::
+
+    The delivery, bounce, and complaint event types are available in both SES Notifications
+    *and* SES Event Publishing. If you're using both, don't enable the same events in both
+    places, or you'll receive duplicate notifications with *different*
+    :attr:`~anymail.signals.AnymailTrackingEvent.event_id`\s.
+
+
+Note that Amazon SES's open and click tracking does not distinguish individual recipients.
+If you send a single message to multiple recipients, Anymail will call your tracking handler
+with the "opened" or "clicked" event for *every* original recipient of the message, including
+all to, cc and bcc addresses. (Amazon recommends avoiding multiple recipients with SES.)
+
+In your tracking signal receiver, the normalized AnymailTrackingEvent's
+:attr:`~anymail.signals.AnymailTrackingEvent.esp_event` will be set to the
+the parsed, top-level JSON event object from SES: either `SES Notification contents`_
+or `SES Event Publishing contents`_. (The two formats are nearly identical.)
+You can use this to obtain SES Message Tags (see :ref:`amazon-ses-tags`) from
+SES Event Publishing notifications:
+
+.. code-block:: python
+
+    from anymail.signals import tracking
+    from django.dispatch import receiver
+
+    @receiver(tracking)  # add weak=False if inside some other function/class
+    def handle_tracking(sender, event, esp_name, **kwargs):
+        if esp_name == "Amazon SES":
+            try:
+                message_tags = {
+                    name: values[0]
+                    for name, values in event.esp_event["mail"]["tags"].items()}
+            except KeyError:
+                message_tags = None  # SES Notification (not Event Publishing) event
+            print("Message %s to %s event %s: Message Tags %r" % (
+                  event.message_id, event.recipient, event.event_type, message_tags))
+
+
+Anymail does *not* currently check `SNS signature verification`_, because Amazon has not
+released a standard way to do that in Python. Instead, Anymail relies on your
+:setting:`WEBHOOK_SECRET <ANYMAIL_WEBHOOK_SECRET>` to verify SNS notifications are from an
+authorized source.
+
+
+.. _Create an SNS Topic:
+    https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html
+.. _configure SES notifications through SNS:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-sns-notifications.html
+.. _create an SES "Configuration Set":
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/event-publishing-create-configuration-set.html
+.. _add an SNS event destination for SES event publishing:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/event-publishing-add-event-destination-sns.html
+.. _SES Notification contents:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html
+.. _SES Event Publishing contents:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/event-publishing-retrieving-sns-contents.html
+.. _SNS signature verification:
+    https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.verify.signature.html
+
+.. _amazon-ses-inbound:
+
+Inbound webhook
+---------------
+
+You can receive email through Amazon SES with Anymail's normalized :ref:`inbound <inbound>`
+handling. See `Receiving email with Amazon SES`_ for background.
+
+Configuring Anymail's inbound webhook for Amazon SES is similar to installing the
+:ref:`tracking webhook <amazon-ses-webhooks>`. You must use a different SNS Topic
+for inbound.
+
+To use Anymail's inbound webhook with Amazon SES:
+
+1. First, if you haven't already, :ref:`configure Anymail webhooks <webhooks-configuration>`
+   and deploy your Django project. (Deploying allows Anymail to confirm the SNS subscription
+   for you in step 3.)
+
+2. `Create an SNS Topic`_ to receive Amazon SES inbound events.
+   The exact topic name is up to you; choose something meaningful like *SES_Inbound_Events*.
+   (If you are also using Anymail's tracking events, this must be a *different* SNS Topic.)
+
+3. Subscribe Anymail's inbound webhook to the SNS Topic you just created. In the SNS
+   console, click into the topic from step 2, then click the "Create subscription" button.
+   For protocol choose HTTPS. For endpoint enter:
+
+   :samp:`https://{random}:{random}@{yoursite.example.com}/anymail/amazon_ses/inbound/`
+
+     * *random:random* is an :setting:`ANYMAIL_WEBHOOK_SECRET` shared secret
+     * *yoursite.example.com* is your Django site
+
+   Anymail will automatically confirm the SNS subscription. (For other options, see
+   :ref:`amazon-ses-confirm-sns-subscriptions` below.)
+
+4. Next, follow Amazon's guide to `Setting up Amazon SES email receiving`_.
+   There are several steps. Come back here when you get to "Action Options"
+   in the last step, "Creating Receipt Rules."
+
+5. Anymail supports two SES receipt actions: S3 and SNS. (Both actually use SNS.)
+   You can choose either one: the SNS action is easier to set up, but the S3 action allows
+   you to receive larger messages. (If you aren't sure, start with SNS and change to S3
+   later if needed. Don't use both at the same time.)
+
+   * **For the SNS action:** choose the SNS Topic you created in step 2. Anymail will handle
+     either Base64 or UTF-8 encoding; use Base64 if you're not sure.
+
+   * **For the S3 action:** choose or create any S3 bucket that Boto will be able to read.
+     (See :ref:`amazon-ses-iam-permissions`; *don't* use a world-readable bucket!)
+     "Object key prefix" is optional. Anymail does *not* currently support the
+     "Encrypt message" option. Finally, choose the SNS Topic you created in step 2.
+
+Amazon SES will likely deliver a test message to your Anymail inbound handler immediately
+after you complete the last step.
+
+If you are using the S3 receipt action, note that Anymail does not delete the S3 object.
+You can delete it from your code after successful processing, or set up S3 bucket policies
+to automatically delete older messages.
+
+Amazon SNS imposes a 15 second limit on all notifications. This includes time to download
+the message (if you are using the S3 receipt action) and any processing in your
+signal receiver. If the total takes longer, SNS will consider the notification failed
+and will make several repeat attempts. To avoid problems, it's essential any lengthy
+operations are offloaded to a background task.
+
+In your inbound signal receiver, the normalized AnymailTrackingEvent's
+:attr:`~anymail.signals.AnymailTrackingEvent.esp_event` will be set to the
+the parsed, top-level JSON object described in `SES Email Receiving contents`_.
+
+.. _Receiving email with Amazon SES:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html
+.. _Setting up Amazon SES email receiving:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-setting-up.html
+.. _SES Email Receiving contents:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-contents.html
+
+
+.. _amazon-ses-confirm-sns-subscriptions:
+
+Confirming SNS subscriptions
+----------------------------
+
+Amazon SNS requires HTTPS endpoints (webhooks) to confirm they actually want to subscribe
+to an SNS Topic. See `Sending SNS messages to HTTPS endpoints`_ in the Amazon SNS docs
+for more information.
+
+(This has nothing to do with verifying email identities in Amazon *SES*,
+and is not related to email recipients confirming subscriptions to your content.)
+
+Anymail will automatically handle SNS endpoint confirmation for you, for both tracking and inbound
+webhooks, if both:
+
+1. You have deployed your Django project with :ref:`Anymail webhooks enabled <webhooks-configuration>`
+   and an Anymail :setting:`WEBHOOK_SECRET <ANYMAIL_WEBHOOK_SECRET>` set, before subscribing the SNS Topic
+   to the webhook URL.
+
+   (If you subscribed the SNS topic too early, you can re-send the confirmation request later
+   from the Subscriptions section of the Amazon SNS dashboard.)
+
+2. The SNS endpoint URL includes the correct Anymail :setting:`WEBHOOK_SECRET <ANYMAIL_WEBHOOK_SECRET>`
+   as HTTP basic authentication. (Amazon SNS only allows this with https urls, not plain http.)
+
+   Anymail requires a valid secret to ensure the subscription request is coming from you, not some other
+   AWS user.
+
+If you do not want Anymail to automatically confirm SNS subscriptions for its webhook URLs, set
+:setting:`AMAZON_SES_AUTO_CONFIRM_SNS_SUBSCRIPTIONS <ANYMAIL_AMAZON_SES_AUTO_CONFIRM_SNS_SUBSCRIPTIONS>`
+to `False` in your ANYMAIL settings.
+
+When auto-confirmation is disabled (or if Anymail receives an unexpected confirmation request),
+it will raise an :exc:`AnymailWebhookValidationFailure`, which should show up in your Django error
+logging. The error message will include the Token you can use to manually confirm the subscription
+in the Amazon SNS dashboard or through the SNS API.
+
+
+.. _Sending SNS messages to HTTPS endpoints:
+    https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html
+
+
+.. _amazon-ses-settings:
+
+Settings
+--------
+
+Additional Anymail settings for use with Amazon SES:
+
+.. setting:: ANYMAIL_AMAZON_SES_CLIENT_PARAMS
+
+.. rubric:: AMAZON_SES_CLIENT_PARAMS
+
+Optional. Additional `session parameters`_ Anymail should use to create the boto3 client. Example:
+
+  .. code-block:: python
+
+      ANYMAIL = {
+          ...
+          "AMAZON_SES_CLIENT_PARAMS": {
+              # example: override normal Boto credentials specifically for Anymail
+              "aws_access_key_id": os.getenv("AWS_ACCESS_KEY_FOR_ANYMAIL_SES"),
+              "aws_secret_access_key": os.getenv("AWS_SECRET_KEY_FOR_ANYMAIL_SES"),
+              "region_name": "us-west-2",
+              # override other default options
+              "config": {
+                  "connect_timeout": 30,
+                  "read_timeout": 30,
+              }
+          },
+      }
+
+In most cases, it's better to let Boto obtain its own credentials through one of its other
+mechanisms: an IAM role for EC2 instances, standard AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+and AWS_SESSION_TOKEN environment variables, or a shared AWS credentials file.
+
+.. _session parameters:
+    https://boto3.readthedocs.io/en/stable/reference/core/session.html#boto3.session.Session.client
+
+
+.. setting:: ANYMAIL_AMAZON_SES_CONFIGURATION_SET_NAME
+
+.. rubric:: AMAZON_SES_CONFIGURATION_SET_NAME
+
+Optional. The name of an Amazon SES `Configuration Set`_ Anymail should use when sending messages.
+The default is to send without any Configuration Set. Note that a Configuration Set is
+required to receive SES Event Publishing tracking events. See :ref:`amazon-ses-webhooks` above.
+
+You can override this for individual messages with :ref:`esp_extra <amazon-ses-esp-extra>`.
+
+.. _Configuration Set:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-configuration-sets.html
+
+
+.. setting:: ANYMAIL_AMAZON_SES_MESSAGE_TAG_NAME
+
+.. rubric:: AMAZON_SES_MESSAGE_TAG_NAME
+
+Optional, default `None`. The name of an Amazon SES "Message Tag" whose value is set
+from a message's Anymail :attr:`~anymail.message.AnymailMessage.tags`.
+See :ref:`amazon-ses-tags` above.
+
+
+.. setting:: ANYMAIL_AMAZON_SES_AUTO_CONFIRM_SNS_SUBSCRIPTIONS
+
+.. rubric:: AMAZON_SES_AUTO_CONFIRM_SNS_SUBSCRIPTIONS
+
+Optional boolean, default `True`. Set to `False` to prevent Anymail webhooks from automatically
+accepting Amazon SNS subscription confirmation requests.
+See :ref:`amazon-ses-confirm-sns-subscriptions` above.
+
+
+.. _amazon-ses-iam-permissions:
+
+IAM permissions
+---------------
+
+**For sending mail,** Anymail requires the following IAM permissions:
+
+* For sending ordinary email, action ``ses:SendRawEmail``
+* For sending template/merge email, action ``ses:SendBulkTemplatedEmail``
+
+This IAM policy statement would permit both:
+
+    .. code-block:: json
+
+        {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Effect": "Allow",
+            "Action": ["ses:SendRawEmail", "ses:SendBulkTemplatedEmail"],
+            "Resource": "*"
+          }]
+        }
+
+You can add other sending restrictions, such as allowed senders, recipients,
+times, or source IP. See Amazon's `Controlling access to Amazon SES`_ guide.
+(Anymail adds "django-anymail" and its version number to the Boto User-Agent.)
+
+
+**For receiving inbound mail,** if you are using the "SNS action" option on the SES
+receipt rule, no special permissions are required.
+
+If you are using the "S3 action" receipt option, Anymail requires the ``s3:GetObject``
+action on the S3 bucket and prefix used.
+(Obviously, you should *never store incoming emails to a public bucket!*)
+
+This IAM policy would let Anymail's inbound webhook download messages stored to
+bucket "my-example-inbound-bucket" without any prefix:
+
+    .. code-block:: json
+
+        {
+          "Version":"2012-10-17",
+          "Statement": [{
+              "Effect": "Allow",
+              "Action": ["s3:GetObject"],
+              "Resource": ["arn:aws:s3:::my-example-inbound-bucket/*"]
+          }]
+        }
+
+There are multiple ways to manage S3 access, and you may want to impose additional
+restrictions. See Amazon's `Managing access permissions to your Amazon S3 resources`_.
+
+Also, you may need to grant Amazon SES (*not* Anymail) permission to *write*
+to that bucket. See Amazon's `Giving permissions to Amazon SES for email receiving`_.
+
+
+**For tracking webhooks,** no special permissions are required.
+
+Also, no special permissions are required for Anymail to
+:ref:`automatically confirm SNS subscriptions <amazon-ses-confirm-sns-subscriptions>`.
+(The ``sns:ConfirmSubscription`` action is `not restricted by IAM policy`_.)
+
+
+.. _Controlling access to Amazon SES:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/control-user-access.html
+.. _Managing access permissions to your Amazon S3 resources:
+    https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-access-control.html
+.. _Giving permissions to Amazon SES for email receiving:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html
+.. _not restricted by IAM policy:
+    https://docs.aws.amazon.com/sns/latest/dg/UsingIAMwithSNS.html#UsingWithSNS_Actions
+

--- a/docs/esps/index.rst
+++ b/docs/esps/index.rst
@@ -12,6 +12,7 @@ and notes about any quirks or limitations:
 .. toctree::
    :maxdepth: 1
 
+   amazon_ses
    mailgun
    mailjet
    mandrill
@@ -30,33 +31,33 @@ The table below summarizes the Anymail features supported for each ESP.
 
 .. rst-class:: sticky-left
 
-============================================  ===========  ==========  ===========  ==========  ==========  ============  ===========
-Email Service Provider                        |Mailgun|    |Mailjet|   |Mandrill|   |Postmark|  |SendGrid|  |SendinBlue|  |SparkPost|
-============================================  ===========  ==========  ===========  ==========  ==========  ============  ===========
+============================================  ============  ===========  ==========  ===========  ==========  ==========  ============  ===========
+Email Service Provider                        |Amazon SES|  |Mailgun|    |Mailjet|   |Mandrill|   |Postmark|  |SendGrid|  |SendinBlue|  |SparkPost|
+============================================  ============  ===========  ==========  ===========  ==========  ==========  ============  ===========
 .. rubric:: :ref:`Anymail send options <anymail-send-options>`
--------------------------------------------------------------------------------------------------------------------------------------
-:attr:`~AnymailMessage.envelope_sender`       Domain only  Yes         Domain only  No          No          No            Yes
-:attr:`~AnymailMessage.metadata`              Yes          Yes         Yes          No          Yes         Yes           Yes
-:attr:`~AnymailMessage.send_at`               Yes          No          Yes          No          Yes         No            Yes
-:attr:`~AnymailMessage.tags`                  Yes          Max 1 tag   Yes          Max 1 tag   Yes         Max 1 tag     Max 1 tag
-:attr:`~AnymailMessage.track_clicks`          Yes          Yes         Yes          Yes         Yes         No            Yes
-:attr:`~AnymailMessage.track_opens`           Yes          Yes         Yes          Yes         Yes         No            Yes
+---------------------------------------------------------------------------------------------------------------------------------------------------
+:attr:`~AnymailMessage.envelope_sender`       Yes           Domain only  Yes         Domain only  No          No          No            Yes
+:attr:`~AnymailMessage.metadata`              Yes           Yes          Yes         Yes          No          Yes         Yes           Yes
+:attr:`~AnymailMessage.send_at`               No            Yes          No          Yes          No          Yes         No            Yes
+:attr:`~AnymailMessage.tags`                  Yes           Yes          Max 1 tag   Yes          Max 1 tag   Yes         Max 1 tag     Max 1 tag
+:attr:`~AnymailMessage.track_clicks`          No            Yes          Yes         Yes          Yes         Yes         No            Yes
+:attr:`~AnymailMessage.track_opens`           No            Yes          Yes         Yes          Yes         Yes         No            Yes
 
 .. rubric:: :ref:`templates-and-merge`
--------------------------------------------------------------------------------------------------------------------------------------
-:attr:`~AnymailMessage.template_id`           No           Yes         Yes          Yes         Yes         Yes           Yes
-:attr:`~AnymailMessage.merge_data`            Yes          Yes         Yes          No          Yes         No            Yes
-:attr:`~AnymailMessage.merge_global_data`     (emulated)   Yes         Yes          Yes         Yes         Yes           Yes
+---------------------------------------------------------------------------------------------------------------------------------------------------
+:attr:`~AnymailMessage.template_id`           Yes           No           Yes         Yes          Yes         Yes         Yes           Yes
+:attr:`~AnymailMessage.merge_data`            Yes           Yes          Yes         Yes          No          Yes         No            Yes
+:attr:`~AnymailMessage.merge_global_data`     Yes           (emulated)   Yes         Yes          Yes         Yes         Yes           Yes
 
 .. rubric:: :ref:`Status <esp-send-status>` and :ref:`event tracking <event-tracking>`
--------------------------------------------------------------------------------------------------------------------------------------
-:attr:`~AnymailMessage.anymail_status`        Yes          Yes         Yes          Yes         Yes         Yes           Yes
-|AnymailTrackingEvent| from webhooks          Yes          Yes         Yes          Yes         Yes         Yes           Yes
+---------------------------------------------------------------------------------------------------------------------------------------------------
+:attr:`~AnymailMessage.anymail_status`        Yes           Yes          Yes         Yes          Yes         Yes         Yes           Yes
+|AnymailTrackingEvent| from webhooks          Yes           Yes          Yes         Yes          Yes         Yes         Yes           Yes
 
 .. rubric:: :ref:`Inbound handling <inbound>`
--------------------------------------------------------------------------------------------------------------------------------------
-|AnymailInboundEvent| from webhooks           Yes          Yes         Yes          Yes         Yes         No            Yes
-============================================  ===========  ==========  ===========  ==========  ==========  ============  ===========
+---------------------------------------------------------------------------------------------------------------------------------------------------
+|AnymailInboundEvent| from webhooks           Yes           Yes          Yes         Yes          Yes         Yes         No            Yes
+============================================  ============  ===========  ==========  ===========  ==========  ==========  ============  ===========
 
 
 Trying to choose an ESP? Please **don't** start with this table. It's far more
@@ -64,6 +65,7 @@ important to consider things like an ESP's deliverability stats, latency, uptime
 and support for developers. The *number* of extra features an ESP offers is almost
 meaningless. (And even specific features don't matter if you don't plan to use them.)
 
+.. |Amazon SES| replace:: :ref:`amazon-ses-backend`
 .. |Mailgun| replace:: :ref:`mailgun-backend`
 .. |Mailjet| replace:: :ref:`mailjet-backend`
 .. |Mandrill| replace:: :ref:`mandrill-backend`

--- a/docs/sending/django_email.rst
+++ b/docs/sending/django_email.rst
@@ -130,11 +130,11 @@ has special handling for certain headers. Anymail replicates its behavior for co
   the :mailheader:`Return-Path` at the recipient end. (Only if your ESP supports altering envelope
   sender, otherwise you'll get an :ref:`unsupported feature <unsupported-features>` error.)
 
-* If you supply a "To" header, you'll get an :ref:`unsupported feature <unsupported-features>` error.
+* If you supply a "To" header, you'll usually get an :ref:`unsupported feature <unsupported-features>` error.
   With Django's SMTP EmailBackend, this can be used to show the recipient a :mailheader:`To` address
   that's different from the actual envelope recipients in the message's
   :class:`to <django.core.mail.EmailMessage>` list. Spoofing the :mailheader:`To` header like this
-  is popular with spammers, and none of Anymail's supported ESPs allow it.
+  is popular with spammers, and almost none of Anymail's supported ESPs allow it.
 
 .. versionchanged:: 2.0
 

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setup(
     zip_safe=False,
     install_requires=["django>=1.8", "requests>=2.4.3", "six"],
     extras_require={
-        # This can be used if particular backends have unique dependencies
-        # (e.g., AWS-SES would want boto).
+        # This can be used if particular backends have unique dependencies.
         # For simplicity, requests is included in the base requirements.
+        "amazon_ses": ["boto3"],
         "mailgun": [],
         "mailjet": [],
         "mandrill": [],
@@ -58,7 +58,7 @@ setup(
     },
     include_package_data=True,
     test_suite="runtests.runtests",
-    tests_require=["mock", "sparkpost"],
+    tests_require=["mock", "boto3", "sparkpost"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     description='Django email integration for Mailgun, Mailjet, Postmark, SendGrid, SendinBlue, SparkPost '
                 'and other transactional ESPs',
     keywords="Django, email, email backend, ESP, transactional mail, "
-             "Mailgun, Mailjet, Mandrill, Postmark, SendinBlue, SendGrid, SparkPost",
+             "Amazon SES, Mailgun, Mailjet, Mandrill, Postmark, SendinBlue, SendGrid, SparkPost",
     author="Mike Edmunds and Anymail contributors",
     author_email="medmunds@gmail.com",
     url="https://github.com/anymail/django-anymail",

--- a/tests/test_amazon_ses_backend.py
+++ b/tests/test_amazon_ses_backend.py
@@ -1,0 +1,487 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import textwrap
+from base64 import b64encode
+from datetime import datetime
+from email.mime.application import MIMEApplication
+
+from botocore.exceptions import ClientError
+from django.core import mail
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+from mock import patch
+
+from anymail.exceptions import AnymailAPIError, AnymailUnsupportedFeature
+from anymail.message import attach_inline_image_file
+
+from .utils import AnymailTestMixin, SAMPLE_IMAGE_FILENAME, sample_image_path, sample_image_content
+
+
+@override_settings(EMAIL_BACKEND='anymail.backends.amazon_ses.EmailBackend')
+class AmazonSESBackendMockAPITestCase(SimpleTestCase, AnymailTestMixin):
+    """TestCase that uses the Amazon SES EmailBackend with a mocked boto3 client"""
+
+    def setUp(self):
+        super(AmazonSESBackendMockAPITestCase, self).setUp()
+
+        # Mock boto3.client('ses').send_raw_email
+        # (We could also use botocore.stub.Stubber, but mock works well with our test structure)
+        self.patch_boto3_client = patch('anymail.backends.amazon_ses.boto3.client', autospec=True)
+        self.mock_client = self.patch_boto3_client.start()
+        self.addCleanup(self.patch_boto3_client.stop)
+        self.set_mock_response()
+
+        # Simple message useful for many tests
+        self.message = mail.EmailMultiAlternatives('Subject', 'Text Body',
+                                                   'from@example.com', ['to@example.com'])
+
+    DEFAULT_SEND_RESPONSE = {
+        'MessageId': '1111111111111111-bbbbbbbb-3333-7777-aaaa-eeeeeeeeeeee-000000',
+        'ResponseMetadata': {
+            'RequestId': 'aaaaaaaa-2222-1111-8888-bbbb3333bbbb',
+            'HTTPStatusCode': 200,
+            'HTTPHeaders': {
+                'x-amzn-requestid': 'aaaaaaaa-2222-1111-8888-bbbb3333bbbb',
+                'content-type': 'text/xml',
+                'content-length': '338',
+                'date': 'Sat, 17 Mar 2018 03:33:33 GMT'
+            },
+            'RetryAttempts': 0
+        }
+    }
+
+    def set_mock_response(self, response=None, operation_name="send_raw_email"):
+        mock_operation = getattr(self.mock_client(), operation_name)
+        mock_operation.return_value = response or self.DEFAULT_SEND_RESPONSE
+        return mock_operation.return_value
+
+    def set_mock_failure(self, response, operation_name="send_raw_email"):
+        mock_operation = getattr(self.mock_client(), operation_name)
+        mock_operation.side_effect = ClientError(response, operation_name=operation_name)
+
+    def get_client_params(self, service="ses"):
+        """Returns kwargs params passed to mock boto3.client constructor
+
+        Fails test if boto3.client wasn't constructed with named service
+        """
+        if self.mock_client.call_args is None:
+            raise AssertionError("boto3.client was not created")
+        (args, kwargs) = self.mock_client.call_args
+        if len(args) < 1 or args[0] != service:
+            raise AssertionError("boto3.client created with service %r, not %r"
+                                 % (args.get(0), service))
+        return kwargs
+
+    def get_send_params(self, operation_name="send_raw_email"):
+        """Returns kwargs params passed to the mock send API.
+
+        Fails test if API wasn't called.
+        """
+        self.mock_client.assert_called_with("ses")
+        mock_operation = getattr(self.mock_client(), operation_name)
+        if mock_operation.call_args is None:
+            raise AssertionError("API was not called")
+        (args, kwargs) = mock_operation.call_args
+        return kwargs
+
+    def assert_esp_not_called(self, msg=None, operation_name="send_raw_email"):
+        mock_operation = getattr(self.mock_client(), operation_name)
+        if mock_operation.called:
+            raise AssertionError(msg or "ESP API was called and shouldn't have been")
+
+
+class AmazonSESBackendStandardEmailTests(AmazonSESBackendMockAPITestCase):
+    """Test backend support for Django standard email features"""
+
+    def test_send_mail(self):
+        """Test basic API for simple send"""
+        mail.send_mail('Subject here', 'Here is the message.',
+                       'from@example.com', ['to@example.com'], fail_silently=False)
+        params = self.get_send_params()
+        # send_raw_email takes a fully-formatted MIME message.
+        # This is a simple (if inexact) way to check for expected headers and body:
+        raw_mime = params['RawMessage']['Data']
+        self.assertIn("\nFrom: from@example.com\n", raw_mime)
+        self.assertIn("\nTo: to@example.com\n", raw_mime)
+        self.assertIn("\nSubject: Subject here\n", raw_mime)
+        self.assertIn("\n\nHere is the message", raw_mime)
+
+    # Since the SES backend generates the MIME message using Django's
+    # EmailMessage.message().to_string(), there's not really a need
+    # to exhaustively test all the various standard email features.
+    # (EmailMessage.message() is well tested in the Django codebase.)
+    # Instead, just spot-check a few things...
+
+    def test_non_ascii_headers(self):
+        self.message.subject = "Thử tin nhắn"  # utf-8 in subject header
+        self.message.to = ['"Người nhận" <to@example.com>']  # utf-8 in display name
+        self.message.cc = ["cc@thư.example.com"]  # utf-8 in domain
+        self.message.send()
+        params = self.get_send_params()
+        raw_mime = params['RawMessage']['Data']
+        # Non-ASCII headers must use MIME encoded-word syntax:
+        self.assertIn("\nSubject: =?utf-8?b?VGjhu60gdGluIG5o4bqvbg==?=\n", raw_mime)
+        # Non-ASCII display names as well:
+        self.assertIn("\nTo: =?utf-8?b?TmfGsOG7nWkgbmjhuq1u?= <to@example.com>\n", raw_mime)
+        # Non-ASCII address domains must use Punycode:
+        self.assertIn("\nCc: cc@xn--th-e0a.example.com\n", raw_mime)
+        # SES doesn't support non-ASCII in the username@ part (RFC 6531 "SMTPUTF8" extension)
+
+    def test_attachments(self):
+        text_content = "• Item one\n• Item two\n• Item three"  # those are \u2022 bullets ("\N{BULLET}")
+        self.message.attach(filename=u"Une pièce jointe.txt",  # utf-8 chars in filename
+                            content=text_content, mimetype="text/plain")
+
+        # Should guess mimetype if not provided...
+        png_content = b"PNG\xb4 pretend this is the contents of a png file"
+        self.message.attach(filename="test.png", content=png_content)
+
+        # Should work with a MIMEBase object (also tests no filename)...
+        pdf_content = b"PDF\xb4 pretend this is valid pdf params"
+        mimeattachment = MIMEApplication(pdf_content, 'pdf')  # application/pdf
+        self.message.attach(mimeattachment)
+
+        self.message.send()
+        params = self.get_send_params()
+        raw_mime = params['RawMessage']['Data']
+
+        # TODO: this hacky approach to testing mime parts doesn't work on Python 2
+        #       because the Python 2 and 3 email packages output mime headers in different orders
+        #       (and sometimes wrap long headers differently)
+        # - could parse an email.message.Message (e.g., AnymailInboundMessage.parse_raw_mime) and walk the parts
+        # - maybe just test that the expected attachments are present (look for Content-Disposition headers)
+        #   and trust that Python and/or Django have tests covering the full content of the part
+
+        self.assertIn('\nContent-Type: text/plain; charset="utf-8"'
+                      '\nMIME-Version: 1.0'
+                      '\nContent-Transfer-Encoding: 8bit'
+                      '\nContent-Disposition: attachment;\n filename*=utf-8\'\'Une%20pi%C3%A8ce%20jointe.txt'
+                      '\n\n{}\n'.format(text_content),
+                      raw_mime)
+
+        self.assertIn('\nContent-Type: image/png'
+                      '\nMIME-Version: 1.0'
+                      '\nContent-Transfer-Encoding: base64'
+                      '\nContent-Disposition: attachment; filename="test.png"'  # attachment, not inline
+                      '\n\n{}\n'.format(b64encode(png_content).decode('ascii')),
+                      raw_mime)
+
+        self.assertIn('\nContent-Type: application/pdf'
+                      '\nMIME-Version: 1.0'
+                      '\nContent-Transfer-Encoding: base64'
+                      '\n\n{}\n'.format(b64encode(pdf_content).decode('ascii')),
+                      raw_mime)
+
+    def test_embedded_images(self):
+        image_filename = SAMPLE_IMAGE_FILENAME
+        image_path = sample_image_path(image_filename)
+        image_data = sample_image_content(image_filename)
+
+        cid = attach_inline_image_file(self.message, image_path, domain="example.com")
+        html_content = '<p>This has an <img src="cid:%s" alt="inline" /> image.</p>' % cid
+        self.message.attach_alternative(html_content, "text/html")
+
+        self.message.send()
+        params = self.get_send_params()
+        raw_mime = params['RawMessage']['Data']
+
+        self.assertIn('\nContent-Type: text/html; charset="utf-8"'
+                      '\nMIME-Version: 1.0'
+                      '\nContent-Transfer-Encoding: 7bit'
+                      '\n\n%s\n' % html_content,
+                      raw_mime)
+
+        self.assertIn('\nContent-Type: image/png'
+                      '\nMIME-Version: 1.0'
+                      '\nContent-Transfer-Encoding: base64'
+                      '\nContent-Disposition: inline; filename="{image_filename}"'  # inline, not attachment
+                      '\nContent-ID: <{cid}>'
+                      '\n\n{image_data}\n'.format(
+                            image_data=textwrap.fill(b64encode(image_data).decode('ascii'), width=76),
+                            image_filename=image_filename,
+                            cid=cid),
+                      raw_mime)
+
+        # Make sure neither the html nor the inline image is treated as an attachment:
+        self.assertNotIn('\nContent-Disposition: attachment', raw_mime)
+
+    def test_multiple_html_alternatives(self):
+        # Multiple alternatives *are* allowed
+        self.message.attach_alternative("<p>First html is OK</p>", "text/html")
+        self.message.attach_alternative("<p>And so is second</p>", "text/html")
+        self.message.send()
+        params = self.get_send_params()
+        raw_mime = params['RawMessage']['Data']
+        self.assertIn('\nContent-Type: text/html; charset="utf-8"'
+                      '\nMIME-Version: 1.0'
+                      '\nContent-Transfer-Encoding: 7bit'
+                      '\n\n<p>First html is OK</p>\n', raw_mime)
+        self.assertIn('\nContent-Type: text/html; charset="utf-8"'
+                      '\nMIME-Version: 1.0'
+                      '\nContent-Transfer-Encoding: 7bit'
+                      '\n\n<p>And so is second</p>\n', raw_mime)
+
+    def test_alternative(self):
+        # Non-HTML alternatives *are* allowed
+        self.message.attach_alternative('{"is": "allowed"}', "application/json")
+        self.message.send()
+        params = self.get_send_params()
+        raw_mime = params['RawMessage']['Data']
+        self.assertIn("\nContent-Type: application/json"
+                      "\nMIME-Version: 1.0"
+                      "\nContent-Transfer-Encoding: base64"
+                      "\n\n%s" % b64encode('{"is": "allowed"}'.encode('utf-8')).decode('ascii'),
+                      raw_mime)
+
+    def test_multiple_from(self):
+        # Amazon SES does not support multiple addresses in the From header
+        self.message.from_email = "from1@example.com, from2@example.com"
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "multiple from emails"):
+            self.message.send()
+
+    def test_api_failure(self):
+        error_response = {
+            'Error': {
+                'Type': 'Sender',
+                'Code': 'MessageRejected',
+                'Message': 'Email address is not verified. The following identities failed '
+                           'the check in region US-EAST-1: to@example.com'
+            },
+            'ResponseMetadata': {
+                'RequestId': 'aaaaaaaa-2222-1111-8888-bbbb3333bbbb',
+                'HTTPStatusCode': 400,
+                'HTTPHeaders': {
+                    'x-amzn-requestid': 'aaaaaaaa-2222-1111-8888-bbbb3333bbbb',
+                    'content-type': 'text/xml',
+                    'content-length': '277',
+                    'date': 'Sat, 17 Mar 2018 04:44:44 GMT'
+                },
+                'RetryAttempts': 0
+            }
+        }
+
+        self.set_mock_failure(error_response)
+        with self.assertRaises(AnymailAPIError) as cm:
+            self.message.send()
+        err = cm.exception
+        # AWS error is included in Anymail message:
+        self.assertIn('Email address is not verified. The following identities failed '
+                      'the check in region US-EAST-1: to@example.com',
+                      str(err))
+        # Raw AWS response is available on the exception:
+        self.assertEqual(err.response, error_response)
+
+    def test_api_failure_fail_silently(self):
+        # Make sure fail_silently is respected
+        self.set_mock_failure({
+            'Error': {'Type': 'Sender', 'Code': 'InvalidParameterValue', 'Message': 'That is not allowed'}})
+        sent = self.message.send(fail_silently=True)
+        self.assertEqual(sent, 0)
+
+
+class AmazonSESBackendAnymailFeatureTests(AmazonSESBackendMockAPITestCase):
+    """Test backend support for Anymail added features"""
+
+    def test_envelope_sender(self):
+        self.message.envelope_sender = "bounce-handler@bounces.example.com"
+        self.message.send()
+        params = self.get_send_params()
+        self.assertEqual(params['Source'], "bounce-handler@bounces.example.com")
+
+    def test_spoofed_to(self):
+        # Amazon SES is one of the few ESPs that actually permits the To header
+        # to differ from the envelope recipient...
+        self.message.to = ["Envelope <envelope-to@example.com>"]
+        self.message.extra_headers["To"] = "Spoofed <spoofed-to@elsewhere.example.org>"
+        self.message.send()
+        params = self.get_send_params()
+        raw_mime = params['RawMessage']['Data']
+        self.assertEqual(params['Destinations'], ["envelope-to@example.com"])
+        self.assertIn("\nTo: Spoofed <spoofed-to@elsewhere.example.org>\n", raw_mime)
+        self.assertNotIn("envelope-to@example.com", raw_mime)
+
+    def test_metadata(self):
+        # Anymail converts metadata to Amazon SES name:value Tags.
+        # Note that both names and values have a very limited character set
+        # (no spaces, no commas, the only punctuation allowed is underscore and hyphen)
+        self.message.metadata = {'user_id': 12345, 'items': 'horse-battery-staple'}
+        self.message.send()
+        params = self.get_send_params()
+        self.assertCountEqual(params['Tags'], [
+            {"Name": "user_id", "Value": "12345"},  # value converted to str
+            {"Name": "items", "Value": "horse-battery-staple"},
+        ])
+
+    def test_send_at(self):
+        # Amazon SES does not support delayed sending
+        self.message.send_at = datetime(2016, 3, 4, 5, 6, 7)
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "send_at"):
+            self.message.send()
+
+    def test_tags(self):
+        # Anymail converts tags list to multiple Amazon SES name:value Tags,
+        # where each Anymail tag becomes a tag named TagN:
+        self.message.tags = ["receipt", "repeat-user"]
+        self.message.send()
+        params = self.get_send_params()
+        self.assertCountEqual(params['Tags'], [
+            {"Name": "Tag0", "Value": "receipt"},
+            {"Name": "Tag1", "Value": "repeat-user"},
+        ])
+
+    def test_tracking(self):
+        # Amazon SES doesn't support overriding click/open-tracking settings
+        # on individual messages through any standard API params.
+        # (You _can_ use a ConfigurationSet to control this; see esp_extra below.)
+        self.message.track_clicks = True
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "track_clicks"):
+            self.message.send()
+        delattr(self.message, 'track_clicks')
+
+        self.message.track_opens = True
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "track_opens"):
+            self.message.send()
+
+    def test_merge_data(self):
+        # Amazon SES only supports merging when using templates (see below)
+        self.message.merge_data = {}
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "merge_data without template_id"):
+            self.message.send()
+        delattr(self.message, 'merge_data')
+
+        self.message.merge_global_data = {'group': "Users", 'site': "ExampleCo"}
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "global_merge_data without template_id"):
+            self.message.send()
+
+    def test_template(self):
+        self.message.template_id = "welcome_template"
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "template_id"):
+            self.message.send()
+
+        # TODO: Implement SES SendTemplatedEmail...
+        # self.message.from_email = '"Example, Inc." <from@example.com>'
+        # self.message.to = ['alice@example.com', 'Bob <bob@example.com>']
+        # self.message.cc = ['cc@example.com']
+        # self.message.merge_data = {
+        #     'alice@example.com': {'name': "Alice", 'group': "Developers"},
+        #     'bob@example.com': {'name': "Bob"},  # and leave group undefined
+        #     'nobody@example.com': {'name': "Not a recipient for this message"},
+        # }
+        # self.message.merge_global_data = {'group': "Users", 'site': "ExampleCo"}
+        # self.message.send()
+        #
+        # self.assert_esp_not_called(operation_name="send_raw_email")  # templates use a different API call...
+        # params = self.get_send_params(operation_name="send_templated_email")
+        # self.assertEqual(params['Template'], "welcome_template")
+        # self.assertEqual(params['Source'], '"Example, Inc." <from@example.com>')
+        # self.assertCountEqual(params['Destinations'], [
+        #     {"Destination": {"ToAddresses": ['alice@example.com'], "CcAddresses": ['cc@example.com']},
+        #      "ReplacementTemplateData": {'name': "Alice", 'group': "Developers"}},
+        #     {"Destination": {"ToAddresses": ['Bob <bob@example.com>'], "CcAddresses": ['cc@example.com']},
+        #      "ReplacementTemplateData": {'name': "Bob"}},
+        # ])
+        # self.assertEqual(params['DefaultTemplateData'], {'group': "Users", 'site': "ExampleCo"})
+
+    def test_default_omits_options(self):
+        """Make sure by default we don't send any ESP-specific options.
+
+        Options not specified by the caller should be omitted entirely from
+        the API call (*not* sent as False or empty). This ensures
+        that your ESP account settings apply by default.
+        """
+        self.message.send()
+        params = self.get_send_params()
+        self.assertNotIn('ConfigurationSetName', params)
+        self.assertNotIn('DefaultTemplateData', params)
+        self.assertNotIn('Destinations', params)
+        self.assertNotIn('FromArn', params)
+        self.assertNotIn('Message', params)
+        self.assertNotIn('ReplyToAddresses', params)
+        self.assertNotIn('ReturnPath', params)
+        self.assertNotIn('ReturnPathArn', params)
+        self.assertNotIn('Source', params)
+        self.assertNotIn('SourceArn', params)
+        self.assertNotIn('Tags', params)
+        self.assertNotIn('Template', params)
+        self.assertNotIn('TemplateArn', params)
+        self.assertNotIn('TemplateData', params)
+
+    def test_esp_extra(self):
+        # Values in esp_extra are merged into the Amazon SES SendRawEmail parameters
+        self.message.esp_extra = {
+            # E.g., if you've set up a configuration set that disables open/click tracking:
+            'ConfigurationSetName': 'NoTrackingConfigurationSet',
+        }
+        self.message.send()
+        params = self.get_send_params()
+        self.assertEqual(params['ConfigurationSetName'], 'NoTrackingConfigurationSet')
+
+    def test_send_attaches_anymail_status(self):
+        """The anymail_status should be attached to the message when it is sent """
+        msg = mail.EmailMessage('Subject', 'Message', 'from@example.com', ['to1@example.com'],)
+        sent = msg.send()
+        self.assertEqual(sent, 1)
+        self.assertEqual(msg.anymail_status.status, {'queued'})
+        self.assertEqual(msg.anymail_status.message_id,
+                         '1111111111111111-bbbbbbbb-3333-7777-aaaa-eeeeeeeeeeee-000000')
+        self.assertEqual(msg.anymail_status.recipients['to1@example.com'].status, 'queued')
+        self.assertEqual(msg.anymail_status.recipients['to1@example.com'].message_id,
+                         '1111111111111111-bbbbbbbb-3333-7777-aaaa-eeeeeeeeeeee-000000')
+        self.assertEqual(msg.anymail_status.esp_response, self.DEFAULT_SEND_RESPONSE)
+
+    # Amazon SES doesn't report rejected addresses at send time in a form that can be
+    # distinguished from other API errors. If SES rejects *any* recipient you'll get
+    # an AnymailAPIError, and the message won't be sent to *all* recipients.
+
+    # noinspection PyUnresolvedReferences
+    def test_send_unparsable_response(self):
+        """If the send succeeds, but result is unexpected format, should raise an API exception"""
+        response_content = {'wrong': 'format'}
+        self.set_mock_response(response_content)
+        with self.assertRaisesMessage(AnymailAPIError, "parsing Amazon SES send result"):
+            self.message.send()
+        self.assertIsNone(self.message.anymail_status.status)
+        self.assertIsNone(self.message.anymail_status.message_id)
+        self.assertEqual(self.message.anymail_status.recipients, {})
+        self.assertEqual(self.message.anymail_status.esp_response, response_content)
+
+
+class AmazonSESBackendConfigurationTests(AmazonSESBackendMockAPITestCase):
+    """Test configuration options"""
+
+    def test_boto_default_config(self):
+        """By default, boto3 gets credentials from the environment or its config files
+
+        See http://boto3.readthedocs.io/en/stable/guide/configuration.html
+        """
+        self.message.send()
+        client_params = self.get_client_params()
+        self.assertEqual(client_params, {})  # no additional params passed to boto.client('ses')
+
+    @override_settings(ANYMAIL={
+        "AMAZON_SES_CLIENT_PARAMS": {
+            # Example for testing; it's not a good idea to hardcode credentials in your code
+            "aws_access_key_id": "test-access-key-id",  # safer: `os.getenv("MY_SPECIAL_AWS_KEY_ID")`
+            "aws_secret_access_key": "test-secret-access-key",
+            "region_name": "ap-northeast-1",
+        }
+    })
+    def test_client_params_in_setting(self):
+        """The Anymail AMAZON_SES_CLIENT_PARAMS setting specifies boto3 config for Anymail"""
+        self.message.send()
+        client_params = self.get_client_params()
+        self.assertEqual(client_params, {
+            "aws_access_key_id": "test-access-key-id",
+            "aws_secret_access_key": "test-secret-access-key",
+            "region_name": "ap-northeast-1",
+        })
+
+    def test_client_params_in_connection_init(self):
+        """You can also supply credentials specifically for a particular EmailBackend connection instance"""
+        conn = mail.get_connection(
+            'anymail.backends.amazon_ses.EmailBackend',
+            client_params={"aws_session_token": "test-session-token"})
+        conn.send_messages([self.message])
+        client_params = self.get_client_params()
+        self.assertEqual(client_params, {"aws_session_token": "test-session-token"})

--- a/tests/test_amazon_ses_backend.py
+++ b/tests/test_amazon_ses_backend.py
@@ -217,10 +217,13 @@ class AmazonSESBackendStandardEmailTests(AmazonSESBackendMockAPITestCase):
         self.assertIn("\nContent-Type: application/json\n", raw_mime)
 
     def test_multiple_from(self):
-        # Amazon SES does not support multiple addresses in the From header
+        # Amazon allows multiple addresses in the From header, but must specify which is Source
         self.message.from_email = "from1@example.com, from2@example.com"
-        with self.assertRaisesMessage(AnymailUnsupportedFeature, "multiple from emails"):
-            self.message.send()
+        self.message.send()
+        params = self.get_send_params()
+        raw_mime = params['RawMessage']['Data']
+        self.assertIn("\nFrom: from1@example.com, from2@example.com\n", raw_mime)
+        self.assertEqual(params['Source'], "from1@example.com")
 
     def test_api_failure(self):
         error_response = {

--- a/tests/test_amazon_ses_inbound.py
+++ b/tests/test_amazon_ses_inbound.py
@@ -186,13 +186,14 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
         self.assertEqual(message.html, """<div dir="ltr">It's a body\N{HORIZONTAL ELLIPSIS}</div>\r\n""")
         self.assertIs(message.spam_detected, True)
 
-    @patch('anymail.backends.amazon_ses.boto3.client', autospec=True)
-    def test_inbound_s3(self, mock_client):
+    @patch('anymail.backends.amazon_ses.boto3.session.Session', autospec=True)
+    def test_inbound_s3(self, mock_session):
         """Should handle 'S3' receipt action"""
 
-        # patch boto3.client('s3').download_fileobj
+        # patch boto3.session.Session().client('s3').download_fileobj
         def mock_download_fileobj(bucket, key, fileobj):
             fileobj.write(self.TEST_MIME_MESSAGE.encode('ascii'))
+        mock_client = mock_session.return_value.client
         mock_s3 = mock_client.return_value
         mock_s3.download_fileobj.side_effect = mock_download_fileobj
 

--- a/tests/test_amazon_ses_inbound.py
+++ b/tests/test_amazon_ses_inbound.py
@@ -226,7 +226,7 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
         response = self.post_from_sns('/anymail/amazon_ses/inbound/', raw_sns_message)
         self.assertEqual(response.status_code, 200)
 
-        mock_client.assert_called_once_with('s3')
+        mock_client.assert_called_once_with('s3', config=ANY)
         mock_s3.download_fileobj.assert_called_once_with(
             "InboundEmailBucket-KeepPrivate", "inbound/fqef5sop459utgdf4o9lqbsv7jeo73pejig34301", ANY)
 

--- a/tests/test_amazon_ses_inbound.py
+++ b/tests/test_amazon_ses_inbound.py
@@ -1,0 +1,200 @@
+from __future__ import unicode_literals
+
+import json
+from base64 import b64encode
+from datetime import datetime
+from textwrap import dedent
+
+from django.utils.timezone import utc
+from mock import ANY
+
+from anymail.exceptions import AnymailConfigurationError
+from anymail.inbound import AnymailInboundMessage
+from anymail.signals import AnymailInboundEvent
+from anymail.webhooks.amazon_ses import AmazonSESInboundWebhookView
+
+from .test_amazon_ses_webhooks import AmazonSESWebhookTestsMixin
+from .webhook_cases import WebhookTestCase
+
+
+class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
+
+    TEST_MIME_MESSAGE = dedent("""\
+        Return-Path: <bounce-handler@mail.example.org>
+        Received: from mail.example.org by inbound-smtp.us-east-1.amazonaws.com...
+        MIME-Version: 1.0
+        Received: by 10.1.1.1 with HTTP; Fri, 30 Mar 2018 10:21:49 -0700 (PDT)
+        From: "Sender, Inc." <from@example.org>
+        Date: Fri, 30 Mar 2018 10:21:50 -0700
+        Message-ID: <CAEPk3RKsi@mail.example.org>
+        Subject: Test inbound message
+        To: Recipient <inbound@example.com>, someone-else@example.org
+        Content-Type: multipart/alternative; boundary="94eb2c05e174adb140055b6339c5"
+
+        --94eb2c05e174adb140055b6339c5
+        Content-Type: text/plain; charset="UTF-8"
+        Content-Transfer-Encoding: quoted-printable
+
+        It's a body=E2=80=A6
+
+        --94eb2c05e174adb140055b6339c5
+        Content-Type: text/html; charset="UTF-8"
+        Content-Transfer-Encoding: quoted-printable
+
+        <div dir=3D"ltr">It's a body=E2=80=A6</div>
+
+        --94eb2c05e174adb140055b6339c5--
+        """).replace("\n", "\r\n")
+
+    def test_inbound_sns_utf8(self):
+        raw_ses_event = {
+            "notificationType": "Received",
+            "mail": {
+                "timestamp": "2018-03-30T17:21:51.636Z",
+                "source": "envelope-from@example.org",
+                "messageId": "jili9m351il3gkburn7o2f0u6788stij94c8ld01",  # assigned by Amazon SES
+                "destination": ["inbound@example.com", "someone-else@example.org"],
+                "headersTruncated": False,
+                "headers": [
+                    # (omitting a few headers that Amazon SES adds on receipt)
+                    {"name": "Return-Path", "value": "<bounce-handler@mail.example.org>"},
+                    {"name": "Received", "value": "from mail.example.org by inbound-smtp.us-east-1.amazonaws.com..."},
+                    {"name": "MIME-Version", "value": "1.0"},
+                    {"name": "Received", "value": "by 10.1.1.1 with HTTP; Fri, 30 Mar 2018 10:21:49 -0700 (PDT)"},
+                    {"name": "From", "value": '"Sender, Inc." <from@example.org>'},
+                    {"name": "Date", "value": "Fri, 30 Mar 2018 10:21:50 -0700"},
+                    {"name": "Message-ID", "value": "<CAEPk3RKsi@mail.example.org>"},
+                    {"name": "Subject", "value": "Test inbound message"},
+                    {"name": "To", "value": "Recipient <inbound@example.com>, someone-else@example.org"},
+                    {"name": "Content-Type", "value": 'multipart/alternative; boundary="94eb2c05e174adb140055b6339c5"'},
+                ],
+                "commonHeaders": {
+                    "returnPath": "bounce-handler@mail.example.org",
+                    "from": ['"Sender, Inc." <from@example.org>'],
+                    "date": "Fri, 30 Mar 2018 10:21:50 -0700",
+                    "to": ["Recipient <inbound@example.com>", "someone-else@example.org"],
+                    "messageId": "<CAEPk3RKsi@mail.example.org>",
+                    "subject": "Test inbound message",
+                },
+            },
+            "receipt": {
+                "timestamp": "2018-03-30T17:21:51.636Z",
+                "processingTimeMillis": 357,
+                "recipients": ["inbound@example.com"],
+                "spamVerdict": {"status": "PASS"},
+                "virusVerdict": {"status": "PASS"},
+                "spfVerdict": {"status": "PASS"},
+                "dkimVerdict": {"status": "PASS"},
+                "dmarcVerdict": {"status": "PASS"},
+                "action": {
+                    "type": "SNS",
+                    "topicArn": "arn:aws:sns:us-east-1:111111111111:SES_Inbound",
+                    "encoding": "UTF8",
+                },
+            },
+            "content": self.TEST_MIME_MESSAGE,
+        }
+
+        raw_sns_message = {
+            "Type": "Notification",
+            "MessageId": "8f6dee70-c885-558a-be7d-bd48bbf5335e",
+            "TopicArn": "arn:aws:sns:us-east-1:111111111111:SES_Inbound",
+            "Subject": "Amazon SES Email Receipt Notification",
+            "Message": json.dumps(raw_ses_event),
+            "Timestamp": "2018-03-30T17:17:36.516Z",
+            "SignatureVersion": "1",
+            "Signature": "EXAMPLE_SIGNATURE==",
+            "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-12345abcde.pem",
+            "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn...",
+        }
+
+        response = self.post_from_sns('/anymail/amazon_ses/inbound/', raw_sns_message)
+        self.assertEqual(response.status_code, 200)
+        kwargs = self.assert_handler_called_once_with(self.inbound_handler, sender=AmazonSESInboundWebhookView,
+                                                      event=ANY, esp_name='Amazon SES')
+        event = kwargs['event']
+        self.assertIsInstance(event, AnymailInboundEvent)
+        self.assertEqual(event.event_type, 'inbound')
+        self.assertEqual(event.timestamp, datetime(2018, 3, 30, 17, 21, 51, microsecond=636000, tzinfo=utc))
+        self.assertEqual(event.event_id, "jili9m351il3gkburn7o2f0u6788stij94c8ld01")
+        self.assertIsInstance(event.message, AnymailInboundMessage)
+        self.assertEqual(event.esp_event, raw_ses_event)
+
+        message = event.message
+        self.assertIsInstance(message, AnymailInboundMessage)
+        self.assertEqual(message.envelope_sender, 'envelope-from@example.org')
+        self.assertEqual(message.envelope_recipient, 'inbound@example.com')
+        self.assertEqual(str(message.from_email), '"Sender, Inc." <from@example.org>')
+        self.assertEqual([str(to) for to in message.to],
+                         ['Recipient <inbound@example.com>', 'someone-else@example.org'])
+        self.assertEqual(message.subject, 'Test inbound message')
+        self.assertEqual(message.text, "It's a body\N{HORIZONTAL ELLIPSIS}\r\n")
+        self.assertEqual(message.html, """<div dir="ltr">It's a body\N{HORIZONTAL ELLIPSIS}</div>\r\n""")
+
+    def test_inbound_sns_base64(self):
+        """Should handle 'Base 64' content option on received email SNS action"""
+        raw_ses_event = {
+            # (omitting some fields that aren't used by Anymail)
+            "notificationType": "Received",
+            "mail": {
+                "source": "envelope-from@example.org",
+                "timestamp": "2018-03-30T17:21:51.636Z",
+                "messageId": "jili9m351il3gkburn7o2f0u6788stij94c8ld01",  # assigned by Amazon SES
+                "destination": ["inbound@example.com", "someone-else@example.org"],
+            },
+            "receipt": {
+                "recipients": ["inbound@example.com"],
+                "action": {
+                    "type": "SNS",
+                    "topicArn": "arn:aws:sns:us-east-1:111111111111:SES_Inbound",
+                    "encoding": "BASE64",
+                },
+            },
+            "content": b64encode(self.TEST_MIME_MESSAGE.encode('utf-8')).decode('ascii'),
+        }
+
+        raw_sns_message = {
+            "Type": "Notification",
+            "MessageId": "8f6dee70-c885-558a-be7d-bd48bbf5335e",
+            "TopicArn": "arn:aws:sns:us-east-1:111111111111:SES_Inbound",
+            "Message": json.dumps(raw_ses_event),
+        }
+
+        response = self.post_from_sns('/anymail/amazon_ses/inbound/', raw_sns_message)
+        self.assertEqual(response.status_code, 200)
+        kwargs = self.assert_handler_called_once_with(self.inbound_handler, sender=AmazonSESInboundWebhookView,
+                                                      event=ANY, esp_name='Amazon SES')
+        event = kwargs['event']
+        self.assertIsInstance(event, AnymailInboundEvent)
+        self.assertEqual(event.event_type, 'inbound')
+        self.assertEqual(event.timestamp, datetime(2018, 3, 30, 17, 21, 51, microsecond=636000, tzinfo=utc))
+        self.assertEqual(event.event_id, "jili9m351il3gkburn7o2f0u6788stij94c8ld01")
+        self.assertIsInstance(event.message, AnymailInboundMessage)
+        self.assertEqual(event.esp_event, raw_ses_event)
+
+        message = event.message
+        self.assertIsInstance(message, AnymailInboundMessage)
+        self.assertEqual(message.envelope_sender, 'envelope-from@example.org')
+        self.assertEqual(message.envelope_recipient, 'inbound@example.com')
+        self.assertEqual(str(message.from_email), '"Sender, Inc." <from@example.org>')
+        self.assertEqual([str(to) for to in message.to],
+                         ['Recipient <inbound@example.com>', 'someone-else@example.org'])
+        self.assertEqual(message.subject, 'Test inbound message')
+        self.assertEqual(message.text, "It's a body\N{HORIZONTAL ELLIPSIS}\r\n")
+        self.assertEqual(message.html, """<div dir="ltr">It's a body\N{HORIZONTAL ELLIPSIS}</div>\r\n""")
+
+    def test_incorrect_tracking_event(self):
+        """The inbound webhook should warn if it receives tracking events"""
+        raw_sns_message = {
+            "Type": "Notification",
+            "MessageId": "8f6dee70-c885-558a-be7d-bd48bbf5335e",
+            "TopicArn": "arn:...:111111111111:SES_Tracking",
+            "Message": '{"notificationType": "Delivery"}',
+        }
+
+        with self.assertRaisesMessage(
+            AnymailConfigurationError,
+            "You seem to have set an Amazon SES *sending* event or notification to publish to an SNS Topic "
+            "that posts to Anymail's *inbound* webhook URL. (SNS TopicArn arn:...:111111111111:SES_Tracking)"
+        ):
+            self.post_from_sns('/anymail/amazon_ses/inbound/', raw_sns_message)

--- a/tests/test_amazon_ses_integration.py
+++ b/tests/test_amazon_ses_integration.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import os
+import unittest
+import warnings
+
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+from anymail.exceptions import AnymailAPIError
+from anymail.message import AnymailMessage
+
+from .utils import AnymailTestMixin, sample_image_path, RUN_LIVE_TESTS
+
+AMAZON_SES_TEST_ACCESS_KEY_ID = os.getenv("AMAZON_SES_TEST_ACCESS_KEY_ID")
+AMAZON_SES_TEST_SECRET_ACCESS_KEY = os.getenv("AMAZON_SES_TEST_SECRET_ACCESS_KEY")
+AMAZON_SES_TEST_REGION_NAME = os.getenv("AMAZON_SES_TEST_REGION_NAME", "us-east-1")
+
+
+@unittest.skipUnless(RUN_LIVE_TESTS, "RUN_LIVE_TESTS disabled in this environment")
+@unittest.skipUnless(AMAZON_SES_TEST_ACCESS_KEY_ID and AMAZON_SES_TEST_SECRET_ACCESS_KEY,
+                     "Set AMAZON_SES_TEST_ACCESS_KEY_ID and AMAZON_SES_TEST_SECRET_ACCESS_KEY "
+                     "environment variables to run Amazon SES integration tests")
+@override_settings(
+    EMAIL_BACKEND="anymail.backends.amazon_ses.EmailBackend",
+    ANYMAIL_AMAZON_SES_CLIENT_PARAMS={
+        # This setting provides Anymail-specific AWS credentials to boto3.client(),
+        # overriding any credentials in the environment or boto config. It's often
+        # *not* the best approach -- see the Anymail and boto3 docs for other options.
+        "aws_access_key_id": AMAZON_SES_TEST_ACCESS_KEY_ID,
+        "aws_secret_access_key": AMAZON_SES_TEST_SECRET_ACCESS_KEY,
+        "region_name": AMAZON_SES_TEST_REGION_NAME,
+    })
+class AmazonSESBackendIntegrationTests(SimpleTestCase, AnymailTestMixin):
+    """Amazon SES API integration tests
+
+    These tests run against the **live** Amazon SES API, using the environment
+    variables `AMAZON_SES_TEST_ACCESS_KEY_ID` and `AMAZON_SES_TEST_SECRET_ACCESS_KEY`
+    as AWS credentials. If those variables are not set, these tests won't run.
+    (You can also set the environment variable `AMAZON_SES_TEST_REGION_NAME`
+    to test SES using a region other than the default "us-east-1".)
+
+    Amazon SES doesn't offer a test mode -- it tries to send everything you ask.
+    To avoid stacking up a pile of undeliverable @example.com
+    emails, the tests use Amazon's @simulator.amazonses.com addresses.
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mailbox-simulator.html
+
+    Amazon SES also doesn't support arbitrary senders (so no from@example.com).
+    We've set up @test-ses.anymail.info as a validated sending domain for these tests.
+    You may need to change the from_email to your own address when testing.
+
+    """
+
+    def setUp(self):
+        super(AmazonSESBackendIntegrationTests, self).setUp()
+        self.message = AnymailMessage('Anymail Amazon SES integration test', 'Text content',
+                                      'test@test-ses.anymail.info', ['success@simulator.amazonses.com'])
+        self.message.attach_alternative('<p>HTML content</p>', "text/html")
+
+        # boto3 relies on GC to close connections. Python 3 warns about unclosed ssl.SSLSocket during cleanup.
+        # We don't care. (It might not be a real problem worth warning, but in any case it's not our problem.)
+        # https://www.google.com/search?q=unittest+boto3+ResourceWarning+unclosed+ssl.SSLSocket
+        # Filter in TestCase.setUp because unittest resets the warning filters for each test.
+        # https://stackoverflow.com/a/26620811/647002
+        warnings.filterwarnings("ignore", message=r"unclosed \<ssl\.SSLSocket", category=ResourceWarning)
+
+    def test_simple_send(self):
+        # Example of getting the Amazon SES send status and message id from the message
+        sent_count = self.message.send()
+        self.assertEqual(sent_count, 1)
+
+        anymail_status = self.message.anymail_status
+        sent_status = anymail_status.recipients['success@simulator.amazonses.com'].status
+        message_id = anymail_status.recipients['success@simulator.amazonses.com'].message_id
+
+        self.assertEqual(sent_status, 'queued')  # Amazon SES always queues (or raises an error)
+        self.assertRegex(message_id, r'[0-9a-f-]+')  # Amazon SES message ids are groups of hex chars
+        self.assertEqual(anymail_status.status, {sent_status})  # set of all recipient statuses
+        self.assertEqual(anymail_status.message_id, message_id)
+
+    def test_all_options(self):
+        message = AnymailMessage(
+            subject="Anymail Amazon SES all-options integration test",
+            body="This is the text body",
+            from_email='"Test From" <test@test-ses.anymail.info>',
+            to=["success+to1@simulator.amazonses.com", "Recipient 2 <success+to2@simulator.amazonses.com>"],
+            cc=["success+cc1@simulator.amazonses.com", "Copy 2 <success+cc2@simulator.amazonses.com>"],
+            bcc=["success+bcc1@simulator.amazonses.com", "Blind Copy 2 <success+bcc2@simulator.amazonses.com>"],
+            reply_to=["reply1@example.com", "Reply 2 <reply2@example.com>"],
+            headers={"X-Anymail-Test": "value"},
+
+            # Amazon SES only allows alphanumeric ASCII characters, '_', and '-' in tag/metadata keys and values:
+            metadata={"meta1": "simple_string", "meta2": 2},
+            tags=["tag_1", "tag_2"],
+        )
+        message.attach("attachment1.txt", "Here is some\ntext for you", "text/plain")
+        message.attach("attachment2.csv", "ID,Name\n1,Amy Lina", "text/csv")
+        cid = message.attach_inline_image_file(sample_image_path())
+        message.attach_alternative(
+            "<p><b>HTML:</b> with <a href='http://example.com'>link</a>"
+            "and image: <img src='cid:%s'></div>" % cid,
+            "text/html")
+
+        message.attach_alternative(
+            "Amazon SES SendRawEmail actually supports multiple alternative parts",
+            "text/x-note-for-email-geeks")
+
+        message.send()
+        self.assertEqual(message.anymail_status.status, {'queued'})
+
+    # TODO: support SendTemplatedEmail
+    # def test_stored_template(self):
+    #     message = AnymailMessage(
+    #         template_id='test-template',  # a real template in our Amazon SES test account
+    #         to=["success+to1@simulator.amazonses.com"],
+    #         merge_data={
+    #             'success+to1@simulator.amazonses.com': {
+    #                 'name': "Test Recipient",
+    #             }
+    #         },
+    #         merge_global_data={
+    #             'order': '12345',
+    #         },
+    #     )
+    #     message.send()
+    #     recipient_status = message.anymail_status.recipients
+    #     self.assertEqual(recipient_status['success+to1@simulator.amazonses.com'].status, 'queued')
+
+    @override_settings(ANYMAIL_AMAZON_SES_CLIENT_PARAMS={
+        "aws_access_key_id": "test-invalid-access-key-id",
+        "aws_secret_access_key": "test-invalid-secret-access-key",
+        "region_name": AMAZON_SES_TEST_REGION_NAME,
+    })
+    def test_invalid_aws_credentials(self):
+        with self.assertRaises(AnymailAPIError) as cm:
+            self.message.send()
+        err = cm.exception
+        # Make sure the exception message includes AWS's response:
+        self.assertIn("The security token included in the request is invalid", str(err))

--- a/tests/test_amazon_ses_integration.py
+++ b/tests/test_amazon_ses_integration.py
@@ -13,6 +13,12 @@ from anymail.message import AnymailMessage
 
 from .utils import AnymailTestMixin, sample_image_path, RUN_LIVE_TESTS
 
+try:
+    ResourceWarning
+except NameError:
+    ResourceWarning = Warning  # Python 2
+
+
 AMAZON_SES_TEST_ACCESS_KEY_ID = os.getenv("AMAZON_SES_TEST_ACCESS_KEY_ID")
 AMAZON_SES_TEST_SECRET_ACCESS_KEY = os.getenv("AMAZON_SES_TEST_SECRET_ACCESS_KEY")
 AMAZON_SES_TEST_REGION_NAME = os.getenv("AMAZON_SES_TEST_REGION_NAME", "us-east-1")
@@ -68,7 +74,7 @@ class AmazonSESBackendIntegrationTests(SimpleTestCase, AnymailTestMixin):
         # https://www.google.com/search?q=unittest+boto3+ResourceWarning+unclosed+ssl.SSLSocket
         # Filter in TestCase.setUp because unittest resets the warning filters for each test.
         # https://stackoverflow.com/a/26620811/647002
-        warnings.filterwarnings("ignore", message=r"unclosed \<ssl\.SSLSocket", category=ResourceWarning)
+        warnings.filterwarnings("ignore", message=r"unclosed <ssl\.SSLSocket", category=ResourceWarning)
 
     def test_simple_send(self):
         # Example of getting the Amazon SES send status and message id from the message

--- a/tests/test_amazon_ses_integration.py
+++ b/tests/test_amazon_ses_integration.py
@@ -94,10 +94,8 @@ class AmazonSESBackendIntegrationTests(SimpleTestCase, AnymailTestMixin):
             bcc=["success+bcc1@simulator.amazonses.com", "Blind Copy 2 <success+bcc2@simulator.amazonses.com>"],
             reply_to=["reply1@example.com", "Reply 2 <reply2@example.com>"],
             headers={"X-Anymail-Test": "value"},
-
-            # Amazon SES only allows alphanumeric ASCII characters, '_', and '-' in tag/metadata keys and values:
             metadata={"meta1": "simple_string", "meta2": 2},
-            tags=["tag_1", "tag_2"],
+            tags=["Re-engagement", "Cohort 12/2017"],
         )
         message.attach("attachment1.txt", "Here is some\ntext for you", "text/plain")
         message.attach("attachment2.csv", "ID,Name\n1,Amy Lina", "text/csv")

--- a/tests/test_amazon_ses_webhooks.py
+++ b/tests/test_amazon_ses_webhooks.py
@@ -439,7 +439,7 @@ class AmazonSESSubscriptionManagementTests(WebhookTestCase, AmazonSESWebhookTest
         response = self.post_from_sns('/anymail/amazon_ses/tracking/', self.SNS_SUBSCRIPTION_CONFIRMATION)
         self.assertEqual(response.status_code, 200)
         # auto-confirmed:
-        self.mock_client.assert_called_once_with('sns')
+        self.mock_client.assert_called_once_with('sns', config=ANY)
         self.mock_client_instance.confirm_subscription.assert_called_once_with(
             TopicArn="arn:aws:sns:us-west-2:123456789012:SES_Notifications",
             Token="EXAMPLE_TOKEN", AuthenticateOnUnsubscribe="true")

--- a/tests/test_amazon_ses_webhooks.py
+++ b/tests/test_amazon_ses_webhooks.py
@@ -1,0 +1,248 @@
+import json
+import warnings
+from datetime import datetime
+
+from django.test import override_settings
+from django.utils.timezone import utc
+from mock import ANY, patch
+
+from anymail.exceptions import AnymailInsecureWebhookWarning
+from anymail.signals import AnymailTrackingEvent
+from anymail.webhooks.amazon_ses import AmazonSESTrackingWebhookView
+
+from .mock_requests_backend import RequestsBackendMockAPITestCase
+from .webhook_cases import WebhookBasicAuthTestsMixin, WebhookTestCase
+
+
+class AmazonSESWebhookTestsMixin(object):
+    def post_from_sns(self, path, raw_sns_message, **kwargs):
+        # noinspection PyUnresolvedReferences
+        return self.client.post(
+            path,
+            content_type='text/plain; charset=UTF-8',  # SNS posts JSON as text/plain
+            data=json.dumps(raw_sns_message),
+            HTTP_X_AMZ_SNS_MESSAGE_ID=raw_sns_message["MessageId"],
+            HTTP_X_AMZ_SNS_MESSAGE_TYPE=raw_sns_message["Type"],
+            # Anymail doesn't use other x-amz-sns-* headers
+            **kwargs)
+
+
+class AmazonSESWebhookSecurityTests(WebhookTestCase, AmazonSESWebhookTestsMixin, WebhookBasicAuthTestsMixin):
+    def call_webhook(self):
+        return self.post_from_sns('/anymail/amazon_ses/tracking/',
+                                  {"Type": "Notification", "MessageId": "123", "Message": "{}"})
+
+    # Most actual tests are in WebhookBasicAuthTestsMixin
+
+    def test_verifies_missing_auth(self):
+        # Must handle missing auth header slightly differently from Anymail default 400 SuspiciousOperation:
+        # SNS will only send basic auth after missing auth responds 401 WWW-Authenticate: Basic realm="..."
+        self.clear_basic_auth()
+        response = self.call_webhook()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response["WWW-Authenticate"], 'Basic realm="Anymail WEBHOOK_SECRET"')
+
+
+class AmazonSESNotificationsTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
+    def test_bounce_event(self):
+        # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-examples.html#notification-examples-bounce
+        raw_ses_event = {
+            "notificationType": "Bounce",
+            "bounce": {
+                "bounceType": "Permanent",
+                "reportingMTA": "dns; email.example.com",
+                "bouncedRecipients": [{
+                    "emailAddress": "jane@example.com",
+                    "status": "5.1.1",
+                    "action": "failed",
+                    "diagnosticCode": "smtp; 550 5.1.1 <jane@example.com>... User unknown"
+                }],
+                "bounceSubType": "General",
+                "timestamp": "2016-01-27T14:59:44.101Z",  # when bounce sent (by receiving ISP)
+                "feedbackId": "00000138111222aa-44455566-cccc-cccc-cccc-ddddaaaa068a-000000",  # unique id for bounce
+                "remoteMtaIp": "127.0.2.0"
+            },
+            "mail": {
+                "timestamp": "2016-01-27T14:59:38.237Z",  # when message sent
+                "source": "john@example.com",
+                "sourceArn": "arn:aws:ses:us-west-2:888888888888:identity/example.com",
+                "sourceIp": "127.0.3.0",
+                "sendingAccountId": "123456789012",
+                "messageId": "00000138111222aa-33322211-cccc-cccc-cccc-ddddaaaa0680-000000",
+                "destination": ["jane@example.com", "mary@example.com", "richard@example.com"],
+                "headersTruncated": False,
+                "headers": [
+                    {"name": "From", "value": '"John Doe" <john@example.com>'},
+                    {"name": "To", "value": '"Jane Doe" <jane@example.com>, "Mary Doe" <mary@example.com>,'
+                                            ' "Richard Doe" <richard@example.com>'},
+                    {"name": "Message-ID", "value": "custom-message-ID"},
+                    {"name": "Subject", "value": "Hello"},
+                    {"name": "Content-Type", "value": 'text/plain; charset="UTF-8"'},
+                    {"name": "Content-Transfer-Encoding", "value": "base64"},
+                    {"name": "Date", "value": "Wed, 27 Jan 2016 14:05:45 +0000"}
+                ],
+                "commonHeaders": {
+                    "from": ["John Doe <john@example.com>"],
+                    "date": "Wed, 27 Jan 2016 14:05:45 +0000",
+                    "to": ["Jane Doe <jane@example.com>, Mary Doe <mary@example.com>,"
+                           " Richard Doe <richard@example.com>"],
+                    "messageId": "custom-message-ID",
+                    "subject": "Hello"
+                }
+            }
+        }
+        raw_sns_event = {
+            "Type": "Notification",
+            "MessageId": "19ba9823-d7f2-53c1-860e-cb10e0d13dfc",  # unique id for SNS event
+            "TopicArn": "arn:aws:sns:us-east-1:1234567890:SES_Events",
+            "Subject": "Amazon SES Email Event Notification",
+            "Message": json.dumps(raw_ses_event) + "\n",
+            "Timestamp": "2018-03-26T17:58:59.675Z",
+            "SignatureVersion": "1",
+            "Signature": "EXAMPLE-SIGNATURE==",
+            "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-12345abcde.pem",
+            "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn...",
+        }
+
+        response = self.post_from_sns('/anymail/amazon_ses/tracking/', raw_sns_event)
+        self.assertEqual(response.status_code, 200)
+        kwargs = self.assert_handler_called_once_with(self.tracking_handler, sender=AmazonSESTrackingWebhookView,
+                                                      event=ANY, esp_name='Amazon SES')
+        event = kwargs['event']
+        self.assertIsInstance(event, AnymailTrackingEvent)
+        self.assertEqual(event.event_type, "bounced")
+        self.assertEqual(event.esp_event, raw_ses_event)
+        self.assertEqual(event.timestamp, datetime(2016, 1, 27, 14, 59, 44, microsecond=101000, tzinfo=utc))
+        self.assertEqual(event.message_id, "00000138111222aa-33322211-cccc-cccc-cccc-ddddaaaa0680-000000")
+        self.assertEqual(event.event_id, "19ba9823-d7f2-53c1-860e-cb10e0d13dfc")
+        self.assertEqual(event.recipient, "jane@example.com")
+        self.assertEqual(event.reject_reason, "bounced")
+        self.assertEqual(event.description,
+                         "The server was unable to deliver your message (ex: unknown user, mailbox not found).")
+        self.assertEqual(event.mta_response, "smtp; 550 5.1.1 <jane@example.com>... User unknown")
+
+
+class AmazonSESSubscriptionManagementTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
+    # Anymail will automatically respond to SNS subscription notifications
+    # if Anymail is configured to require basic auth via WEBHOOK_SECRET.
+    # (Note that WebhookTestCase sets up ANYMAIL WEBHOOK_SECRET.)
+
+    # Borrow requests mocking from RequestsBackendMockAPITestCase
+    MockResponse = RequestsBackendMockAPITestCase.MockResponse
+
+    def setUp(self):
+        super(AmazonSESSubscriptionManagementTests, self).setUp()
+        self.patch_request = patch('anymail.webhooks.amazon_ses.requests.get', autospec=True)
+        self.mock_request = self.patch_request.start()
+        self.addCleanup(self.patch_request.stop)
+        self.mock_request.return_value = self.MockResponse(status_code=200)
+
+    SNS_SUBSCRIPTION_CONFIRMATION = {
+        "Type": "SubscriptionConfirmation",
+        "MessageId": "165545c9-2a5c-472c-8df2-7ff2be2b3b1b",
+        "Token": "EXAMPLE_TOKEN",
+        "TopicArn": "arn:aws:sns:us-west-2:123456789012:SES_Notifications",
+        "Message": "You have chosen to subscribe ...\nTo confirm..., visit the SubscribeURL included in this message.",
+        "SubscribeURL": "https://sns.us-west-2.amazonaws.com/?Action=ConfirmSubscription&TopicArn=...",
+        "Timestamp": "2012-04-26T20:45:04.751Z",
+        "SignatureVersion": "1",
+        "Signature": "EXAMPLE-SIGNATURE==",
+        "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-12345abcde.pem"
+    }
+
+    def test_sns_subscription_auto_confirmation(self):
+        """Anymail webhook will auto-confirm SNS topic subscriptions"""
+        response = self.post_from_sns('/anymail/amazon_ses/tracking/', self.SNS_SUBSCRIPTION_CONFIRMATION)
+        self.assertEqual(response.status_code, 200)
+        # auto-visited the SubscribeURL:
+        self.mock_request.assert_called_once_with(
+            "https://sns.us-west-2.amazonaws.com/?Action=ConfirmSubscription&TopicArn=...")
+        # didn't notify receivers:
+        self.assertEqual(self.tracking_handler.call_count, 0)
+        self.assertEqual(self.inbound_handler.call_count, 0)
+
+    def test_sns_subscription_confirmation_failure(self):
+        """Auto-confirmation notifies if SubscribeURL errors"""
+        self.mock_request.return_value = self.MockResponse(status_code=500, raw=b"Gateway timeout")
+        with self.assertLogs('django.security.AnymailWebhookValidationFailure') as cm:
+            response = self.post_from_sns('/anymail/amazon_ses/tracking/', self.SNS_SUBSCRIPTION_CONFIRMATION)
+        self.assertEqual(response.status_code, 400)  # bad request
+        self.assertEqual(
+            ["Anymail received a 500 error trying to automatically confirm a subscription to Amazon SNS topic "
+             "'arn:aws:sns:us-west-2:123456789012:SES_Notifications'. The response was 'Gateway timeout'."],
+            [record.getMessage() for record in cm.records])
+        # auto-visited the SubscribeURL:
+        self.mock_request.assert_called_once_with(
+            "https://sns.us-west-2.amazonaws.com/?Action=ConfirmSubscription&TopicArn=...")
+        # didn't notify receivers:
+        self.assertEqual(self.tracking_handler.call_count, 0)
+        self.assertEqual(self.inbound_handler.call_count, 0)
+
+    @override_settings(ANYMAIL={})  # clear WEBHOOK_SECRET setting from base WebhookTestCase
+    def test_sns_subscription_confirmation_auth_disabled(self):
+        """Anymail *won't* auto-confirm SNS subscriptions if WEBHOOK_SECRET isn't in use"""
+        warnings.simplefilter("ignore", AnymailInsecureWebhookWarning)  # (this gets tested elsewhere)
+        with self.assertLogs('django.security.AnymailWebhookValidationFailure') as cm:
+            response = self.post_from_sns('/anymail/amazon_ses/tracking/', self.SNS_SUBSCRIPTION_CONFIRMATION)
+        self.assertEqual(response.status_code, 400)  # bad request
+        self.assertEqual(
+            ["Anymail received an unexpected SubscriptionConfirmation request for Amazon SNS topic "
+             "'arn:aws:sns:us-west-2:123456789012:SES_Notifications'. (Anymail can automatically confirm "
+             "SNS subscriptions if you set a WEBHOOK_SECRET and use that in your SNS notification url. Or "
+             "you can manually confirm this subscription in the SNS dashboard with token 'EXAMPLE_TOKEN'.)"],
+            [record.getMessage() for record in cm.records])
+        # *didn't* visit the SubscribeURL:
+        self.assertEqual(self.mock_request.call_count, 0)
+        # didn't notify receivers:
+        self.assertEqual(self.tracking_handler.call_count, 0)
+        self.assertEqual(self.inbound_handler.call_count, 0)
+
+    def test_sns_confirmation_success_notification(self):
+        """Anymail ignores the 'Successfully validated' notification after confirming an SNS subscription"""
+        response = self.post_from_sns('/anymail/amazon_ses/tracking/', {
+            "Type": "Notification",
+            "MessageId": "7fbca0d9-eeab-5285-ae27-f3f57f2e84b0",
+            "TopicArn": "arn:aws:sns:us-west-2:123456789012:SES_Notifications",
+            "Message": "Successfully validated SNS topic for Amazon SES event publishing.",
+            "Timestamp": "2018-03-21T16:58:45.077Z",
+            "SignatureVersion": "1",
+            "Signature": "EXAMPLE_SIGNATURE==",
+            "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-12345abcde.pem",
+            "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe...",
+        })
+        self.assertEqual(response.status_code, 200)
+        # didn't notify receivers:
+        self.assertEqual(self.tracking_handler.call_count, 0)
+        self.assertEqual(self.inbound_handler.call_count, 0)
+
+    def test_sns_unsubscribe_confirmation(self):
+        """Anymail ignores the UnsubscribeConfirmation SNS message after deleting a subscription"""
+        response = self.post_from_sns('/anymail/amazon_ses/tracking/', {
+            "Type": "UnsubscribeConfirmation",
+            "MessageId": "47138184-6831-46b8-8f7c-afc488602d7d",
+            "Token": "EXAMPLE_TOKEN",
+            "TopicArn": "arn:aws:sns:us-west-2:123456789012:SES_Notifications",
+            "Message": "You have chosen to deactivate subscription ...\nTo cancel ... visit the SubscribeURL...",
+            "SubscribeURL": "https://sns.us-west-2.amazonaws.com/?Action=ConfirmSubscription&TopicArn=...",
+            "Timestamp": "2012-04-26T20:06:41.581Z",
+            "SignatureVersion": "1",
+            "Signature": "EXAMPLE_SIGNATURE==",
+            "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-12345abcde.pem",
+        })
+        self.assertEqual(response.status_code, 200)
+        # *didn't* visit the SubscribeURL (because that would re-enable the subscription!):
+        self.assertEqual(self.mock_request.call_count, 0)
+        # didn't notify receivers:
+        self.assertEqual(self.tracking_handler.call_count, 0)
+        self.assertEqual(self.inbound_handler.call_count, 0)
+
+    @override_settings(ANYMAIL_AMAZON_SES_AUTO_CONFIRM_SNS_SUBSCRIPTIONS=False)
+    def test_disable_auto_confirmation(self):
+        """The ANYMAIL setting AMAZON_SES_AUTO_CONFIRM_SNS_SUBSCRIPTIONS will disable this feature"""
+        response = self.post_from_sns('/anymail/amazon_ses/tracking/', self.SNS_SUBSCRIPTION_CONFIRMATION)
+        self.assertEqual(response.status_code, 200)
+        # *didn't* visit the SubscribeURL:
+        self.assertEqual(self.mock_request.call_count, 0)
+        # didn't notify receivers:
+        self.assertEqual(self.tracking_handler.call_count, 0)
+        self.assertEqual(self.inbound_handler.call_count, 0)

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     djangoMaster: https://github.com/django/django/tarball/master
     # testing dependencies (duplicates setup.py tests_require):
     mock
+    boto3
     sparkpost
 ignore_outcome =
     django21: True

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ commands =
 passenv =
     RUN_LIVE_TESTS
     CONTINUOUS_INTEGRATION
+    AMAZON_SES_TEST_*
     MAILGUN_TEST_*
     MAILJET_TEST_*
     MANDRILL_TEST_*


### PR DESCRIPTION
In-progress implementation of Amazon SES support (#54). This first commit implements all backend functionality other than templates.

For testing, pip can install directly from this feature branch:

```bash
pip install https://github.com/anymail/django-anymail/tarball/feature_amazon_ses#egg=django-anymail[amazon_ses]
```

(You may need to add `--upgrade` if you already have Anymail installed. The `#egg=django-anymail[amazon_ses]` part lets pip know to also install the extra dependencies for amazon_ses support in django-anymail—namely, boto3.)

To use the backend, specify `EMAIL_BACKEND = "anymail.backends.amazon_ses.EmailBackend"` in your Django settings. There are no specific Anymail settings required—[boto3 finds your AWS credentials](http://boto3.readthedocs.io/en/stable/guide/configuration.html) in its usual places.

TODO:
- Finish backend:
  - [x] Fix fragile tests (need better approach for comparing MIME parts)
  - [x] Implement `template_id` and `merge_data` using newish SES SendBulkTemplatedEmail API
  - [x] Resolve other open design/enhancement decisions (see TODO comments in source)
- Webhooks:
  - [x] Tracking webhooks
  - [x] Inbound webhook
  - ~Webhook [signature verification](https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.verify.signature.html)~ (holding out for something at least semi-official)
- [x] [Docs](http://anymail.readthedocs.io/en/feature_amazon_ses/esps/amazon_ses/)
