### PR TITLE
Docs: fix RTD Sphinx build, update deps

### DIFF
--- a/docs/_readme/template.txt
+++ b/docs/_readme/template.txt
@@ -1,6 +1,6 @@
 %(head_prefix)s
 <!--
-  This approximates PyPI.org project page styling as of 5/2023,
+  This approximates PyPI.org project page styling as of 8/2023,
   and loads their compiled CSS that was in use at that time.
 
   (Styling seems to change more often than basic page structure,
@@ -17,9 +17,9 @@
 %(head)s
 <!-- template (stylesheet) omitted -->
 
-<link rel="stylesheet" href="/static/css/warehouse-ltr.a42ccb04.css">
-<link rel="stylesheet" href="/static/css/fontawesome.d37999f3.css">
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,600,600italic,700,700italic|Source+Code+Pro:500">
+<link rel="stylesheet" href="/static/css/warehouse-ltr.1dcaa944.css">
+<link rel="stylesheet" href="/static/css/fontawesome.b50b476c.css">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+3:400,400italic,600,600italic,700,700italic|Source+Code+Pro:500">
 <noscript>
   <link rel="stylesheet" href="/static/css/noscript.0673c9ea.css">
 </noscript>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ needs_sphinx = "1.0"
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.intersphinx", "sphinx.ext.extlinks"]
+extensions = ["sphinx.ext.intersphinx", "sphinx.ext.extlinks", "sphinx_rtd_theme"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -98,12 +98,7 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-if not ON_READTHEDOCS:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme  # this seems to come with sphinx; if not, pip install it
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# else readthedocs.org uses their theme by default (and specifying it here breaks them)
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -261,7 +256,7 @@ texinfo_documents = [
 # -- Options for extlinks ---------------------------------------------------
 
 extlinks = {
-    "pypi": ("https://pypi.org/project/%s/", ""),
+    "pypi": ("https://pypi.org/project/%s/", "%s"),
 }
 
 # -- Options for Intersphinx ------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,6 @@
 # Packages required only for building docs
 
-# (Pygments defaulted "python" to Python 2 before v2.5.0; it doesn't use semver)
-Pygments~=2.9.0
-readme-renderer~=37.3
-sphinx~=4.0
-sphinx-rtd-theme~=0.5.2
+Pygments~=2.16.1
+readme-renderer~=41.0
+sphinx~=7.2
+sphinx-rtd-theme~=1.3.0


### PR DESCRIPTION
ReadTheDocs builds have started failing.

Updating to latest sphinx-rtd-theme and Sphinx seems to solve the problem.
(Also update other docs dependencies.)