### PR TITLE
treat message with 'merge_global_data' attribute as batch to force personalizations expansion

### DIFF
--- a/anymail/backends/base.py
+++ b/anymail/backends/base.py
@@ -252,7 +252,7 @@ class BasePayload(object):
 
     # If any of these attrs are set on a message, treat the message
     # as a batch send (separate message for each `to` recipient):
-    batch_attrs = ('merge_data', 'merge_metadata')
+    batch_attrs = ('merge_data', 'merge_global_data', 'merge_metadata')
 
     def __init__(self, message, defaults, backend):
         self.message = message


### PR DESCRIPTION
don't know if this correct for all cases, but it works when we need same data for multiple recipients
see #179  