### PR TITLE
Mailgun: make merge_data work with stored handlebars templates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,19 @@ Release history
 ^^^^^^^^^^^^^^^
     ..  This extra heading level keeps the ToC from becoming unmanageably long
 
+vNext
+-----
+
+*Not yet released*
+
+Features
+~~~~~~~~
+
+* **Mailgun:** Support Mailgun's new (ESP stored) handlebars templates via `template_id`.
+  See `docs <https://anymail.readthedocs.io/en/latest/esps/mailgun/#batch-sending-merge-and-esp-templates>`__.
+  (Thanks `@anstosa`_.)
+
+
 v6.1
 ----
 
@@ -964,6 +977,7 @@ Features
 .. _#153: https://github.com/anymail/issues/153
 
 .. _@ailionx: https://github.com/ailionx
+.. _@anstosa: https://github.com/anstosa
 .. _@calvin: https://github.com/calvin
 .. _@costela: https://github.com/costela
 .. _@decibyte: https://github.com/decibyte

--- a/docs/esps/index.rst
+++ b/docs/esps/index.rst
@@ -46,7 +46,7 @@ Email Service Provider                        |Amazon SES|  |Mailgun|    |Mailje
 
 .. rubric:: :ref:`templates-and-merge`
 ---------------------------------------------------------------------------------------------------------------------------------------------------
-:attr:`~AnymailMessage.template_id`           Yes           No           Yes         Yes          Yes         Yes         Yes           Yes
+:attr:`~AnymailMessage.template_id`           Yes           Yes          Yes         Yes          Yes         Yes         Yes           Yes
 :attr:`~AnymailMessage.merge_data`            Yes           Yes          Yes         Yes          No          Yes         No            Yes
 :attr:`~AnymailMessage.merge_global_data`     Yes           (emulated)   Yes         Yes          Yes         Yes         Yes           Yes
 


### PR DESCRIPTION
Mailgun has two different template mechanisms and two different ways
of providing substitution variables to them. Update Anymail's
normalized merge_data handling to work with either (while preserving
existing batch send and metadata capabilities that also use Mailgun's
custom data and recipient variables parameters).

Completes work started by @anstosa in #156.
Closes #155.