### PR TITLE
also consider Content-ID when marking attachment as inline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,10 @@ v4.3
 Features
 ~~~~~~~~
 
+*  Treat MIME attachments that have a *Content-ID* but no explicit *Content-Disposition*
+   header as inline, matching the behavior of many email clients. For maximum
+   compatibility, you should always set both (or use Anymail's inline helper functions).
+   (Thanks `@costela`_.)
 *  Add (undocumented) DEBUG_API_REQUESTS Anymail setting. When enabled, prints raw
    API request and response during send. Currently implemented only for Requests-based
    backends (all but Amazon SES and SparkPost). Because this can expose API keys and

--- a/anymail/utils.py
+++ b/anymail/utils.py
@@ -291,7 +291,8 @@ class Attachment(object):
                     self.content = attachment.as_string().encode(self.encoding)
             self.mimetype = attachment.get_content_type()
 
-            if get_content_disposition(attachment) == 'inline':
+            content_disposition = get_content_disposition(attachment)
+            if content_disposition == 'inline' or (not content_disposition and 'Content-ID' in attachment):
                 self.inline = True
                 self.content_id = attachment["Content-ID"]  # probably including the <...>
                 if self.content_id is not None:

--- a/docs/sending/django_email.rst
+++ b/docs/sending/django_email.rst
@@ -88,6 +88,15 @@ and :meth:`~email.message.Message.add_header` should be helpful.)
 Even if you mark an attachment as inline, some email clients may decide to also
 display it as an attachment. This is largely outside your control.
 
+.. versionchanged:: 4.3
+
+    For convenience, Anymail will treat an attachment with a :mailheader:`Content-ID`
+    but no :mailheader:`Content-Disposition` as inline. (Many---though not all---email
+    clients make the same assumption. But to ensure consistent behavior with non-Anymail
+    email backends, you should always set *both* :mailheader:`Content-ID` and
+    :mailheader:`Content-Disposition: inline` headers for inline images. Or just use
+    Anymail's :ref:`inline image helpers <inline-images>`, which handle this for you.)
+
 
 .. _message-headers:
 


### PR DESCRIPTION
As explained in #125, this should bring `django-anymail` more inline with the behavior of many MUAs that optimistically consider an attachment as "inline" when it has a `Content-ID` but no `Content-Disposition`.