### PR TITLE
Fix: don't include sender/recipient in AnymailError description

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,13 @@ Fixes
   an EmailMessage's `body`, and generally improve alternative part
   handling for consistency with Django's SMTP EmailBackend.
   (Thanks to `@cjsoftuk`_ for reporting the issue.)
+* Remove "sending a message from *sender* to *recipient*" from `AnymailError`
+  text, as this can unintentionally leak personal information into logs.
+  [Note that `AnymailError` *does* still include any error description
+  from your ESP, and this often contains email addresses and other content
+  from the sent message. If this is a concern, you can adjust Django's logging
+  config to limit collection from Anymail or implement custom PII filtering.]
+  (Thanks to `@coupa-anya`_ for reporting the issue.)
 
 
 v8.4
@@ -1257,6 +1264,7 @@ Features
 .. _@chrisgrande: https://github.com/chrisgrande
 .. _@cjsoftuk: https://github.com/cjsoftuk
 .. _@costela: https://github.com/costela
+.. _@coupa-anya: https://github.com/coupa-anya
 .. _@decibyte: https://github.com/decibyte
 .. _@dominik-lekse: https://github.com/dominik-lekse
 .. _@ewingrj: https://github.com/ewingrj

--- a/anymail/exceptions.py
+++ b/anymail/exceptions.py
@@ -39,25 +39,9 @@ class AnymailError(Exception):
         parts = [
             " ".join([str(arg) for arg in self.args]),
             self.describe_cause(),
-            self.describe_send(),
             self.describe_response(),
         ]
         return "\n".join(filter(None, parts))
-
-    def describe_send(self):
-        """Return a string describing the ESP send in self.email_message, or None"""
-        if self.email_message is None:
-            return None
-        description = "Sending a message"
-        try:
-            description += " to %s" % ','.join(self.email_message.to)
-        except AttributeError:
-            pass
-        try:
-            description += " from %s" % self.email_message.from_email
-        except AttributeError:
-            pass
-        return description
 
     def describe_response(self):
         """Return a formatted string of self.status_code and response, or None"""


### PR DESCRIPTION
Remove `AnymailError.describe_send`, which added sender and
recipient email addresses to every AnymailError message
(whether or not relevant to the error).

Addresses #245