### PR TITLE
Fixed #361: AttributeError in mailgun webhooks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,13 @@ Features
   (Thanks to `@Arondit`_ for the implementation.)
 
 
+Fixes
+~~~~~
+
+* **Mailgun:** Avoid an error when Mailgun posts null delivery-status
+  to the event tracking webhook. (Thanks to `@izimobil`_ for the fix.)
+
+
 v10.2
 -----
 
@@ -1595,6 +1602,7 @@ Features
 .. _@Flexonze: https://github.com/Flexonze
 .. _@gdvalderrama: https://github.com/gdvalderrama
 .. _@Honza-m: https://github.com/Honza-m
+.. _@izimobil: https://github.com/izimobil
 .. _@janneThoft: https://github.com/janneThoft
 .. _@jc-ee: https://github.com/jc-ee
 .. _@joshkersey: https://github.com/joshkersey

--- a/anymail/webhooks/mailgun.py
+++ b/anymail/webhooks/mailgun.py
@@ -172,12 +172,12 @@ class MailgunTrackingWebhookView(MailgunBaseWebhookView):
 
         try:
             delivery_status = event_data["delivery-status"]
-        except KeyError:
-            description = None
-            mta_response = None
-        else:
+            # if delivery_status is None, an AttributeError will be raised
             description = delivery_status.get("description")
             mta_response = delivery_status.get("message")
+        except (KeyError, AttributeError):
+            description = None
+            mta_response = None
 
         if "reason" in event_data:
             reject_reason = self.reject_reasons.get(

--- a/tests/test_mailgun_webhooks.py
+++ b/tests/test_mailgun_webhooks.py
@@ -630,54 +630,13 @@ class MailgunTestCase(WebhookTestCase):
         self.assertEqual(event.event_type, "clicked")
         self.assertEqual(event.click_url, "https://example.com/test")
 
-    def test_no_delivery_status(self):
+    def test_delivery_status_is_none_event(self):
         raw_event = mailgun_sign_payload(
             {
-                "signature": {
-                    "timestamp": "1534108637",
-                    "token": "651869375b9df3c98fc15c4889b102119add1235c38fc92824",
-                    "signature": "...",
-                },
                 "event-data": {
-                    "tags": [],
-                    "timestamp": 1534108637.153125,
-                    "storage": {
-                        "url": "https://sw.api.mailgun.net/v3/domains/"
-                        "example.org/messages/eyJwI...",
-                        "key": "eyJwI...",
-                    },
-                    "recipient-domain": "example.com",
-                    "id": "hTWCTD81RtiDN-...",
-                    "campaigns": [],
-                    "user-variables": {},
-                    "flags": {
-                        "is-routed": False,
-                        "is-authenticated": True,
-                        "is-system-test": False,
-                        "is-test-mode": False,
-                    },
-                    "log-level": "info",
-                    "envelope": {
-                        "sending-ip": "333.123.123.200",
-                        "sender": "test@example.org",
-                        "transport": "smtp",
-                        "targets": "recipient@example.com",
-                    },
-                    "message": {
-                        "headers": {
-                            "to": "recipient@example.com",
-                            "message-id": "20180812211713.1.DF5966851B4BAA99"
-                            "@example.org",
-                            "from": "test@example.org",
-                            "subject": "Testing",
-                        },
-                        "attachments": [],
-                        "size": 809,
-                    },
-                    "recipient": "recipient@example.com",
                     "event": "accepted",
                     "delivery-status": None,
-                },
+                }
             }
         )
         response = self.client.post(

--- a/tests/test_mailgun_webhooks.py
+++ b/tests/test_mailgun_webhooks.py
@@ -630,6 +630,63 @@ class MailgunTestCase(WebhookTestCase):
         self.assertEqual(event.event_type, "clicked")
         self.assertEqual(event.click_url, "https://example.com/test")
 
+    def test_no_delivery_status(self):
+        raw_event = mailgun_sign_payload(
+            {
+                "signature": {
+                    "timestamp": "1534108637",
+                    "token": "651869375b9df3c98fc15c4889b102119add1235c38fc92824",
+                    "signature": "...",
+                },
+                "event-data": {
+                    "tags": [],
+                    "timestamp": 1534108637.153125,
+                    "storage": {
+                        "url": "https://sw.api.mailgun.net/v3/domains/"
+                        "example.org/messages/eyJwI...",
+                        "key": "eyJwI...",
+                    },
+                    "recipient-domain": "example.com",
+                    "id": "hTWCTD81RtiDN-...",
+                    "campaigns": [],
+                    "user-variables": {},
+                    "flags": {
+                        "is-routed": False,
+                        "is-authenticated": True,
+                        "is-system-test": False,
+                        "is-test-mode": False,
+                    },
+                    "log-level": "info",
+                    "envelope": {
+                        "sending-ip": "333.123.123.200",
+                        "sender": "test@example.org",
+                        "transport": "smtp",
+                        "targets": "recipient@example.com",
+                    },
+                    "message": {
+                        "headers": {
+                            "to": "recipient@example.com",
+                            "message-id": "20180812211713.1.DF5966851B4BAA99"
+                            "@example.org",
+                            "from": "test@example.org",
+                            "subject": "Testing",
+                        },
+                        "attachments": [],
+                        "size": 809,
+                    },
+                    "recipient": "recipient@example.com",
+                    "event": "accepted",
+                    "delivery-status": None,
+                },
+            }
+        )
+        response = self.client.post(
+            "/anymail/mailgun/tracking/",
+            data=json.dumps(raw_event),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
 
 @tag("mailgun")
 @override_settings(ANYMAIL_MAILGUN_WEBHOOK_SIGNING_KEY=TEST_WEBHOOK_SIGNING_KEY)


### PR DESCRIPTION
This fixes the case of delivery-status being None in the event data posted to mailgun webhook handler.
See: #361