### PR TITLE
Resend: support batch send

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Features
 
 * **Brevo:** Add support for batch sending
   (`docs <https://anymail.dev/en/latest/esps/brevo/#batch-sending-merge-and-esp-templates>`__).
+* **Resend:** Add support for batch sending
+  (`docs <https://anymail.dev/en/latest/esps/resend/#batch-sending-merge-and-esp-templates>`__).
 
 
 v10.2

--- a/docs/esps/esp-feature-matrix.csv
+++ b/docs/esps/esp-feature-matrix.csv
@@ -2,7 +2,7 @@ Email Service Provider,:ref:`amazon-ses-backend`,:ref:`brevo-backend`,:ref:`mail
 .. rubric:: :ref:`Anymail send options <anymail-send-options>`,,,,,,,,,,,
 :attr:`~AnymailMessage.envelope_sender`,Yes,No,No,Domain only,Yes,Domain only,Yes,No,No,No,Yes
 :attr:`~AnymailMessage.metadata`,Yes,Yes,No,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_metadata`,No,Yes,No,Yes,Yes,Yes,No,Yes,No,Yes,Yes
+:attr:`~AnymailMessage.merge_metadata`,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes
 :attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,Yes,No,No,No,Yes,Yes
 :attr:`~AnymailMessage.tags`,Yes,Yes,Yes,Yes,Max 1 tag,Yes,Max 1 tag,Max 1 tag,Yes,Yes,Max 1 tag
 :attr:`~AnymailMessage.track_clicks`,No,No,Yes,Yes,Yes,Yes,No,Yes,No,Yes,Yes

--- a/docs/esps/resend.rst
+++ b/docs/esps/resend.rst
@@ -176,16 +176,6 @@ anyway---see :ref:`unsupported-features`.
   tracking webhook using :ref:`esp_event <resend-esp-event>`. (The linked
   sections below include examples.)
 
-**No stored templates or batch sending**
-  Resend does not currently offer ESP stored templates or merge capabilities,
-  including Anymail's
-  :attr:`~anymail.message.AnymailMessage.merge_data`,
-  :attr:`~anymail.message.AnymailMessage.merge_global_data`,
-  :attr:`~anymail.message.AnymailMessage.merge_metadata`, and
-  :attr:`~anymail.message.AnymailMessage.template_id` features.
-  (Resend's current template feature is only supported in node.js,
-  using templates that are rendered in their API client.)
-
 **No click/open tracking overrides**
   Resend does not support :attr:`~anymail.message.AnymailMessage.track_clicks`
   or :attr:`~anymail.message.AnymailMessage.track_opens`. Its
@@ -240,6 +230,47 @@ values directly to Resend's `send-email API`_. Example:
               {"name": "Feature_Flag_1", "value": "test_22_a"},
           ],
       }
+
+
+.. _resend-templates:
+
+Batch sending/merge and ESP templates
+-------------------------------------
+
+.. versionadded:: 10.3
+
+    Support for batch sending with
+    :attr:`~anymail.message.AnymailMessage.merge_metadata`.
+
+Resend supports :ref:`batch sending <batch-send>` (where each *To*
+recipient sees only their own email address). It also supports
+per-recipient metadata with batch sending.
+
+Set Anymail's normalized :attr:`~anymail.message.AnymailMessage.merge_metadata`
+attribute to use Resend's batch-send API:
+
+  .. code-block:: python
+
+      message = EmailMessage(
+          to=["alice@example.com", "Bob <bob@example.com>"],
+          from_email="...", subject="...", body="..."
+      )
+      message.merge_metadata = {
+          'alice@example.com': {'user_id': "12345"},
+          'bob@example.com': {'user_id': "54321"},
+      }
+
+Resend does not currently offer :ref:`ESP stored templates <esp-stored-templates>`
+or merge capabilities, so does not support Anymail's
+:attr:`~anymail.message.AnymailMessage.merge_data`,
+:attr:`~anymail.message.AnymailMessage.merge_global_data`, or
+:attr:`~anymail.message.AnymailMessage.template_id` message attributes.
+(Resend's current template feature is only supported in node.js,
+using templates that are rendered in their API client.)
+
+(Setting :attr:`~anymail.message.AnymailMessage.merge_data` to an empty
+dict will also invoke batch send, but trying to supply merge data for
+any recipient will raise an :exc:`~anymail.exceptions.AnymailUnsupportedFeature` error.)
 
 
 .. _resend-webhooks:


### PR DESCRIPTION
Add support for `merge_metadata` and new Resend email/batch API.

Closes #356 