### PR TITLE
Tests: work around Mailgun event reporting change

### DIFF
--- a/tests/test_mailgun_integration.py
+++ b/tests/test_mailgun_integration.py
@@ -151,7 +151,13 @@ class MailgunBackendIntegrationTests(SimpleTestCase, AnymailTestMixin):
         self.assertEqual(headers["subject"], "Anymail Mailgun all-options integration test")
 
         attachments = event["message"]["attachments"]
-        self.assertEqual(len(attachments), 2)  # because inline image shouldn't be an attachment
+        if len(attachments) == 3:
+            # The inline attachment shouldn't be in the event message.attachments array, 
+            # but sometimes is included for the accepted event (see #172)
+            inline_attachment = attachments.pop(0)
+            self.assertEqual(inline_attachment["filename"], cid)
+            self.assertEqual(inline_attachment["content-type"], "image/png")
+        self.assertEqual(len(attachments), 2)
         self.assertEqual(attachments[0]["filename"], "attachment1.txt")
         self.assertEqual(attachments[0]["content-type"], "text/plain")
         self.assertEqual(attachments[1]["filename"], "vedhæftet fil.csv")

--- a/tests/test_mailgun_integration.py
+++ b/tests/test_mailgun_integration.py
@@ -152,7 +152,7 @@ class MailgunBackendIntegrationTests(SimpleTestCase, AnymailTestMixin):
 
         attachments = event["message"]["attachments"]
         if len(attachments) == 3:
-            # The inline attachment shouldn't be in the event message.attachments array, 
+            # The inline attachment shouldn't be in the event message.attachments array,
             # but sometimes is included for the accepted event (see #172)
             inline_attachment = attachments.pop(0)
             self.assertEqual(inline_attachment["filename"], cid)


### PR DESCRIPTION
In the live integration tests, work around Mailgun's recent change
to how inline attachments are reported in "accepted" events data.

(But keep it working either way, since it seems likely this change was
unintentional—other event types still exclude inline attachments from
`event.message.attachments`.)

Fixes #172