### PR TITLE
Brevo: Rename SendinBlue to Brevo

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,6 +40,7 @@ jobs:
         # combination, to avoid rapidly consuming the testing accounts' entire send allotments.
         config:
           - { tox: django41-py310-amazon_ses, python: "3.10" }
+          - { tox: django41-py310-brevo, python: "3.10" }
           - { tox: django41-py310-mailersend, python: "3.10" }
           - { tox: django41-py310-mailgun, python: "3.10" }
           - { tox: django41-py310-mailjet, python: "3.10" }
@@ -48,7 +49,6 @@ jobs:
           - { tox: django41-py310-postmark, python: "3.10" }
           - { tox: django41-py310-resend, python: "3.10" }
           - { tox: django41-py310-sendgrid, python: "3.10" }
-          - { tox: django41-py310-sendinblue, python: "3.10" }
           - { tox: django41-py310-sparkpost, python: "3.10" }
           - { tox: django41-py310-unisender_go, python: "3.10" }
 
@@ -77,6 +77,8 @@ jobs:
           ANYMAIL_TEST_AMAZON_SES_DOMAIN: ${{ secrets.ANYMAIL_TEST_AMAZON_SES_DOMAIN }}
           ANYMAIL_TEST_AMAZON_SES_REGION_NAME: ${{ secrets.ANYMAIL_TEST_AMAZON_SES_REGION_NAME }}
           ANYMAIL_TEST_AMAZON_SES_SECRET_ACCESS_KEY: ${{ secrets.ANYMAIL_TEST_AMAZON_SES_SECRET_ACCESS_KEY }}
+          ANYMAIL_TEST_BREVO_API_KEY: ${{ secrets.ANYMAIL_TEST_BREVO_API_KEY }}
+          ANYMAIL_TEST_BREVO_DOMAIN: ${{ vars.ANYMAIL_TEST_BREVO_DOMAIN }}
           ANYMAIL_TEST_MAILERSEND_API_TOKEN: ${{ secrets.ANYMAIL_TEST_MAILERSEND_API_TOKEN }}
           ANYMAIL_TEST_MAILERSEND_DOMAIN: ${{ secrets.ANYMAIL_TEST_MAILERSEND_DOMAIN }}
           ANYMAIL_TEST_MAILGUN_API_KEY: ${{ secrets.ANYMAIL_TEST_MAILGUN_API_KEY }}
@@ -94,8 +96,6 @@ jobs:
           ANYMAIL_TEST_SENDGRID_API_KEY: ${{ secrets.ANYMAIL_TEST_SENDGRID_API_KEY }}
           ANYMAIL_TEST_SENDGRID_DOMAIN: ${{ secrets.ANYMAIL_TEST_SENDGRID_DOMAIN }}
           ANYMAIL_TEST_SENDGRID_TEMPLATE_ID: ${{ secrets.ANYMAIL_TEST_SENDGRID_TEMPLATE_ID }}
-          ANYMAIL_TEST_SENDINBLUE_API_KEY: ${{ secrets.ANYMAIL_TEST_SENDINBLUE_API_KEY }}
-          ANYMAIL_TEST_SENDINBLUE_DOMAIN: ${{ secrets.ANYMAIL_TEST_SENDINBLUE_DOMAIN }}
           ANYMAIL_TEST_SPARKPOST_API_KEY: ${{ secrets.ANYMAIL_TEST_SPARKPOST_API_KEY }}
           ANYMAIL_TEST_SPARKPOST_DOMAIN: ${{ secrets.ANYMAIL_TEST_SPARKPOST_DOMAIN }}
           ANYMAIL_TEST_UNISENDER_GO_API_KEY: ${{ secrets.ANYMAIL_TEST_UNISENDER_GO_API_KEY }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,16 @@ vNext
 
 *unreleased changes*
 
+Deprecations
+~~~~~~~~~~~~
+
+* **SendinBlue:** Rename "SendinBlue" to "Brevo" throughout Anymail's code.
+  This affects the email backend name, settings names, and webhook URLs.
+  The old names will continue to work for now, but are deprecated. See
+  `Updating code from SendinBlue to Brevo <https://anymail.dev/en/latest/esps/brevo/#brevo-rename>`__
+  for details.
+
+
 Features
 ~~~~~~~~
 

--- a/anymail/backends/sendinblue.py
+++ b/anymail/backends/sendinblue.py
@@ -1,0 +1,20 @@
+import warnings
+
+from ..exceptions import AnymailDeprecationWarning
+from .brevo import EmailBackend as BrevoEmailBackend
+
+
+class EmailBackend(BrevoEmailBackend):
+    """
+    Deprecated compatibility backend for old Brevo name "SendinBlue".
+    """
+
+    esp_name = "SendinBlue"
+
+    def __init__(self, **kwargs):
+        warnings.warn(
+            "`anymail.backends.sendinblue.EmailBackend` has been renamed"
+            " `anymail.backends.brevo.EmailBackend`.",
+            AnymailDeprecationWarning,
+        )
+        super().__init__(**kwargs)

--- a/anymail/urls.py
+++ b/anymail/urls.py
@@ -16,6 +16,10 @@ from .webhooks.postal import PostalInboundWebhookView, PostalTrackingWebhookView
 from .webhooks.postmark import PostmarkInboundWebhookView, PostmarkTrackingWebhookView
 from .webhooks.resend import ResendTrackingWebhookView
 from .webhooks.sendgrid import SendGridInboundWebhookView, SendGridTrackingWebhookView
+from .webhooks.sendinblue import (
+    SendinBlueInboundWebhookView,
+    SendinBlueTrackingWebhookView,
+)
 from .webhooks.sparkpost import (
     SparkPostInboundWebhookView,
     SparkPostTrackingWebhookView,
@@ -69,6 +73,12 @@ urlpatterns = [
         name="sendgrid_inbound_webhook",
     ),
     path(
+        # Compatibility for old SendinBlue esp_name; use Brevo in new code
+        "sendinblue/inbound/",
+        SendinBlueInboundWebhookView.as_view(),
+        name="sendinblue_inbound_webhook",
+    ),
+    path(
         "sparkpost/inbound/",
         SparkPostInboundWebhookView.as_view(),
         name="sparkpost_inbound_webhook",
@@ -117,6 +127,12 @@ urlpatterns = [
         "sendgrid/tracking/",
         SendGridTrackingWebhookView.as_view(),
         name="sendgrid_tracking_webhook",
+    ),
+    path(
+        # Compatibility for old SendinBlue esp_name; use Brevo in new code
+        "sendinblue/tracking/",
+        SendinBlueTrackingWebhookView.as_view(),
+        name="sendinblue_tracking_webhook",
     ),
     path(
         "sparkpost/tracking/",

--- a/anymail/urls.py
+++ b/anymail/urls.py
@@ -4,6 +4,7 @@ from .webhooks.amazon_ses import (
     AmazonSESInboundWebhookView,
     AmazonSESTrackingWebhookView,
 )
+from .webhooks.brevo import BrevoInboundWebhookView, BrevoTrackingWebhookView
 from .webhooks.mailersend import (
     MailerSendInboundWebhookView,
     MailerSendTrackingWebhookView,
@@ -15,10 +16,6 @@ from .webhooks.postal import PostalInboundWebhookView, PostalTrackingWebhookView
 from .webhooks.postmark import PostmarkInboundWebhookView, PostmarkTrackingWebhookView
 from .webhooks.resend import ResendTrackingWebhookView
 from .webhooks.sendgrid import SendGridInboundWebhookView, SendGridTrackingWebhookView
-from .webhooks.sendinblue import (
-    SendinBlueInboundWebhookView,
-    SendinBlueTrackingWebhookView,
-)
 from .webhooks.sparkpost import (
     SparkPostInboundWebhookView,
     SparkPostTrackingWebhookView,
@@ -31,6 +28,11 @@ urlpatterns = [
         "amazon_ses/inbound/",
         AmazonSESInboundWebhookView.as_view(),
         name="amazon_ses_inbound_webhook",
+    ),
+    path(
+        "brevo/inbound/",
+        BrevoInboundWebhookView.as_view(),
+        name="brevo_inbound_webhook",
     ),
     path(
         "mailersend/inbound/",
@@ -67,11 +69,6 @@ urlpatterns = [
         name="sendgrid_inbound_webhook",
     ),
     path(
-        "sendinblue/inbound/",
-        SendinBlueInboundWebhookView.as_view(),
-        name="sendinblue_inbound_webhook",
-    ),
-    path(
         "sparkpost/inbound/",
         SparkPostInboundWebhookView.as_view(),
         name="sparkpost_inbound_webhook",
@@ -80,6 +77,11 @@ urlpatterns = [
         "amazon_ses/tracking/",
         AmazonSESTrackingWebhookView.as_view(),
         name="amazon_ses_tracking_webhook",
+    ),
+    path(
+        "brevo/tracking/",
+        BrevoTrackingWebhookView.as_view(),
+        name="brevo_tracking_webhook",
     ),
     path(
         "mailersend/tracking/",
@@ -115,11 +117,6 @@ urlpatterns = [
         "sendgrid/tracking/",
         SendGridTrackingWebhookView.as_view(),
         name="sendgrid_tracking_webhook",
-    ),
-    path(
-        "sendinblue/tracking/",
-        SendinBlueTrackingWebhookView.as_view(),
-        name="sendinblue_tracking_webhook",
     ),
     path(
         "sparkpost/tracking/",

--- a/anymail/webhooks/sendinblue.py
+++ b/anymail/webhooks/sendinblue.py
@@ -1,0 +1,38 @@
+import warnings
+
+from ..exceptions import AnymailDeprecationWarning
+from .brevo import BrevoInboundWebhookView, BrevoTrackingWebhookView
+
+
+class SendinBlueTrackingWebhookView(BrevoTrackingWebhookView):
+    """
+    Deprecated compatibility tracking webhook for old Brevo name "SendinBlue".
+    """
+
+    esp_name = "SendinBlue"
+
+    def __init__(self, **kwargs):
+        warnings.warn(
+            "Anymail's SendinBlue webhook URLs are deprecated."
+            " Update your Brevo transactional email webhook URL to change"
+            " 'anymail/sendinblue' to 'anymail/brevo'.",
+            AnymailDeprecationWarning,
+        )
+        super().__init__(**kwargs)
+
+
+class SendinBlueInboundWebhookView(BrevoInboundWebhookView):
+    """
+    Deprecated compatibility inbound webhook for old Brevo name "SendinBlue".
+    """
+
+    esp_name = "SendinBlue"
+
+    def __init__(self, **kwargs):
+        warnings.warn(
+            "Anymail's SendinBlue webhook URLs are deprecated."
+            " Update your Brevo inbound webhook URL to change"
+            " 'anymail/sendinblue' to 'anymail/brevo'.",
+            AnymailDeprecationWarning,
+        )
+        super().__init__(**kwargs)

--- a/docs/esps/brevo.rst
+++ b/docs/esps/brevo.rst
@@ -4,14 +4,24 @@
 Brevo
 =====
 
+.. Docs note: esps/sendinblue is redirected to esps/brevo in ReadTheDocs config.
+   Please preserve existing _sendinblue-* ref labels, so that redirected link
+   anchors work properly (in old links from external sites). E.g.:
+     an old link:   https://anymail.dev/en/stable/esps/sendinblue#sendinblue-templates
+     redirects to:  https://anymail.dev/en/stable/esps/brevo#sendinblue-templates
+     which is also: https://anymail.dev/en/stable/esps/brevo#brevo-templates
+   (There's no need to create _sendinblue-* duplicates of any new _brevo-* labels.)
+
 Anymail integrates with the `Brevo`_ email service (formerly Sendinblue), using their `API v3`_.
 Brevo's transactional API does not support some basic email features, such as
-inline images. Be sure to review the :ref:`limitations <sendinblue-limitations>` below.
+inline images. Be sure to review the :ref:`limitations <brevo-limitations>` below.
 
-.. versionchanged:: 10.1
+.. versionchanged:: 10.3
 
-   Brevo was called "Sendinblue" until May, 2023. To avoid unnecessary code changes,
-   Anymail still uses the old name in code (settings, backend, webhook urls, etc.).
+   SendinBlue rebranded as Brevo in May, 2023. Anymail 10.3 uses the new
+   name throughout its code; earlier versions used the old name. Code that
+   refers to "SendinBlue" should continue to work, but is now deprecated.
+   See :ref:`brevo-rename` for details.
 
 .. important::
 
@@ -36,14 +46,14 @@ To use Anymail's Brevo backend, set:
 
   .. code-block:: python
 
-      EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"
+      EMAIL_BACKEND = "anymail.backends.brevo.EmailBackend"
 
 in your settings.py.
 
 
-.. setting:: ANYMAIL_SENDINBLUE_API_KEY
+.. setting:: ANYMAIL_BREVO_API_KEY
 
-.. rubric:: SENDINBLUE_API_KEY
+.. rubric:: BREVO_API_KEY
 
 The API key can be retrieved from your Brevo `SMTP & API settings`_ on the
 "API Keys" tab (don't try to use an SMTP key). Required.
@@ -55,23 +65,23 @@ Anymail. If you don't see a v3 key listed, use "Create a New API Key".)
 
       ANYMAIL = {
           ...
-          "SENDINBLUE_API_KEY": "<your v3 API key>",
+          "BREVO_API_KEY": "<your v3 API key>",
       }
 
-Anymail will also look for ``SENDINBLUE_API_KEY`` at the
-root of the settings file if neither ``ANYMAIL["SENDINBLUE_API_KEY"]``
-nor ``ANYMAIL_SENDINBLUE_API_KEY`` is set.
+Anymail will also look for ``BREVO_API_KEY`` at the
+root of the settings file if neither ``ANYMAIL["BREVO_API_KEY"]``
+nor ``ANYMAIL_BREVO_API_KEY`` is set.
 
 .. _SMTP & API settings: https://app.brevo.com/settings/keys/api
 
 
-.. setting:: ANYMAIL_SENDINBLUE_API_URL
+.. setting:: ANYMAIL_BREVO_API_URL
 
-.. rubric:: SENDINBLUE_API_URL
+.. rubric:: BREVO_API_URL
 
 The base url for calling the Brevo API.
 
-The default is ``SENDINBLUE_API_URL = "https://api.brevo.com/v3/"``
+The default is ``BREVO_API_URL = "https://api.brevo.com/v3/"``
 (It's unlikely you would need to change this.)
 
 .. versionchanged:: 10.1
@@ -79,6 +89,7 @@ The default is ``SENDINBLUE_API_URL = "https://api.brevo.com/v3/"``
    Earlier Anymail releases used ``https://api.sendinblue.com/v3/``.
 
 
+.. _brevo-esp-extra:
 .. _sendinblue-esp-extra:
 
 esp_extra support
@@ -106,6 +117,7 @@ to apply it to all messages.)
 .. _smtp/email API: https://developers.brevo.com/reference/sendtransacemail
 
 
+.. _brevo-limitations:
 .. _sendinblue-limitations:
 
 Limitations and quirks
@@ -192,6 +204,7 @@ Brevo can handle.
   on individual messages.
 
 
+.. _brevo-templates:
 .. _sendinblue-templates:
 
 Batch sending/merge and ESP templates
@@ -267,9 +280,9 @@ message's headers: ``message.extra_headers = {"idempotencyKey": "...uuid..."}``.
 
 .. caution::
 
-    **Sendinblue "old template language" not supported**
+    **"Old template language" not supported**
 
-    Sendinblue once supported two different template styles: a "new" template
+    Brevo once supported two different template styles: a "new" template
     language that uses Django-like template syntax (with ``{{ param.NAME }}``
     substitutions), and an "old" template language that used percent-delimited
     ``%NAME%`` substitutions.
@@ -299,17 +312,18 @@ message's headers: ``message.extra_headers = {"idempotencyKey": "...uuid..."}``.
     https://help.brevo.com/hc/en-us/articles/360000991960
 
 
+.. _brevo-webhooks:
 .. _sendinblue-webhooks:
 
 Status tracking webhooks
 ------------------------
 
 If you are using Anymail's normalized :ref:`status tracking <event-tracking>`, add
-the url at Brevo's site under  `Transactional > Email > Settings > Webhook`_.
+the url at Brevo's site under `Transactional > Email > Settings > Webhook`_.
 
 The "URL to call" is:
 
-   :samp:`https://{random}:{random}@{yoursite.example.com}/anymail/sendinblue/tracking/`
+   :samp:`https://{random}:{random}@{yoursite.example.com}/anymail/brevo/tracking/`
 
      * *random:random* is an :setting:`ANYMAIL_WEBHOOK_SECRET` shared secret
      * *yoursite.example.com* is your Django site
@@ -336,10 +350,17 @@ For example, it's not uncommon to receive a "delivered" event before the corresp
 The event's :attr:`~anymail.signals.AnymailTrackingEvent.esp_event` field will be
 a `dict` of raw webhook data received from Brevo.
 
+.. versionchanged:: 10.3
+
+    Older Anymail versions used a tracking webhook URL containing "sendinblue" rather
+    than "brevo". The old URL will still work, but is deprecated. See :ref:`brevo-rename`
+    below.
+
 
 .. _Transactional > Email > Settings > Webhook: https://app-smtp.brevo.com/webhook
 
 
+.. _brevo-inbound:
 .. _sendinblue-inbound:
 
 Inbound webhook
@@ -353,7 +374,7 @@ guide to enable inbound service and add Anymail's inbound webhook.
 
 At the "Creating the webhook" step, set the ``"url"`` param to:
 
-   :samp:`https://{random}:{random}@{yoursite.example.com}/anymail/sendinblue/inbound/`
+   :samp:`https://{random}:{random}@{yoursite.example.com}/anymail/brevo/inbound/`
 
      * *random:random* is an :setting:`ANYMAIL_WEBHOOK_SECRET` shared secret
      * *yoursite.example.com* is your Django site
@@ -364,6 +385,12 @@ by entering your API key in "Header" field above the example, and then clicking
 "Try It!". The `webhooks management APIs`_ and `inbound events list API`_ can
 be helpful for diagnosing inbound issues.
 
+.. versionchanged:: 10.3
+
+    Older Anymail versions used an inbound webhook URL containing "sendinblue" rather
+    than "brevo". The old URL will still work, but is deprecated. See :ref:`brevo-rename`
+    below.
+
 
 .. _Inbound parsing webhooks:
     https://developers.brevo.com/docs/inbound-parse-webhooks
@@ -371,3 +398,101 @@ be helpful for diagnosing inbound issues.
     https://developers.brevo.com/reference/getwebhooks-1
 .. _inbound events list API:
     https://developers.brevo.com/reference/getinboundemailevents
+
+
+.. _brevo-rename:
+
+Updating code from SendinBlue to Brevo
+--------------------------------------
+
+SendinBlue rebranded as Brevo in May, 2023. Anymail 10.3 has switched
+to the new name.
+
+If your code refers to the old "sendinblue" name
+(in :setting:`!EMAIL_BACKEND` and :setting:`!ANYMAIL` settings, :attr:`!esp_name`
+checks, or elsewhere) you should update it to use "brevo" instead.
+If you are using Anymail's tracking or inbound webhooks, you should
+also update the webhook URLs you've configured at Brevo.
+
+For compatibility, code and URLs using the old name are still functional in Anymail.
+But they will generate deprecation warnings, and may be removed in a future release.
+
+To update your code:
+
+.. setting:: ANYMAIL_SENDINBLUE_API_KEY
+.. setting:: ANYMAIL_SENDINBLUE_API_URL
+
+1.  In your settings.py, update the :setting:`!EMAIL_BACKEND`
+    and rename any ``"SENDINBLUE_..."`` settings to ``"BREVO_..."``:
+
+    .. code-block:: diff
+
+      - EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"  # old
+      + EMAIL_BACKEND = "anymail.backends.brevo.EmailBackend"       # new
+
+        ANYMAIL = {
+            ...
+      -     "SENDINBLUE_API_KEY": "<your v3 API key>",  # old
+      +     "BREVO_API_KEY": "<your v3 API key>",       # new
+            # (Also change "SENDINBLUE_API_URL" to "BREVO_API_URL" if present)
+
+            # If you are using Brevo-specific global send defaults, change:
+      -     "SENDINBLUE_SEND_DEFAULTS" = {...},  # old
+      +     "BREVO_SEND_DEFAULTS" = {...},       # new
+        }
+
+2.  If you are using Anymail's status tracking webhook,
+    go to Brevo's dashboard (under `Transactional > Email > Settings > Webhook`_),
+    and change the end or the URL from ``.../anymail/sendinblue/tracking/``
+    to ``.../anymail/brevo/tracking/``. (Or use the code below to automate this.)
+
+    In your :ref:`tracking signal receiver function <signal-receivers>`,
+    if you are examining the ``esp_name`` parameter, the name will change
+    once you have updated the webhook URL. If you had been checking
+    whether ``esp_name == "SendinBlue"``, change that to check if
+    ``esp_name == "Brevo"``.
+
+3.  If you are using Anymail's inbound handling, update the inbound webhook
+    URL to change ``.../anymail/sendinblue/inbound/`` to ``.../anymail/brevo/inbound/``.
+    You will need to use Brevo's webhooks API to make the change---see below.
+
+    In your :ref:`inbound signal receiver function <inbound-signal-receivers>`,
+    if you are examining the ``esp_name`` parameter, the name will change
+    once you have updated the webhook URL. If you had been checking
+    whether ``esp_name == "SendinBlue"``, change that to check if
+    ``esp_name == "Brevo"``.
+
+That should be everything, but to double check you may want to search your
+code for any remaining references to "sendinblue" (case-insensitive).
+(E.g., ``grep -r -i sendinblue``.)
+
+To update both the tracking and inbound webhook URLs using Brevo's `webhooks API`_,
+you could run something like this Python code:
+
+.. code-block:: python
+
+    # Update Brevo webhook URLs to replace "anymail/sendinblue" with "anymail/brevo".
+    import requests
+    BREVO_API_KEY = "<your API key>"
+
+    headers = {
+        "accept": "application/json",
+        "api-key": BREVO_API_KEY,
+    }
+
+    response = requests.get("https://api.brevo.com/v3/webhooks", headers=headers)
+    response.raise_for_status()
+    webhooks = response.json()
+
+    for webhook in webhooks:
+        if "anymail/sendinblue" in webhook["url"]:
+            response = requests.put(
+                f"https://api.brevo.com/v3/webhooks/{webhook['id']}",
+                headers=headers,
+                json={
+                    "url": webhook["url"].replace("anymail/sendinblue", "anymail/brevo")
+                }
+            )
+            response.raise_for_status()
+
+.. _webhooks API: https://developers.brevo.com/reference/updatewebhook-1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
 # (For simplicity, requests is included in the base dependencies.)
 # (Do not use underscores in extra names: they get normalized to hyphens.)
 amazon-ses = ["boto3"]
+brevo = []
 mailersend = []
 mailgun = []
 mailjet = []

--- a/tests/test_brevo_inbound.py
+++ b/tests/test_brevo_inbound.py
@@ -7,15 +7,15 @@ from responses.matchers import header_matcher
 from anymail.exceptions import AnymailConfigurationError
 from anymail.inbound import AnymailInboundMessage
 from anymail.signals import AnymailInboundEvent
-from anymail.webhooks.sendinblue import SendinBlueInboundWebhookView
+from anymail.webhooks.brevo import BrevoInboundWebhookView
 
 from .utils import sample_email_content, sample_image_content
 from .webhook_cases import WebhookTestCase
 
 
-@tag("sendinblue")
-@override_settings(ANYMAIL_SENDINBLUE_API_KEY="test-api-key")
-class SendinBlueInboundTestCase(WebhookTestCase):
+@tag("brevo")
+@override_settings(ANYMAIL_BREVO_API_KEY="test-api-key")
+class BrevoInboundTestCase(WebhookTestCase):
     def test_inbound_basics(self):
         # Actual (sanitized) Brevo inbound message payload 7/2023
         raw_event = {
@@ -54,16 +54,16 @@ class SendinBlueInboundTestCase(WebhookTestCase):
         }
 
         response = self.client.post(
-            "/anymail/sendinblue/inbound/",
+            "/anymail/brevo/inbound/",
             content_type="application/json",
             data={"items": [raw_event]},
         )
         self.assertEqual(response.status_code, 200)
         kwargs = self.assert_handler_called_once_with(
             self.inbound_handler,
-            sender=SendinBlueInboundWebhookView,
+            sender=BrevoInboundWebhookView,
             event=ANY,
-            esp_name="SendinBlue",
+            esp_name="Brevo",
         )
         # AnymailInboundEvent
         event = kwargs["event"]
@@ -123,15 +123,15 @@ class SendinBlueInboundTestCase(WebhookTestCase):
             }
         }
         self.client.post(
-            "/anymail/sendinblue/inbound/",
+            "/anymail/brevo/inbound/",
             content_type="application/json",
             data={"items": [raw_event]},
         )
         kwargs = self.assert_handler_called_once_with(
             self.inbound_handler,
-            sender=SendinBlueInboundWebhookView,
+            sender=BrevoInboundWebhookView,
             event=ANY,
-            esp_name="SendinBlue",
+            esp_name="Brevo",
         )
         event = kwargs["event"]
         message = event.message
@@ -203,16 +203,16 @@ class SendinBlueInboundTestCase(WebhookTestCase):
         )
 
         response = self.client.post(
-            "/anymail/sendinblue/inbound/",
+            "/anymail/brevo/inbound/",
             content_type="application/json",
             data={"items": [raw_event]},
         )
         self.assertEqual(response.status_code, 200)
         kwargs = self.assert_handler_called_once_with(
             self.inbound_handler,
-            sender=SendinBlueInboundWebhookView,
+            sender=BrevoInboundWebhookView,
             event=ANY,
-            esp_name="SendinBlue",
+            esp_name="Brevo",
         )
         event = kwargs["event"]
         message = event.message
@@ -235,12 +235,12 @@ class SendinBlueInboundTestCase(WebhookTestCase):
 
     def test_misconfigured_tracking(self):
         errmsg = (
-            "You seem to have set SendinBlue's *tracking* webhook URL"
-            " to Anymail's SendinBlue *inbound* webhook URL."
+            "You seem to have set Brevo's *tracking* webhook URL"
+            " to Anymail's Brevo *inbound* webhook URL."
         )
         with self.assertRaisesMessage(AnymailConfigurationError, errmsg):
             self.client.post(
-                "/anymail/sendinblue/inbound/",
+                "/anymail/brevo/inbound/",
                 content_type="application/json",
                 data={"event": "delivered"},
             )

--- a/tests/test_brevo_integration.py
+++ b/tests/test_brevo_integration.py
@@ -10,39 +10,39 @@ from anymail.message import AnymailMessage
 
 from .utils import AnymailTestMixin
 
-ANYMAIL_TEST_SENDINBLUE_API_KEY = os.getenv("ANYMAIL_TEST_SENDINBLUE_API_KEY")
-ANYMAIL_TEST_SENDINBLUE_DOMAIN = os.getenv("ANYMAIL_TEST_SENDINBLUE_DOMAIN")
+ANYMAIL_TEST_BREVO_API_KEY = os.getenv("ANYMAIL_TEST_BREVO_API_KEY")
+ANYMAIL_TEST_BREVO_DOMAIN = os.getenv("ANYMAIL_TEST_BREVO_DOMAIN")
 
 
-@tag("sendinblue", "live")
+@tag("brevo", "live")
 @unittest.skipUnless(
-    ANYMAIL_TEST_SENDINBLUE_API_KEY and ANYMAIL_TEST_SENDINBLUE_DOMAIN,
-    "Set ANYMAIL_TEST_SENDINBLUE_API_KEY and ANYMAIL_TEST_SENDINBLUE_DOMAIN "
-    "environment variables to run SendinBlue integration tests",
+    ANYMAIL_TEST_BREVO_API_KEY and ANYMAIL_TEST_BREVO_DOMAIN,
+    "Set ANYMAIL_TEST_BREVO_API_KEY and ANYMAIL_TEST_BREVO_DOMAIN "
+    "environment variables to run Brevo integration tests",
 )
 @override_settings(
-    ANYMAIL_SENDINBLUE_API_KEY=ANYMAIL_TEST_SENDINBLUE_API_KEY,
-    ANYMAIL_SENDINBLUE_SEND_DEFAULTS=dict(),
-    EMAIL_BACKEND="anymail.backends.sendinblue.EmailBackend",
+    ANYMAIL_BREVO_API_KEY=ANYMAIL_TEST_BREVO_API_KEY,
+    ANYMAIL_BREVO_SEND_DEFAULTS=dict(),
+    EMAIL_BACKEND="anymail.backends.brevo.EmailBackend",
 )
-class SendinBlueBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
-    """SendinBlue v3 API integration tests
+class BrevoBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
+    """Brevo v3 API integration tests
 
-    SendinBlue doesn't have sandbox so these tests run
-    against the **live** SendinBlue API, using the
-    environment variable `ANYMAIL_TEST_SENDINBLUE_API_KEY` as the API key,
-    and `ANYMAIL_TEST_SENDINBLUE_DOMAIN` to construct sender addresses.
+    Brevo doesn't have sandbox so these tests run
+    against the **live** Brevo API, using the
+    environment variable `ANYMAIL_TEST_BREVO_API_KEY` as the API key,
+    and `ANYMAIL_TEST_BREVO_DOMAIN` to construct sender addresses.
     If those variables are not set, these tests won't run.
 
-    https://developers.sendinblue.com/docs/faq#section-how-can-i-test-the-api-
+    https://developers.brevo.com/docs/faq#how-can-i-test-the-api
 
     """
 
     def setUp(self):
         super().setUp()
-        self.from_email = "from@%s" % ANYMAIL_TEST_SENDINBLUE_DOMAIN
+        self.from_email = "from@%s" % ANYMAIL_TEST_BREVO_DOMAIN
         self.message = AnymailMessage(
-            "Anymail SendinBlue integration test",
+            "Anymail Brevo integration test",
             "Text content",
             self.from_email,
             ["test+to1@anymail.dev"],
@@ -50,7 +50,7 @@ class SendinBlueBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         self.message.attach_alternative("<p>HTML content</p>", "text/html")
 
     def test_simple_send(self):
-        # Example of getting the SendinBlue send status and message id from the message
+        # Example of getting the Brevo send status and message id from the message
         sent_count = self.message.send()
         self.assertEqual(sent_count, 1)
 
@@ -58,7 +58,7 @@ class SendinBlueBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         sent_status = anymail_status.recipients["test+to1@anymail.dev"].status
         message_id = anymail_status.recipients["test+to1@anymail.dev"].message_id
 
-        self.assertEqual(sent_status, "queued")  # SendinBlue always queues
+        self.assertEqual(sent_status, "queued")  # Brevo always queues
         # Message-ID can be ...@smtp-relay.mail.fr or .sendinblue.com:
         self.assertRegex(message_id, r"\<.+@.+\>")
         # set of all recipient statuses:
@@ -68,27 +68,27 @@ class SendinBlueBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     def test_all_options(self):
         send_at = datetime.now() + timedelta(minutes=2)
         message = AnymailMessage(
-            subject="Anymail SendinBlue all-options integration test",
+            subject="Anymail Brevo all-options integration test",
             body="This is the text body",
             from_email=formataddr(("Test From, with comma", self.from_email)),
             to=["test+to1@anymail.dev", '"Recipient 2, OK?" <test+to2@anymail.dev>'],
             cc=["test+cc1@anymail.dev", "Copy 2 <test+cc2@anymail.dev>"],
             bcc=["test+bcc1@anymail.dev", "Blind Copy 2 <test+bcc2@anymail.dev>"],
-            # SendinBlue API v3 only supports single reply-to
+            # Brevo API v3 only supports single reply-to
             reply_to=['"Reply, with comma" <reply@example.com>'],
             headers={"X-Anymail-Test": "value", "X-Anymail-Count": 3},
             metadata={"meta1": "simple string", "meta2": 2},
             send_at=send_at,
             tags=["tag 1", "tag 2"],
         )
-        # SendinBlue requires an HTML body:
+        # Brevo requires an HTML body:
         message.attach_alternative("<p>HTML content</p>", "text/html")
 
         message.attach("attachment1.txt", "Here is some\ntext for you", "text/plain")
         message.attach("attachment2.csv", "ID,Name\n1,Amy Lina", "text/csv")
 
         message.send()
-        # SendinBlue always queues:
+        # Brevo always queues:
         self.assertEqual(message.anymail_status.status, {"queued"})
         self.assertRegex(message.anymail_status.message_id, r"\<.+@.+\>")
 
@@ -118,7 +118,7 @@ class SendinBlueBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         message.attach("attachment1.txt", "Here is some\ntext", "text/plain")
 
         message.send()
-        # SendinBlue always queues:
+        # Brevo always queues:
         self.assertEqual(message.anymail_status.status, {"queued"})
         recipient_status = message.anymail_status.recipients
         self.assertEqual(recipient_status["test+to1@anymail.dev"].status, "queued")
@@ -135,11 +135,11 @@ class SendinBlueBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             recipient_status["test+to2@anymail.dev"].message_id,
         )
 
-    @override_settings(ANYMAIL_SENDINBLUE_API_KEY="Hey, that's not an API key!")
+    @override_settings(ANYMAIL_BREVO_API_KEY="Hey, that's not an API key!")
     def test_invalid_api_key(self):
         with self.assertRaises(AnymailAPIError) as cm:
             self.message.send()
         err = cm.exception
         self.assertEqual(err.status_code, 401)
-        # Make sure the exception message includes SendinBlue's response:
+        # Make sure the exception message includes Brevo's response:
         self.assertIn("Key not found", str(err))

--- a/tests/test_sendinblue_deprecations.py
+++ b/tests/test_sendinblue_deprecations.py
@@ -1,0 +1,117 @@
+from unittest.mock import ANY
+
+from django.core.mail import EmailMessage, send_mail
+from django.test import ignore_warnings, override_settings, tag
+
+from anymail.exceptions import AnymailConfigurationError, AnymailDeprecationWarning
+from anymail.webhooks.sendinblue import (
+    SendinBlueInboundWebhookView,
+    SendinBlueTrackingWebhookView,
+)
+
+from .mock_requests_backend import RequestsBackendMockAPITestCase
+from .webhook_cases import WebhookTestCase
+
+
+@tag("brevo", "sendinblue")
+@override_settings(
+    EMAIL_BACKEND="anymail.backends.sendinblue.EmailBackend",
+    ANYMAIL={"SENDINBLUE_API_KEY": "test_api_key"},
+)
+@ignore_warnings(category=AnymailDeprecationWarning)
+class SendinBlueBackendDeprecationTests(RequestsBackendMockAPITestCase):
+    DEFAULT_RAW_RESPONSE = (
+        b'{"messageId":"<201801020304.1234567890@smtp-relay.mailin.fr>"}'
+    )
+    DEFAULT_STATUS_CODE = 201  # Brevo v3 uses '201 Created' for success (in most cases)
+
+    def test_deprecation_warning(self):
+        message = EmailMessage(
+            "Subject", "Body", "from@example.com", ["to@example.com"]
+        )
+        with self.assertWarnsMessage(
+            AnymailDeprecationWarning,
+            "`anymail.backends.sendinblue.EmailBackend` has been renamed"
+            " `anymail.backends.brevo.EmailBackend`.",
+        ):
+            message.send()
+        self.assert_esp_called("https://api.brevo.com/v3/smtp/email")
+
+    @override_settings(ANYMAIL={"BREVO_API_KEY": "test_api_key"})
+    def test_missing_api_key_error_uses_correct_setting_name(self):
+        # The sendinblue.EmailBackend requires SENDINBLUE_ settings names
+        with self.assertRaisesMessage(AnymailConfigurationError, "SENDINBLUE_API_KEY"):
+            send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
+
+
+@tag("brevo", "sendinblue")
+@ignore_warnings(category=AnymailDeprecationWarning)
+class SendinBlueTrackingWebhookDeprecationTests(WebhookTestCase):
+    def test_deprecation_warning(self):
+        with self.assertWarnsMessage(
+            AnymailDeprecationWarning,
+            "Anymail's SendinBlue webhook URLs are deprecated.",
+        ):
+            response = self.client.post(
+                "/anymail/sendinblue/tracking/",
+                content_type="application/json",
+                data="{}",
+            )
+        self.assertEqual(response.status_code, 200)
+        # Old url uses old names to preserve compatibility:
+        self.assert_handler_called_once_with(
+            self.tracking_handler,
+            sender=SendinBlueTrackingWebhookView,  # *not* BrevoTrackingWebhookView
+            event=ANY,
+            esp_name="SendinBlue",  # *not* "Brevo"
+        )
+
+    def test_misconfigured_inbound(self):
+        # Uses old esp_name when called on old URL
+        errmsg = (
+            "You seem to have set Brevo's *inbound* webhook URL"
+            " to Anymail's SendinBlue *tracking* webhook URL."
+        )
+        with self.assertRaisesMessage(AnymailConfigurationError, errmsg):
+            self.client.post(
+                "/anymail/sendinblue/tracking/",
+                content_type="application/json",
+                data={"items": []},
+            )
+
+
+@tag("brevo", "sendinblue")
+@override_settings(ANYMAIL_SENDINBLUE_API_KEY="test-api-key")
+@ignore_warnings(category=AnymailDeprecationWarning)
+class SendinBlueInboundWebhookDeprecationTests(WebhookTestCase):
+    def test_deprecation_warning(self):
+        with self.assertWarnsMessage(
+            AnymailDeprecationWarning,
+            "Anymail's SendinBlue webhook URLs are deprecated.",
+        ):
+            response = self.client.post(
+                "/anymail/sendinblue/inbound/",
+                content_type="application/json",
+                data='{"items":[{}]}',
+            )
+        self.assertEqual(response.status_code, 200)
+        # Old url uses old names to preserve compatibility:
+        self.assert_handler_called_once_with(
+            self.inbound_handler,
+            sender=SendinBlueInboundWebhookView,  # *not* BrevoInboundWebhookView
+            event=ANY,
+            esp_name="SendinBlue",  # *not* "Brevo"
+        )
+
+    def test_misconfigured_tracking(self):
+        # Uses old esp_name when called on old URL
+        errmsg = (
+            "You seem to have set Brevo's *tracking* webhook URL"
+            " to Anymail's SendinBlue *inbound* webhook URL."
+        )
+        with self.assertRaisesMessage(AnymailConfigurationError, errmsg):
+            self.client.post(
+                "/anymail/sendinblue/inbound/",
+                content_type="application/json",
+                data={"event": "delivered"},
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ setenv =
     # (resend should work with or without its extras, so it isn't in `none`)
     none: ANYMAIL_SKIP_TESTS=amazon_ses,postal
     amazon_ses: ANYMAIL_ONLY_TEST=amazon_ses
+    brevo: ANYMAIL_ONLY_TEST=brevo
     mailersend: ANYMAIL_ONLY_TEST=mailersend
     mailgun: ANYMAIL_ONLY_TEST=mailgun
     mailjet: ANYMAIL_ONLY_TEST=mailjet
@@ -68,7 +69,6 @@ setenv =
     resend: ANYMAIL_ONLY_TEST=resend
     sendgrid: ANYMAIL_ONLY_TEST=sendgrid
     unisender_go: ANYMAIL_ONLY_TEST=unisender_go
-    sendinblue: ANYMAIL_ONLY_TEST=sendinblue
     sparkpost: ANYMAIL_ONLY_TEST=sparkpost
 ignore_outcome =
     # CI that wants to handle errors itself can set TOX_OVERRIDE_IGNORE_OUTCOME=false


### PR DESCRIPTION
I've been rethinking my arguments in #321 about leaving "SendinBlue" in the code while calling it "Brevo" everywhere else. I now feel this creates more confusion (particularly with new users) than it avoids.

This PR renames "sendinblue" to "brevo" throughout the code, but maintains compatibility versions on the old names and URLs (with deprecation warnings). 

The compatibility versions use the old `esp_name`, which means that settings names and other related features are also unchanged. So if you have `EMAIL_BACKEND = "…⁠sendinblue.EmailBackend"`, Anymail will continue to look for `SENDINBLUE_API_KEY` in the settings. But when you update to `EMAIL_BACKEND = "…⁠brevo.EmailBackend"`, you'll need to switch to `BREVO_API_KEY` at the same time.

I don't have any particular schedule for removing the deprecated compatibility versions. (They don't really add maintenance overhead.)