### PR TITLE
Treat first text/plain alternative as plaintext body

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,20 @@ Release history
 ^^^^^^^^^^^^^^^
     ..  This extra heading level keeps the ToC from becoming unmanageably long
 
+vNext
+-----
+
+*Unreleased changes on main branch*
+
+Fixes
+~~~~~
+
+* Allow `attach_alternative("content", "text/plain")` in place of setting
+  an EmailMessage's `body`, and generally improve alternative part
+  handling for consistency with Django's SMTP EmailBackend.
+  (Thanks to `@cjsoftuk`_ for reporting the issue.)
+
+
 v8.4
 ----
 
@@ -1241,6 +1255,7 @@ Features
 .. _@anstosa: https://github.com/anstosa
 .. _@calvin: https://github.com/calvin
 .. _@chrisgrande: https://github.com/chrisgrande
+.. _@cjsoftuk: https://github.com/cjsoftuk
 .. _@costela: https://github.com/costela
 .. _@decibyte: https://github.com/decibyte
 .. _@dominik-lekse: https://github.com/dominik-lekse

--- a/anymail/backends/test.py
+++ b/anymail/backends/test.py
@@ -107,7 +107,12 @@ class TestPayload(BasePayload):
         self.params['html_body'] = body
 
     def add_alternative(self, content, mimetype):
-        self.unsupported_feature("alternative part with type '%s'" % mimetype)
+        # For testing purposes, we allow all "text/*" alternatives,
+        # but not any other mimetypes.
+        if mimetype.startswith('text'):
+            self.params.setdefault('alternatives', []).append((content, mimetype))
+        else:
+            self.unsupported_feature("alternative part with type '%s'" % mimetype)
 
     def add_attachment(self, attachment):
         self.params.setdefault('attachments', []).append(attachment)


### PR DESCRIPTION
Improve handling of alternative parts and `content_subtype`
to match how Django's SMTP backend handles some unusual cases.

Change Test backend to support (and record) text/* alternative
parts. (But still reject other types of alternatives.)

Fixes #252