### PR TITLE
Tests: get tox py36 tests working again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,8 @@ jobs:
         run: |
           set -x
           python -VV
-          python -m pip install 'tox<4'
+          # Must pin virtualenv for tox py36 testenv:
+          python -m pip install 'tox<4' 'virtualenv<20.22.0'
           python -m tox --version
       - name: Test ${{ matrix.tox.name }}
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,12 @@ Fixes
 * **Postmark:** Workaround for handling inbound test webhooks.
   (`More info <https://github.com/anymail/django-anymail/issues/304>`__)
 
+Deprecations
+~~~~~~~~~~~~
+
+* This will be the last Anymail release to support Python 3.6
+  (which reached end-of-life on 2021-12-23).
+
 Other
 ~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ requirements_dev = [
     "sphinx-rtd-theme",
     "tox",
     "twine",
+    "virtualenv<20.22.0",  # tox dependency, pinned for Python 3.6 tox testenv
     "wheel",
 ]
 


### PR DESCRIPTION
tox dependency virtualenv dropped support for creating Python 3.6 environments in a minor release. [1]

Announce deprecation of Anymail Python 3.6 support. Until that can take effect, pin an older version of virtualenv that still works for tox py36 testenv.

[1]: See https://github.com/pypa/virtualenv/pull/2548#issuecomment-1527278210 et seq