### PR TITLE
Fix empty strings in AnymailInboundMessage from/to/cc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,9 @@ vNext
 Fixes
 ~~~~~
 
+* **Postmark:** Fix spurious AnymailInvalidAddress in ``message.cc`` when
+  inbound message has no Cc recipients. (Thanks to `@Ecno92`_.)
+
 * **Postmark:** Workaround for handling inbound test webhooks.
   (`More info <https://github.com/anymail/django-anymail/issues/304>`__)
 
@@ -1428,6 +1431,7 @@ Features
 .. _@dgilmanAIDENTIFIED: https://github.com/dgilmanAIDENTIFIED
 .. _@dimitrisor: https://github.com/dimitrisor
 .. _@dominik-lekse: https://github.com/dominik-lekse
+.. _@Ecno92: https://github.com/Ecno92
 .. _@erikdrums: https://github.com/erikdrums
 .. _@ewingrj: https://github.com/ewingrj
 .. _@fdemmer: https://github.com/fdemmer

--- a/anymail/inbound.py
+++ b/anymail/inbound.py
@@ -113,7 +113,10 @@ class AnymailInboundMessage(Message):
         """
         values = self.get_all(header)
         if values is not None:
-            values = parse_address_list(values)
+            if "".join(values).strip() == "":
+                values = None
+            else:
+                values = parse_address_list(values)
         return values or []
 
     def get_date_header(self, header):

--- a/anymail/message.py
+++ b/anymail/message.py
@@ -1,8 +1,8 @@
 from email.mime.image import MIMEImage
-from email.utils import unquote
+from email.utils import make_msgid, unquote
 from pathlib import Path
 
-from django.core.mail import EmailMessage, EmailMultiAlternatives, make_msgid
+from django.core.mail import EmailMessage, EmailMultiAlternatives
 
 from .utils import UNSET
 

--- a/tests/test_inbound.py
+++ b/tests/test_inbound.py
@@ -307,6 +307,12 @@ class AnymailInboundMessageConveniencePropTests(SimpleTestCase):
         self.assertEqual(msg.to, [])
         self.assertEqual(msg.cc, [])
 
+        # Empty strings
+        msg = AnymailInboundMessage.construct(from_email="", to="", cc="")
+        self.assertIsNone(msg.from_email)
+        self.assertEqual(msg.to, [])
+        self.assertEqual(msg.cc, [])
+
     def test_body_props(self):
         msg = AnymailInboundMessage.construct(text="Test plaintext", html="Test HTML")
         self.assertEqual(msg.text, "Test plaintext")


### PR DESCRIPTION
Fix `AnymailInboundMessage.to`, `.cc`, `.from_email` when message was built with `AnymailInboundMessage.construct()` using empty strings for those params. (Postmark inbound relies on this.)

Fixes #307