### PR TITLE
Sendinblue: Support send_at

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,9 @@ Breaking changes
 Features
 ~~~~~~~~
 
+* **Sendinblue:** Support delayed sending using Anymail's `send_at` option.
+  (Thanks to `@dimitrisor`_ for noting Sendinblue's public beta release
+  of this capability.)
 * Support customizing the requests.Session for requests-based backends,
   and document how this can be used to mount an adapter that simplifies
   automatic retry logic. (Thanks to `@dgilmanAIDENTIFIED`_.)
@@ -1366,6 +1369,7 @@ Features
 .. _@coupa-anya: https://github.com/coupa-anya
 .. _@decibyte: https://github.com/decibyte
 .. _@dgilmanAIDENTIFIED: https://github.com/dgilmanAIDENTIFIED
+.. _@dimitrisor: https://github.com/dimitrisor
 .. _@dominik-lekse: https://github.com/dominik-lekse
 .. _@erikdrums: https://github.com/erikdrums
 .. _@ewingrj: https://github.com/ewingrj

--- a/anymail/backends/sendinblue.py
+++ b/anymail/backends/sendinblue.py
@@ -162,3 +162,10 @@ class SendinBluePayload(RequestsPayload):
     def set_metadata(self, metadata):
         # SendinBlue expects a single string payload
         self.data['headers']["X-Mailin-custom"] = self.serialize_json(metadata)
+
+    def set_send_at(self, send_at):
+        try:
+            start_time_iso = send_at.isoformat(timespec="milliseconds")
+        except (AttributeError, TypeError):
+            start_time_iso = send_at  # assume user already formatted
+        self.data['scheduledAt'] = start_time_iso

--- a/docs/esps/index.rst
+++ b/docs/esps/index.rst
@@ -40,7 +40,7 @@ Email Service Provider                        |Amazon SES|  |Mailgun|    |Mailje
 :attr:`~AnymailMessage.envelope_sender`       Yes           Domain only  Yes         Domain only  Yes         No          No          No            Yes
 :attr:`~AnymailMessage.metadata`              Yes           Yes          Yes         Yes          No          Yes         Yes         Yes           Yes
 :attr:`~AnymailMessage.merge_metadata`        No            Yes          Yes         Yes          No          Yes         Yes         No            Yes
-:attr:`~AnymailMessage.send_at`               No            Yes          No          Yes          No          No          Yes         No            Yes
+:attr:`~AnymailMessage.send_at`               No            Yes          No          Yes          No          No          Yes         Yes           Yes
 :attr:`~AnymailMessage.tags`                  Yes           Yes          Max 1 tag   Yes          Max 1 tag   Max 1 tag   Yes         Yes           Max 1 tag
 :attr:`~AnymailMessage.track_clicks`          No            Yes          Yes         Yes          No          Yes         Yes         No            Yes
 :attr:`~AnymailMessage.track_opens`           No            Yes          Yes         Yes          No          Yes         Yes         No            Yes

--- a/docs/esps/sendinblue.rst
+++ b/docs/esps/sendinblue.rst
@@ -78,18 +78,20 @@ set a message's :attr:`~anymail.message.AnymailMessage.esp_extra` to
 a `dict` that will be merged into the json sent to Sendinblue's
 `smtp/email API`_.
 
-Example:
+For example, you could set Sendinblue's *batchId* for use with
+their `batched scheduled sending`_:
 
     .. code-block:: python
 
         message.esp_extra = {
-            'hypotheticalFutureSendinblueParam': '2022',  # merged into send params
+            'batchId': '275d3289-d5cb-4768-9460-a990054b6c81',  # merged into send params
         }
 
 
 (You can also set `"esp_extra"` in Anymail's :ref:`global send defaults <send-defaults>`
 to apply it to all messages.)
 
+.. _batched scheduled sending: https://developers.sendinblue.com/docs/schedule-batch-sendings
 .. _smtp/email API: https://developers.sendinblue.com/v3.0/reference#sendtransacemail
 
 
@@ -141,8 +143,10 @@ Sendinblue can handle.
   as a JSON-encoded string using their :mailheader:`X-Mailin-custom` email header.
   The metadata is available in tracking webhooks.
 
-**No delayed sending**
-  Sendinblue does not support :attr:`~anymail.message.AnymailMessage.send_at`.
+**Delayed sending**
+  .. versionadded:: 9.0
+     Earlier versions of Anymail did not support :attr:`~anymail.message.AnymailMessage.send_at`
+     with Sendinblue.
 
 **No click-tracking or open-tracking options**
   Sendinblue does not provide a way to control open or click tracking for individual

--- a/tests/test_sendinblue_integration.py
+++ b/tests/test_sendinblue_integration.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from datetime import datetime, timedelta
 from email.utils import formataddr
 
 from django.test import SimpleTestCase, override_settings, tag
@@ -55,6 +56,7 @@ class SendinBlueBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         self.assertEqual(anymail_status.message_id, message_id)
 
     def test_all_options(self):
+        send_at = datetime.now() + timedelta(minutes=2)
         message = AnymailMessage(
             subject="Anymail SendinBlue all-options integration test",
             body="This is the text body",
@@ -66,6 +68,7 @@ class SendinBlueBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             headers={"X-Anymail-Test": "value", "X-Anymail-Count": 3},
 
             metadata={"meta1": "simple string", "meta2": 2},
+            send_at=send_at,
             tags=["tag 1", "tag 2"],
         )
         message.attach_alternative('<p>HTML content</p>', "text/html")  # SendinBlue requires an HTML body


### PR DESCRIPTION
Add support for delayed sending via
Sendinblue's public beta "scheduledAt"
parameter.

Closes #280