### PR TITLE
Fix global SEND_DEFAULTS merging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,14 @@ vNext
 
 *unreleased changes*
 
+Fixes
+~~~~~
+
+* Correctly merge global ``SEND_DEFAULTS`` with message ``esp_extra``
+  for ESP APIs that use a nested structure (including Mandrill and SparkPost).
+  Clarify intent of global defaults merging code for other message properties.
+  (Thanks to `@mounirmesselmeni`_ for reporting the issue.)
+
 Other
 ~~~~~
 
@@ -1571,6 +1579,7 @@ Features
 .. _@mark-mishyn: https://github.com/mark-mishyn
 .. _@martinezleoml: https://github.com/martinezleoml
 .. _@mbk-ok: https://github.com/mbk-ok
+.. _@mounirmesselmeni: https://github.com/mounirmesselmeni
 .. _@mwheels: https://github.com/mwheels
 .. _@nuschk: https://github.com/nuschk
 .. _@puru02: https://github.com/puru02

--- a/anymail/webhooks/mailgun.py
+++ b/anymail/webhooks/mailgun.py
@@ -21,8 +21,8 @@ from ..signals import (
 )
 from ..utils import (
     UNSET,
-    combine,
     get_anymail_setting,
+    merge_dicts_shallow,
     parse_single_address,
     querydict_getfirst,
 )
@@ -341,7 +341,9 @@ class MailgunTrackingWebhookView(MailgunBaseWebhookView):
             if len(variables) >= 1:
                 # Each X-Mailgun-Variables value is JSON. Parse and merge them all into
                 # single dict:
-                metadata = combine(*[json.loads(value) for value in variables])
+                metadata = merge_dicts_shallow(
+                    *[json.loads(value) for value in variables]
+                )
 
         elif event_type in self._known_legacy_event_fields:
             # For other events, we must extract from the POST fields, ignoring known


### PR DESCRIPTION
Fixes merging global `SEND_DEFAULTS`
with message `esp_extra` for ESP APIs
that use nested payload structures.
And clarifies intent for other properties.

Fixes #338