### PR TITLE
Fix reference to non-existent method on `EmailMessage`

### DIFF
--- a/docs/inbound.rst
+++ b/docs/inbound.rst
@@ -304,7 +304,7 @@ Normalized inbound message
     .. code-block:: python
 
         message['reply-to']  # the Reply-To header (header keys are case-insensitive)
-        message.getall('DKIM-Signature')  # list of all DKIM-Signature headers
+        message.get_all('DKIM-Signature')  # list of all DKIM-Signature headers
 
     And you can use Message methods like :meth:`~email.message.EmailMessage.walk` and
     :meth:`~email.message.EmailMessage.get_content_type` to examine more-complex


### PR DESCRIPTION
It's `get_all`, not `getall`.  https://docs.python.org/3.12/library/email.message.html#email.message.EmailMessage.get_all

I checked python versions 3.6-3.12 and confirmed it's always been the case.