### PR TITLE
Improvements to Sendinblue Backend

### DIFF
--- a/anymail/backends/sendinblue.py
+++ b/anymail/backends/sendinblue.py
@@ -1,5 +1,4 @@
 from requests.structures import CaseInsensitiveDict
-from six.moves.urllib.parse import quote
 
 from .base_requests import AnymailRequestsBackend, RequestsPayload
 from ..exceptions import AnymailRequestsAPIError
@@ -67,7 +66,6 @@ class SendinBluePayload(RequestsPayload):
 
     def __init__(self, message, defaults, backend, *args, **kwargs):
         self.all_recipients = []  # used for backend.parse_recipient_status
-        self.template_id = None
 
         http_headers = kwargs.pop('headers', {})
         http_headers['api-key'] = backend.api_key
@@ -76,10 +74,7 @@ class SendinBluePayload(RequestsPayload):
         super(SendinBluePayload, self).__init__(message, defaults, backend, headers=http_headers, *args, **kwargs)
 
     def get_api_endpoint(self):
-        if self.template_id:
-            return "smtp/templates/%s/send" % quote(str(self.template_id), safe='')
-        else:
-            return "smtp/email"
+        return "smtp/email"
 
     def init_payload(self):
         self.data = {  # becomes json
@@ -91,47 +86,10 @@ class SendinBluePayload(RequestsPayload):
 
         if not self.data['headers']:
             del self.data['headers']  # don't send empty headers
-
-        # SendinBlue use different argument's name if we use template functionality
-        if self.template_id:
-            data = self._transform_data_for_templated_email(self.data)
-        else:
-            data = self.data
-
-        return self.serialize_json(data)
-
-    def _transform_data_for_templated_email(self, data):
-        """
-        Transform the default Payload's data (used for basic transactional email) to
-        the data used by SendinBlue in case of a templated transactional email.
-        :param data: The data we want to transform
-        :return: The transformed data
-        """
-        if data.pop('subject', False):
-            self.unsupported_feature("overriding template subject")
-        if data.pop('sender', False):
-            self.unsupported_feature("overriding template from_email")
-        if data.pop('textContent', False) or data.pop('htmlContent', False):
+        if self.data.get('templateId') and (self.data.pop('textContent', False) or self.data.pop('htmlContent', False)):
             self.unsupported_feature("overriding template body content")
 
-        transformation = {
-            'to': 'emailTo',
-            'cc': 'emailCc',
-            'bcc': 'emailBcc',
-        }
-        for key, new_key in transformation.items():
-            if key in data:
-                if any(email.get('name') for email in data[key]):
-                    self.unsupported_feature("display names in %s when sending with a template" % key)
-                data[new_key] = [email['email'] for email in data[key]]
-                del data[key]
-
-        if 'replyTo' in data:
-            if data['replyTo'].get('name'):
-                self.unsupported_feature("display names in reply_to when sending with a template")
-            data['replyTo'] = data['replyTo']['email']
-
-        return data
+        return self.serialize_json(self.data)
 
     #
     # Payload construction
@@ -171,12 +129,10 @@ class SendinBluePayload(RequestsPayload):
 
     def set_tags(self, tags):
         if len(tags) > 0:
-            self.data['headers']["X-Mailin-tag"] = tags[0]
-            if len(tags) > 1:
-                self.unsupported_feature('multiple tags (%r)' % tags)
+            self.data['tags'] = tags
 
     def set_template_id(self, template_id):
-        self.template_id = template_id
+        self.data['templateId'] = template_id
 
     def set_text_body(self, body):
         if body:

--- a/anymail/backends/sendinblue.py
+++ b/anymail/backends/sendinblue.py
@@ -165,7 +165,7 @@ class SendinBluePayload(RequestsPayload):
         self.unsupported_feature("merge_data")
 
     def set_merge_global_data(self, merge_global_data):
-        self.data['attributes'] = merge_global_data
+        self.data['params'] = merge_global_data
 
     def set_metadata(self, metadata):
         # SendinBlue expects a single string payload

--- a/docs/esps/index.rst
+++ b/docs/esps/index.rst
@@ -40,7 +40,7 @@ Email Service Provider                        |Amazon SES|  |Mailgun|    |Mailje
 :attr:`~AnymailMessage.metadata`              Yes           Yes          Yes         Yes          Yes         Yes         Yes           Yes
 :attr:`~AnymailMessage.merge_metadata`        No            Yes          Yes         Yes          Yes         Yes         No            Yes
 :attr:`~AnymailMessage.send_at`               No            Yes          No          Yes          No          Yes         No            Yes
-:attr:`~AnymailMessage.tags`                  Yes           Yes          Max 1 tag   Yes          Max 1 tag   Yes         Max 1 tag     Max 1 tag
+:attr:`~AnymailMessage.tags`                  Yes           Yes          Max 1 tag   Yes          Max 1 tag   Yes         Yes           Max 1 tag
 :attr:`~AnymailMessage.track_clicks`          No            Yes          Yes         Yes          Yes         Yes         No            Yes
 :attr:`~AnymailMessage.track_opens`           No            Yes          Yes         Yes          Yes         Yes         No            Yes
 

--- a/docs/esps/sendinblue.rst
+++ b/docs/esps/sendinblue.rst
@@ -131,9 +131,8 @@ SendinBlue can handle.
   to the SendinBlue API if the name is not set correctly.
 
 **Additional template limitations**
-  If you are sending using a SendinBlue template, their API doesn't allow display
-  names in recipient or reply-to emails, and doesn't support overriding the template's
-  from_email, subject, or body. See the :ref:`templates <sendinblue-templates>`
+  If you are sending using a SendinBlue template, their API doesn't support overriding the template's
+  body. See the :ref:`templates <sendinblue-templates>`
   section below.
 
 **Single Reply-To**
@@ -141,15 +140,6 @@ SendinBlue can handle.
 
   If you are ignoring unsupported features and have multiple reply addresses,
   Anymail will use only the first one.
-
-**Single tag**
-  SendinBlue supports a single message tag, which can be used for filtering in their
-  dashboard statistics and logs panels, and is available in tracking webhooks.
-  Anymail will pass the first of a message's :attr:`~anymail.message.AnymailMessage.tags`
-  to SendinBlue, using their :mailheader:`X-Mailin-tag` email header.
-
-  Trying to send a message with more than one tag will result in an error unless you
-  are ignoring unsupported features.
 
 **Metadata**
   Anymail passes :attr:`~anymail.message.AnymailMessage.metadata` to SendinBlue
@@ -189,7 +179,7 @@ the messages's :attr:`~anymail.message.AnymailMessage.merge_global_data`:
   .. code-block:: python
 
       message = EmailMessage(
-          subject=None,  # required for SendinBlue templates
+          subject="My Subject",  # optional for SendinBlue templates
           body=None,  # required for SendinBlue templates
           to=["alice@example.com"]  # single recipient...
           # ...multiple to emails would all get the same message
@@ -208,14 +198,9 @@ variables using %-delimited names, e.g., `%order_no%` or `%ship_date%`
 from the example above.
 
 Note that SendinBlue's API does not permit overriding a template's
-subject, body, or from_email. You *must* set them to `None` as shown above,
+body. You *must* set it to `None` as shown above,
 or Anymail will raise an :exc:`~anymail.exceptions.AnymailUnsupportedFeature`
 error (if you are not ignoring unsupported features).
-
-Also, SendinBlue's API does not permit display names in recipient or reply-to
-emails when sending with a template. Code like `to=["Alice <alice@example.com>"]`
-will result in an unsupported feature error. (SendinBlue supports display names
-only in *non*-template sends.)
 
 
 .. _sendinblue-webhooks:

--- a/tests/test_sendinblue_backend.py
+++ b/tests/test_sendinblue_backend.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import json
-
 from base64 import b64encode, b64decode
 from datetime import datetime
 from decimal import Decimal
@@ -16,7 +15,6 @@ from django.utils.timezone import get_fixed_timezone, override as override_curre
 from anymail.exceptions import (AnymailAPIError, AnymailConfigurationError, AnymailSerializationError,
                                 AnymailUnsupportedFeature)
 from anymail.message import attach_inline_image_file
-
 from .mock_requests_backend import RequestsBackendMockAPITestCase, SessionSharingTestCasesMixin
 from .utils import sample_image_content, sample_image_path, SAMPLE_IMAGE_FILENAME, AnymailTestMixin
 
@@ -367,6 +365,14 @@ class SendinBlueBackendAnymailFeatureTests(SendinBlueBackendMockAPITestCase):
         with self.assertRaises(AnymailUnsupportedFeature):
             self.message.send()
 
+    def test_merge_global_data(self):
+        self.message.merge_global_data = {
+            'a': 'b'
+        }
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data['params'], {'a': 'b'})
+
     def test_default_omits_options(self):
         """Make sure by default we don't send any ESP-specific options.
 
@@ -392,8 +398,8 @@ class SendinBlueBackendAnymailFeatureTests(SendinBlueBackendMockAPITestCase):
             },
             'tracking_settings': {
                 'subscription_tracking': {
-                        'enable': True,
-                        'substitution_tag': '[unsubscribe_url]',
+                    'enable': True,
+                    'substitution_tag': '[unsubscribe_url]',
                 },
             },
         }
@@ -410,7 +416,7 @@ class SendinBlueBackendAnymailFeatureTests(SendinBlueBackendMockAPITestCase):
         """ The anymail_status should be attached to the message when it is sent """
         # the DEFAULT_RAW_RESPONSE above is the *only* success response SendinBlue returns,
         # so no need to override it here
-        msg = mail.EmailMessage('Subject', 'Message', 'from@example.com', ['to1@example.com'],)
+        msg = mail.EmailMessage('Subject', 'Message', 'from@example.com', ['to1@example.com'], )
         sent = msg.send()
         self.assertEqual(sent, 1)
         self.assertEqual(msg.anymail_status.status, {'queued'})


### PR DESCRIPTION
- Multiple tags can be send now (regardless of template or not)
- When sending a mail using a template, display name is supported on 'to', 'bcc', 'cc' and 'replyTo'. Also supports overriding 'from_email' and 'subject'
- Removed use of deprecated SendinBlue API endpoint