### PR TITLE
Inbound: fix get_content_disposition with non-ASCII filename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
   # this avoids duplicate builds on the PR *branches*, too.)
   only:
     - master
-    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+    - /^v\d+\.\d+(\.(\d|x)+)?(-\S*)?$/
 
 env:
   global:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,18 @@ Release history
 ^^^^^^^^^^^^^^^
     ..  This extra heading level keeps the ToC from becoming unmanageably long
 
+v7.2.1
+------
+
+*2020-08-05*
+
+Fixes
+~~~~~
+
+* **Inbound:** Fix a Python 2.7-only UnicodeEncodeError when attachments have non-ASCII
+  filenames. (Thanks to `@kika115`_ for reporting it.)
+
+
 v7.2 LTS
 --------
 
@@ -1099,6 +1111,7 @@ Features
 .. _@janneThoft: https://github.com/janneThoft
 .. _@jc-ee: https://github.com/jc-ee
 .. _@joshkersey: https://github.com/joshkersey
+.. _@kika115: https://github.com/kika115
 .. _@Lekensteyn: https://github.com/Lekensteyn
 .. _@lewistaylor: https://github.com/lewistaylor
 .. _@mbk-ok: https://github.com/mbk-ok

--- a/anymail/utils.py
+++ b/anymail/utils.py
@@ -333,7 +333,7 @@ def get_content_disposition(mimeobj):
     if value is None:
         return None
     # _splitparam(value)[0].lower() :
-    return str(value).partition(';')[0].strip().lower()
+    return force_str(value, errors='replace').partition(';')[0].strip().lower()
 
 
 def get_anymail_setting(name, default=UNSET, esp_name=None, kwargs=None, allow_bare=False):

--- a/tests/test_inbound.py
+++ b/tests/test_inbound.py
@@ -137,6 +137,15 @@ class AnymailInboundMessageConstructionTests(SimpleTestCase):
         att = AnymailInboundMessage.construct_attachment(content_type="image/png", content=content, base64=True)
         self.assertEqual(att.get_content_bytes(), SAMPLE_IMAGE_CONTENT)
 
+    def test_construct_attachment_unicode_filename(self):
+        # Issue #197
+        att = AnymailInboundMessage.construct_attachment(
+            content_type="text/plain", content="Unicode ✓", charset='utf-8', base64=False,
+            filename="Simulácia.txt", content_id="inline-id",)
+        self.assertEqual(att.get_filename(), "Simulácia.txt")
+        self.assertTrue(att.is_inline_attachment())
+        self.assertEqual(att.get_content_text(), "Unicode ✓")
+
     def test_parse_raw_mime(self):
         # (we're not trying to exhaustively test email.parser MIME handling here;
         # just that AnymailInboundMessage.parse_raw_mime calls it correctly)


### PR DESCRIPTION
Fix Anymail's backported get_content_disposition to handle
values containing non-ASCII filenames. (Only applies on
Python 2.7.)

Fixes #197