### PR TITLE
Test release version of Django 4.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,17 @@ Release history
 ^^^^^^^^^^^^^^^
     ..  This extra heading level keeps the ToC from becoming unmanageably long
 
+vNext
+-----
+
+*Unreleased changes*
+
+Other
+~~~~~
+
+* Test against Django 4.2 release.
+
+
 v9.1
 ----
 

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
-        # not yet registered: "Framework :: Django :: 4.2",
+        "Framework :: Django :: 4.2",
         "Environment :: Web Environment",
     ],
     long_description=long_description,

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,14 @@ envlist =
     # Factors: django-python-extras
     # Test lint, docs, earliest/latest Django first, to catch most errors early...
     lint
-    django41-py310-all
+    django42-py311-all
     django30-py36-all
     docs
     # ... then test all the other supported combinations:
+    # Django 4.2: Python 3.8, 3.9, 3.10, 3.11
+    django42-py{38,39,310,py38,py39}-all
     # Django 4.1: Python 3.8, 3.9, 3.10
-    django41-py{38,39,py38,py39}-all
+    django41-py{38,39,310,py38,py39}-all
     # Django 4.0: Python 3.8, 3.9, 3.10
     django40-py{38,39,310,py38,py39}-all
     # Django 3.2: Python 3.6, 3.7, 3.8, 3.9
@@ -20,12 +22,12 @@ envlist =
     # Django 3.0: Python 3.6, 3.7, 3.8, 3.9 (added in 3.0.11)
     django30-py{37,38,39,py38,py39}-all
     # ... then prereleases (if available) and current development:
-    # Django 4.2 alpha: Python 3.8, 3.9, 3.10, 3.11
-    django42-py{38,39,310,311,py38,py39}-all
+    # Django 5.0 alpha: Python 3.10+
+    #   [not yet in alpha] django50-py{310,311,py310,py311}-all
     # Django 5.0 dev: Python 3.10+
     djangoDev-py{310,311}-all
     # ... then partial installation (limit extras):
-    django41-py310-{none,amazon_ses,postal}
+    django42-py311-{none,amazon_ses,postal}
     # ... then older versions of some dependencies:
     django32-py37-all-old_urllib3
 
@@ -36,7 +38,8 @@ deps =
     django32: django~=3.2.0
     django40: django~=4.0.0
     django41: django~=4.1.0
-    django42: django~=4.2.0a0
+    django42: django~=4.2.0
+    django50: django~=5.0.0a0
     djangoDev: https://github.com/django/django/tarball/main
     old_urllib3: urllib3<1.25
 extras =


### PR DESCRIPTION
Django 4.2 has been released. (Tests no longer need to ask for prerelease version.)
