### PR TITLE
Mailgun/SendGrid inbound: workaround Django filename issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,23 @@ vNext
 
 *Unreleased changes in main branch*
 
+Fixes
+~~~~~
+
+* **Mailgun and SendGrid inbound:** Work around a Django limitation that
+  drops attachments with certain filenames. The missing attachments
+  are now simply omitted from the resulting inbound message. (In earlier
+  releases, they would cause a MultiValueDictKeyError in Anymail's
+  inbound webhook.)
+
+  Anymail documentation now recommends using Mailgun's and SendGrid's "raw MIME"
+  inbound options, which avoid the problem and preserve all attachments.
+
+  See `Mailgun inbound <https://anymail.readthedocs.io/en/latest/esps/mailgun/#mailgun-inbound>`__
+  and `SendGrid inbound <https://anymail.readthedocs.io/en/latest/esps/sendgrid/#sendgrid-inbound>`__
+  for details. (Thanks to `@erikdrums`_ for reporting and helping investigate the problem.)
+
+
 Other
 ~~~~~
 
@@ -1299,6 +1316,7 @@ Features
 .. _@coupa-anya: https://github.com/coupa-anya
 .. _@decibyte: https://github.com/decibyte
 .. _@dominik-lekse: https://github.com/dominik-lekse
+.. _@erikdrums: https://github.com/erikdrums
 .. _@ewingrj: https://github.com/ewingrj
 .. _@fdemmer: https://github.com/fdemmer
 .. _@Flexonze: https://github.com/Flexonze

--- a/anymail/inbound.py
+++ b/anymail/inbound.py
@@ -99,7 +99,7 @@ class AnymailInboundMessage(Message):
     def inline_attachments(self):
         """dict of Content-ID: attachment (as MIMEPart objects)"""
         return {unquote(part['Content-ID']): part for part in self.walk()
-                if part.is_inline_attachment() and part['Content-ID']}
+                if part.is_inline_attachment() and part['Content-ID'] is not None}
 
     def get_address_header(self, header):
         """Return the value of header parsed into a (possibly-empty) list of EmailAddress objects"""
@@ -299,11 +299,11 @@ class AnymailInboundMessage(Message):
         # some sort of lazy attachment where the content is only pulled in if/when
         # requested (and then use file.chunks() to minimize memory usage)
         return cls.construct_attachment(
-            content_type=file.content_type,
+            content_type=getattr(file, 'content_type', None),
             content=file.read(),
-            filename=file.name,
+            filename=getattr(file, 'name', None),
             content_id=content_id,
-            charset=file.charset)
+            charset=getattr(file, 'charset', None))
 
     @classmethod
     def construct_attachment(cls, content_type, content,

--- a/docs/esps/sendgrid.rst
+++ b/docs/esps/sendgrid.rst
@@ -428,17 +428,24 @@ The Destination URL setting will be:
      * *random:random* is an :setting:`ANYMAIL_WEBHOOK_SECRET` shared secret
      * *yoursite.example.com* is your Django site
 
-Be sure the URL has a trailing slash. (SendGrid's inbound processing won't follow Django's
+You should enable SendGrid's "POST the raw, full MIME message" checkbox (see note below).
+And be sure the URL has a trailing slash. (SendGrid's inbound processing won't follow Django's
 :setting:`APPEND_SLASH` redirect.)
 
 If you want to use Anymail's normalized :attr:`~anymail.inbound.AnymailInboundMessage.spam_detected` and
 :attr:`~anymail.inbound.AnymailInboundMessage.spam_score` attributes, be sure to enable the "Check
 incoming emails for spam" checkbox.
 
-In most cases, you should enable SendGrid's "POST the raw, full MIME message" checkbox.
-Anymail should work either way (and you can change the option at any time), but enabling
-raw MIME will give the most accurate representation of *any* received email (including
-complex forms like multi-message mailing list digests).
+.. note::
+
+    Anymail supports either option for SendGrid's "POST the raw, full MIME message" checkbox, but
+    enabling this setting is preferred to get the most accurate representation of any received email.
+    Using raw MIME also avoids a limitation in Django's :mimetype:`multipart/form-data` handling
+    that can strip attachments with certain filenames.
+
+    .. versionchanged:: vNext
+       Leaving SendGrid's "full MIME" checkbox disabled is no longer recommended.
+
 
 .. _Inbound Parse Webhook:
    https://sendgrid.com/docs/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.html


### PR DESCRIPTION
Workaround for Django multipart/form-data limitation
where certain attachment filenames cause fields to be dropped
or to end up in request.POST rather than request.FILES.

Handle the MultiValueDictKeyError in inbound webhooks when
this has occurred. Also update docs to recommend avoiding
the problem by using Mailgun and SendGrid's "raw MIME" options.

Also handle reported cases of empty, duplicate keys in Mailgun's
content-id-map.

Fixes #272