### PR TITLE
Workaround for postmark inbound test email can not be parsed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,12 @@ vNext
 
 *Unreleased changes*
 
+Fixes
+~~~~~
+
+* **Postmark:** Workaround for handling inbound test webhooks.
+  (`More info <https://github.com/anymail/django-anymail/issues/304>`__)
+
 Other
 ~~~~~
 

--- a/anymail/webhooks/postmark.py
+++ b/anymail/webhooks/postmark.py
@@ -169,7 +169,13 @@ class PostmarkInboundWebhookView(PostmarkBaseWebhookView):
         attachments = [
             AnymailInboundMessage.construct_attachment(
                 content_type=attachment["ContentType"],
-                content=attachment["Content"],
+                content=(
+                    attachment.get("Content")
+                    # WORKAROUND:
+                    # The test webhooks are not like their real webhooks
+                    # This allows the test webhooks to be parsed.
+                    or attachment["Data"]
+                ),
                 base64=True,
                 filename=attachment.get("Name", "") or None,
                 content_id=attachment.get("ContentID", "") or None,

--- a/tests/test_postmark_inbound.py
+++ b/tests/test_postmark_inbound.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY
 
 from django.test import tag
 
-from anymail.exceptions import AnymailConfigurationError
+from anymail.exceptions import AnymailConfigurationError, AnymailWarning
 from anymail.inbound import AnymailInboundMessage
 from anymail.signals import AnymailInboundEvent
 from anymail.webhooks.postmark import PostmarkInboundWebhookView
@@ -178,11 +178,14 @@ class PostmarkInboundTestCase(WebhookTestCase):
             ]
         }
 
-        response = self.client.post(
-            "/anymail/postmark/inbound/",
-            content_type="application/json",
-            data=json.dumps(raw_event),
-        )
+        with self.assertWarnsRegex(
+            AnymailWarning, r"Received a test webhook attachment. "
+        ):
+            response = self.client.post(
+                "/anymail/postmark/inbound/",
+                content_type="application/json",
+                data=json.dumps(raw_event),
+            )
         self.assertEqual(response.status_code, 200)
         kwargs = self.assert_handler_called_once_with(
             self.inbound_handler,


### PR DESCRIPTION
Recently we discussed the issue that Postmark's inbound test webhooks are not in the same format as real inbound webhooks. 

I have created a workaround for this issue. Now anymail will handle the events without crashing. 
Also it will raise a warning, so that the user might consider testing with a real event before going to production.

I did my best to make this change according to the quality standards of this project. If something is missing or changed let me know. 

Closes #304 