### PR TITLE
Update tox for Django dev branch install

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     django30: django~=3.0.0
     django31: django~=3.1.0
     django32: django>=3.2a1
-    djangoDev: https://github.com/django/django/tarball/master
+    djangoDev: https://github.com/django/django/tarball/main
     old_urllib3: urllib3<1.25
     # testing dependencies (duplicates setup.py tests_require, less optional extras):
     mock
@@ -44,6 +44,7 @@ ignore_outcome =
 args_are_paths = false
 commands_pre =
     python -VV
+    python -c 'import django; print("Django", django.__version__)'
 commands =
     python runtests.py {posargs}
 passenv =
@@ -61,9 +62,10 @@ passenv =
 	# (but not any of the live test API keys)
 deps =
     flake8
-commands =
-    python --version
+commands_pre =
+    python -VV
     flake8 --version
+commands =
     flake8
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,9 @@ setenv =
 whitelist_externals = /bin/bash
 deps =
     -rdocs/requirements.txt
+commands_pre =
+    python -VV
+    sphinx-build --version
 commands =
     # Verify README.rst as used in setup.py long_description:
     python setup.py check --restructuredtext --strict


### PR DESCRIPTION
Django has renamed their dev branch to "main".

(Also clean up some version reporting.)