### PR TITLE
Mailgun: disable RFC 5758 filename workaround when urllib3 is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,9 @@ matrix:
     - { env: TOXENV=django22-py37-none, python: 3.7 }
     - { env: TOXENV=django22-py37-amazon_ses, python: 3.7 }
     - { env: TOXENV=django22-py37-sparkpost, python: 3.7 }
+    # Test some specific older package versions
+    - { env: TOXENV=django111-py27-all-old_urllib3, python: 3.7 }
+    - { env: TOXENV=django22-py37-all-old_urllib3, python: 3.7 }
 
   allow_failures:
     - env: TOXENV=djangoMaster-py37-all

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,14 @@ Features
   (Thanks `@anstosa`_.)
 
 
+Other
+~~~~~
+
+* **Mailgun:** Disable Anymail's workaround for a Requests/urllib3 issue with non-ASCII
+  attachment filenames when a newer version of urllib3--which fixes the problem--is
+  installed. (Workaround was added in Anymail v4.3; fix appears in urllib3 v1.25.)
+
+
 v6.1
 ----
 

--- a/tests/mock_requests_backend.py
+++ b/tests/mock_requests_backend.py
@@ -115,6 +115,13 @@ class RequestsBackendMockAPITestCase(SimpleTestCase, AnymailTestMixin):
         """Returns the auth sent to the mock ESP API"""
         return self.get_api_call_arg('auth', required)
 
+    def get_api_prepared_request(self):
+        """Returns the PreparedRequest that would have been sent"""
+        (args, kwargs) = self.mock_request.call_args
+        kwargs.pop('timeout', None)  # Session-only param
+        request = requests.Request(**kwargs)
+        return request.prepare()
+
     def assert_esp_not_called(self, msg=None):
         if self.mock_request.called:
             raise AssertionError(msg or "ESP API was called and shouldn't have been")

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ envlist =
     djangoMaster-py{36,37}-all
     # ... then partial installation (limit extras):
     django22-py37-{none,amazon_ses,sparkpost}
+    # ... then older versions of some dependencies:
+    django111-py27-all-old_urllib3
+    django22-py37-all-old_urllib3
 
 [testenv]
 deps =
@@ -23,6 +26,7 @@ deps =
     django21: django~=2.1.0
     django22: django~=2.2.0
     djangoMaster: https://github.com/django/django/tarball/master
+    old_urllib3: urllib3<1.25
     # testing dependencies (duplicates setup.py tests_require, less optional extras):
     mock
 extras =


### PR DESCRIPTION
urllib3 v1.25 fixes non-ASCII filenames in multipart form data to be
RFC 5758 compliant by default, so our earlier workaround is no longer
needed. Disable the workaround if we detect that Requests is using a
fixed version of urllib3.

Closes #157