### PR TITLE
Fix: Handle SubscriptionChange event in Postmark webhook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,19 @@ Release history
 ^^^^^^^^^^^^^^^
     ..  This extra heading level keeps the ToC from becoming unmanageably long
 
+vNext
+-----
+
+*Unreleased changes*
+
+Fixes
+~~~~~
+
+* **Postmark:** Handle Postmark's SubscriptionChange events as Anymail
+  unsubscribe, subscribe, or bounce tracking events, rather than "unknown".
+  (Thanks to `@puru02`_ for the fix.)
+
+
 v8.6 LTS
 --------
 
@@ -1344,6 +1357,7 @@ Features
 .. _@mbk-ok: https://github.com/mbk-ok
 .. _@mwheels: https://github.com/mwheels
 .. _@nuschk: https://github.com/nuschk
+.. _@puru02: https://github.com/puru02
 .. _@RignonNoel: https://github.com/RignonNoel
 .. _@sebashwa: https://github.com/sebashwa
 .. _@sebbacon: https://github.com/sebbacon

--- a/anymail/webhooks/postmark.py
+++ b/anymail/webhooks/postmark.py
@@ -34,6 +34,7 @@ class PostmarkTrackingWebhookView(PostmarkBaseWebhookView):
         'Delivery': EventType.DELIVERED,
         'Open': EventType.OPENED,
         'SpamComplaint': EventType.COMPLAINED,
+        'SubscriptionChange': EventType.UNSUBSCRIBED,
         'Inbound': EventType.INBOUND,  # future, probably
     }
 
@@ -61,6 +62,7 @@ class PostmarkTrackingWebhookView(PostmarkBaseWebhookView):
         'InboundError': (EventType.INBOUND_FAILED, None),
         'DMARCPolicy': (EventType.REJECTED, RejectReason.BLOCKED),
         'TemplateRenderingFailed': (EventType.FAILED, None),
+        'ManualSuppression': (EventType.REJECTED, None),
     }
 
     def esp_to_anymail_event(self, esp_event):
@@ -87,6 +89,16 @@ class PostmarkTrackingWebhookView(PostmarkBaseWebhookView):
                 event_type, reject_reason = self.event_types[esp_event['Type']]
             except KeyError:
                 pass
+        if event_type == EventType.UNSUBSCRIBED:
+            if esp_event['SuppressSending']:
+                # Postmark doesn't provide a way to distinguish between
+                # explicit unsubscribes and bounces
+                try:
+                    event_type, reject_reason = self.event_types[esp_event['SuppressionReason']]
+                except KeyError:
+                    pass
+            else:
+                event_type, reject_reason = self.event_types['Subscribe']
 
         recipient = getfirst(esp_event, ['Email', 'Recipient'], None)  # Email for bounce; Recipient for open
 

--- a/anymail/webhooks/postmark.py
+++ b/anymail/webhooks/postmark.py
@@ -62,7 +62,7 @@ class PostmarkTrackingWebhookView(PostmarkBaseWebhookView):
         'InboundError': (EventType.INBOUND_FAILED, None),
         'DMARCPolicy': (EventType.REJECTED, RejectReason.BLOCKED),
         'TemplateRenderingFailed': (EventType.FAILED, None),
-        'ManualSuppression': (EventType.REJECTED, None),
+        'ManualSuppression': (EventType.UNSUBSCRIBED, RejectReason.UNSUBSCRIBED),
     }
 
     def esp_to_anymail_event(self, esp_event):
@@ -103,7 +103,7 @@ class PostmarkTrackingWebhookView(PostmarkBaseWebhookView):
         recipient = getfirst(esp_event, ['Email', 'Recipient'], None)  # Email for bounce; Recipient for open
 
         try:
-            timestr = getfirst(esp_event, ['DeliveredAt', 'BouncedAt', 'ReceivedAt'])
+            timestr = getfirst(esp_event, ['DeliveredAt', 'BouncedAt', 'ReceivedAt', 'ChangedAt'])
         except KeyError:
             timestamp = None
         else:


### PR DESCRIPTION
Handle SubscriptionChange event in Postmark webhook.
This event was previously not handled and treated as event type Unknown.

The SuppressSending field indicates whether the SubscriptionChange was a deactivation or reactivation.

Postmark doesn't provide a consistent way to distinguish between explicit unsubscribes and bounces so a lot of bounced emails have event type sent to Unknown. This fix will prevent that and classify bounced, unsubscribed, and resubscribed emails correctly.

https://postmarkapp.com/developer/webhooks/subscription-change-webhook