### PR TITLE
Postmark: fix silent failures for send-time validation errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,11 @@ Fixes
 * **Postmark:** Fix two different errors when sending with a template but no merge
   data. (Thanks to `@kareemcoding`_ and `@Tobeyforce`_ for reporting them.)
 
+* **Postmark:** Fix silent failure when sending with long metadata keys and some
+  other errors Postmark detects at send time. Report invalid 'cc' and 'bcc' addresses
+  detected at send time the same as 'to' recipients. (Thanks to `@chrisgrande`_ for
+  reporting the problem.)
+
 
 v8.2
 -----
@@ -1222,6 +1227,7 @@ Features
 .. _@alee: https://github.com/alee
 .. _@anstosa: https://github.com/anstosa
 .. _@calvin: https://github.com/calvin
+.. _@chrisgrande: https://github.com/chrisgrande
 .. _@costela: https://github.com/costela
 .. _@decibyte: https://github.com/decibyte
 .. _@dominik-lekse: https://github.com/dominik-lekse


### PR DESCRIPTION
Postmark uses their ErrorCode 300 to report several different
send-time validation errors, some of which identify invalid
recipients that need to be handled specially, but many of which
are ordinary API errors.

Rework the logic for parsing ErrorCode 300 error messages:
Handle only "Invalid 'To'" or "Error parsing 'To'" (or 'Cc'
or 'Bcc') as recipient errors. Otherwise raise an API error.

Fixes #238 silent failure when sending with long metadata keys.