### PR TITLE
Travis: attempt to test with released Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ matrix:
     - { env: DJANGO=1.11, python: pypy }
     # Django 2.0: Python 3.5+
     - { env: DJANGO=2.0, python: 3.5 }
-    - { env: DJANGO=2.0 RUN_LIVE_TESTS=true, python: 3.6 }
+    - { env: DJANGO=2.0, python: 3.6 }
     - { env: DJANGO=2.0, python: pypy3 }
     # Django 2.1: Python 3.5, 3.6, or 3.7
     - { env: DJANGO=2.1, python: 3.5 }
-    - { env: DJANGO=2.1, python: 3.6 }
+    - { env: DJANGO=2.1 RUN_LIVE_TESTS=true, python: 3.6 }
     - { env: DJANGO=2.1, python: 3.7, dist: xenial, sudo: true }
     - { env: DJANGO=2.1, python: pypy3 }
     # Django development master (direct from GitHub source):

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,14 @@ matrix:
     # Django 2.1: Python 3.5, 3.6, or 3.7
     - { env: DJANGO=2.1, python: 3.5 }
     - { env: DJANGO=2.1, python: 3.6 }
-    - { env: DJANGO=2.1, python: 3.7-dev }
+    - { env: DJANGO=2.1, python: 3.7, dist: xenial, sudo: true }
     - { env: DJANGO=2.1, python: pypy3 }
     # Django development master (direct from GitHub source):
-    - { env: DJANGO=master, python: 3.7-dev }
+    - { env: DJANGO=master, python: 3.6 }
 
   allow_failures:
     - env: DJANGO=master
-      python: 3.7-dev
+      python: 3.6
 
 cache: pip
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ envlist =
     docs
     # ... then test all the other supported combinations:
     django21-py{35,37,py3}
-    django20-py{35,py3}
-    django111-py{34,35,36,py2}
+    django20-py{35,36,py3}
+    django111-py{34,35,36,py}
     # ... then prereleases (if available):
     # django22-py{35,36,37}
     djangoMaster-py{36,37}


### PR DESCRIPTION
The python3.7-dev environment available on Travis default trusty is
apparently an outdated beta. Released Python 3.7 is only available in
Travis on the xenial platform.