### PR TITLE
Docs: fix broken links in search results

### DIFF
--- a/docs/_static/anymail-theme.css
+++ b/docs/_static/anymail-theme.css
@@ -25,11 +25,11 @@ table.sticky-left th:first-of-type[colspan] > p {
 
    This makes code.xref's inside an <a> use standard link coloring instead.
 
-   [1]: https://github.com/rtfd/sphinx_rtd_theme/blob/0.4.2/sass/_theme_rst.sass#L293-L294
-   [2]: https://github.com/rtfd/sphinx_rtd_theme/blob/0.4.2/sass/_theme_rst.sass#L287-L289
+   [1]: https://github.com/readthedocs/sphinx_rtd_theme/blob/2.0.0/src/sass/_theme_rst.sass#L484
+   [2]: https://github.com/readthedocs/sphinx_rtd_theme/blob/2.0.0/src/sass/_theme_rst.sass#L477
 
-   Related: https://github.com/rtfd/sphinx_rtd_theme/issues/153
-            https://github.com/rtfd/sphinx_rtd_theme/issues/92
+   Related: https://github.com/readthedocs/sphinx_rtd_theme/issues/153
+            https://github.com/readthedocs/sphinx_rtd_theme/issues/92
 */
 .rst-content a code.xref {
   color: inherit;

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@
 Pygments~=2.16.1
 readme-renderer~=41.0
 sphinx~=7.2
-sphinx-rtd-theme~=1.3.0
+sphinx-rtd-theme~=2.0.0


### PR DESCRIPTION
Upgrade to sphinx-rtd-theme 2.0.x
to fix broken links in search results
(for searches rendered client side).

See https://github.com/sphinx-doc/sphinx/issues/11608#issuecomment-1684410476 and https://github.com/readthedocs/sphinx_rtd_theme/pull/1507