### PR TITLE
Support merge_headers in Amazon SES bulk send

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,13 @@ Breaking changes
   (Anymail 10.0 switched to the SES v2 API by default. If your ``EMAIL_BACKEND``
   setting has ``amazon_sesv2``, change that to just ``amazon_ses``.)
 
+Features
+~~~~~~~~
+
+* **Amazon SES:** Add new ``merge_headers`` option for per-recipient
+  headers with template sends. (Requires boto3 >= 1.34.98.)
+  (Thanks to `@carrerasrodrigo`_ the implementation.)
+
 
 v10.3
 -----
@@ -1615,6 +1622,7 @@ Features
 .. _@Arondit: https://github.com/Arondit
 .. _@b0d0nne11: https://github.com/b0d0nne11
 .. _@calvin: https://github.com/calvin
+.. _@carrerasrodrigo: https://github.com/carrerasrodrigo
 .. _@chrisgrande: https://github.com/chrisgrande
 .. _@cjsoftuk: https://github.com/cjsoftuk
 .. _@costela: https://github.com/costela

--- a/anymail/backends/amazon_ses.py
+++ b/anymail/backends/amazon_ses.py
@@ -298,6 +298,9 @@ class AmazonSESV2SendEmailPayload(AmazonSESBasePayload):
         # metadata.
         self.mime_message["X-Metadata"] = self.serialize_json(metadata)
 
+    def set_merge_headers(self, merge_headers):
+        self.unsupported_feature("merge_headers without template_id")
+
     def set_tags(self, tags):
         # See note about Amazon SES Message Tags and custom headers in set_metadata
         # above. To support reliable retrieval in webhooks, use custom headers for tags.
@@ -327,9 +330,6 @@ class AmazonSESV2SendEmailPayload(AmazonSESBasePayload):
     def set_merge_data(self, merge_data):
         self.unsupported_feature("merge_data without template_id")
 
-    def set_merge_header_data(self, merge_data):
-        self.unsupported_feature("merge_header_data without template_id")
-
     def set_merge_global_data(self, merge_global_data):
         self.unsupported_feature("global_merge_data without template_id")
 
@@ -342,7 +342,7 @@ class AmazonSESV2SendBulkEmailPayload(AmazonSESBasePayload):
         # late-bind recipients and merge_data in finalize_payload
         self.recipients = {"to": [], "cc": [], "bcc": []}
         self.merge_data = {}
-        self.merge_header_data = {}
+        self.merge_headers = {}
 
     def finalize_payload(self):
         # Build BulkEmailEntries from recipients and merge_data.
@@ -359,8 +359,9 @@ class AmazonSESV2SendBulkEmailPayload(AmazonSESBasePayload):
             ]
 
         # Construct an entry with merge data for each "to" recipient:
-        self.params["BulkEmailEntries"] = [
-            {
+        self.params["BulkEmailEntries"] = []
+        for to in self.recipients["to"]:
+            entry = {
                 "Destination": dict(ToAddresses=[to.address], **cc_and_bcc_addresses),
                 "ReplacementEmailContent": {
                     "ReplacementTemplate": {
@@ -369,10 +370,11 @@ class AmazonSESV2SendBulkEmailPayload(AmazonSESBasePayload):
                         ),
                     }
                 },
-                "ReplacementHeaders": self.merge_header_data.get(to.addr_spec, []),
             }
-            for to in self.recipients["to"]
-        ]
+
+            if len(self.merge_headers) > 0:
+                entry["ReplacementHeaders"] = self.merge_headers.get(to.addr_spec, [])
+            self.params["BulkEmailEntries"].append(entry)
 
     def parse_recipient_status(self, response):
         try:
@@ -495,9 +497,9 @@ class AmazonSESV2SendBulkEmailPayload(AmazonSESBasePayload):
         # late-bound in finalize_payload
         self.merge_data = merge_data
 
-    def set_merge_header_data(self, merge_data):
+    def set_merge_headers(self, merge_headers):
         # late-bound in finalize_payload
-        self.merge_header_data = merge_data
+        self.merge_headers = merge_headers
 
     def set_merge_global_data(self, merge_global_data):
         # DefaultContent.Template.TemplateData

--- a/anymail/backends/amazon_ses.py
+++ b/anymail/backends/amazon_ses.py
@@ -327,6 +327,9 @@ class AmazonSESV2SendEmailPayload(AmazonSESBasePayload):
     def set_merge_data(self, merge_data):
         self.unsupported_feature("merge_data without template_id")
 
+    def set_merge_header_data(self, merge_data):
+        self.unsupported_feature("merge_header_data without template_id")
+
     def set_merge_global_data(self, merge_global_data):
         self.unsupported_feature("global_merge_data without template_id")
 
@@ -339,6 +342,7 @@ class AmazonSESV2SendBulkEmailPayload(AmazonSESBasePayload):
         # late-bind recipients and merge_data in finalize_payload
         self.recipients = {"to": [], "cc": [], "bcc": []}
         self.merge_data = {}
+        self.merge_header_data = {}
 
     def finalize_payload(self):
         # Build BulkEmailEntries from recipients and merge_data.
@@ -365,6 +369,7 @@ class AmazonSESV2SendBulkEmailPayload(AmazonSESBasePayload):
                         ),
                     }
                 },
+                "ReplacementHeaders": self.merge_header_data.get(to.addr_spec, [])
             }
             for to in self.recipients["to"]
         ]
@@ -489,6 +494,10 @@ class AmazonSESV2SendBulkEmailPayload(AmazonSESBasePayload):
     def set_merge_data(self, merge_data):
         # late-bound in finalize_payload
         self.merge_data = merge_data
+
+    def set_merge_header_data(self, merge_data):
+        # late-bound in finalize_payload
+        self.merge_header_data = merge_data
 
     def set_merge_global_data(self, merge_global_data):
         # DefaultContent.Template.TemplateData

--- a/anymail/backends/amazon_ses.py
+++ b/anymail/backends/amazon_ses.py
@@ -369,7 +369,7 @@ class AmazonSESV2SendBulkEmailPayload(AmazonSESBasePayload):
                         ),
                     }
                 },
-                "ReplacementHeaders": self.merge_header_data.get(to.addr_spec, [])
+                "ReplacementHeaders": self.merge_header_data.get(to.addr_spec, []),
             }
             for to in self.recipients["to"]
         ]

--- a/anymail/backends/amazon_ses.py
+++ b/anymail/backends/amazon_ses.py
@@ -373,7 +373,10 @@ class AmazonSESV2SendBulkEmailPayload(AmazonSESBasePayload):
             }
 
             if len(self.merge_headers) > 0:
-                entry["ReplacementHeaders"] = self.merge_headers.get(to.addr_spec, [])
+                entry["ReplacementHeaders"] = [
+                    {"Name": key, "Value": value}
+                    for key, value in self.merge_headers.get(to.addr_spec, {}).items()
+                ]
             self.params["BulkEmailEntries"].append(entry)
 
     def parse_recipient_status(self, response):

--- a/anymail/backends/base.py
+++ b/anymail/backends/base.py
@@ -285,8 +285,8 @@ class BasePayload:
         ("track_opens", last, None),
         ("template_id", last, force_non_lazy),
         ("merge_data", merge_dicts_one_level, force_non_lazy_dict),
-        ("merge_header_data", None, None),
         ("merge_global_data", merge_dicts_shallow, force_non_lazy_dict),
+        ("merge_headers", None, None),
         ("merge_metadata", merge_dicts_one_level, force_non_lazy_dict),
         ("esp_extra", merge_dicts_deep, force_non_lazy_dict),
     )
@@ -294,7 +294,7 @@ class BasePayload:
 
     # If any of these attrs are set on a message, treat the message
     # as a batch send (separate message for each `to` recipient):
-    batch_attrs = ("merge_data", "merge_header_data", "merge_metadata")
+    batch_attrs = ("merge_data", "merge_headers", "merge_metadata")
 
     def __init__(self, message, defaults, backend):
         self.message = message
@@ -618,8 +618,8 @@ class BasePayload:
     def set_merge_data(self, merge_data):
         self.unsupported_feature("merge_data")
 
-    def set_merge_header_data(self, merge_data):
-        self.unsupported_feature("set_merge_header_data")
+    def set_merge_headers(self, merge_headers):
+        self.unsupported_feature("merge_headers")
 
     def set_merge_global_data(self, merge_global_data):
         self.unsupported_feature("merge_global_data")

--- a/anymail/backends/base.py
+++ b/anymail/backends/base.py
@@ -285,6 +285,7 @@ class BasePayload:
         ("track_opens", last, None),
         ("template_id", last, force_non_lazy),
         ("merge_data", merge_dicts_one_level, force_non_lazy_dict),
+        ("merge_header_data", None, None),
         ("merge_global_data", merge_dicts_shallow, force_non_lazy_dict),
         ("merge_metadata", merge_dicts_one_level, force_non_lazy_dict),
         ("esp_extra", merge_dicts_deep, force_non_lazy_dict),
@@ -293,7 +294,7 @@ class BasePayload:
 
     # If any of these attrs are set on a message, treat the message
     # as a batch send (separate message for each `to` recipient):
-    batch_attrs = ("merge_data", "merge_metadata")
+    batch_attrs = ("merge_data", "merge_header_data", "merge_metadata")
 
     def __init__(self, message, defaults, backend):
         self.message = message
@@ -616,6 +617,9 @@ class BasePayload:
 
     def set_merge_data(self, merge_data):
         self.unsupported_feature("merge_data")
+
+    def set_merge_header_data(self, merge_data):
+        self.unsupported_feature("set_merge_header_data")
 
     def set_merge_global_data(self, merge_global_data):
         self.unsupported_feature("merge_global_data")

--- a/anymail/backends/test.py
+++ b/anymail/backends/test.py
@@ -147,8 +147,8 @@ class TestPayload(BasePayload):
     def set_merge_data(self, merge_data):
         self.params["merge_data"] = merge_data
 
-    def set_merge_header_data(self, merge_data):
-        self.params["merge_header_data"] = merge_data
+    def set_merge_headers(self, merge_headers):
+        self.params["merge_headers"] = merge_headers
 
     def set_merge_metadata(self, merge_metadata):
         self.params["merge_metadata"] = merge_metadata

--- a/anymail/backends/test.py
+++ b/anymail/backends/test.py
@@ -147,6 +147,9 @@ class TestPayload(BasePayload):
     def set_merge_data(self, merge_data):
         self.params["merge_data"] = merge_data
 
+    def set_merge_header_data(self, merge_data):
+        self.params["merge_header_data"] = merge_data
+
     def set_merge_metadata(self, merge_metadata):
         self.params["merge_metadata"] = merge_metadata
 

--- a/anymail/message.py
+++ b/anymail/message.py
@@ -28,6 +28,7 @@ class AnymailMessageMixin(EmailMessage):
         self.track_opens = kwargs.pop("track_opens", UNSET)
         self.template_id = kwargs.pop("template_id", UNSET)
         self.merge_data = kwargs.pop("merge_data", UNSET)
+        self.merge_header_data = kwargs.pop("merge_header_data", UNSET)
         self.merge_global_data = kwargs.pop("merge_global_data", UNSET)
         self.merge_metadata = kwargs.pop("merge_metadata", UNSET)
         self.anymail_status = AnymailStatus()

--- a/anymail/message.py
+++ b/anymail/message.py
@@ -28,8 +28,8 @@ class AnymailMessageMixin(EmailMessage):
         self.track_opens = kwargs.pop("track_opens", UNSET)
         self.template_id = kwargs.pop("template_id", UNSET)
         self.merge_data = kwargs.pop("merge_data", UNSET)
-        self.merge_header_data = kwargs.pop("merge_header_data", UNSET)
         self.merge_global_data = kwargs.pop("merge_global_data", UNSET)
+        self.merge_headers = kwargs.pop("merge_headers", UNSET)
         self.merge_metadata = kwargs.pop("merge_metadata", UNSET)
         self.anymail_status = AnymailStatus()
 

--- a/tests/test_amazon_ses_backend.py
+++ b/tests/test_amazon_ses_backend.py
@@ -654,17 +654,14 @@ class AmazonSESBackendAnymailFeatureTests(AmazonSESBackendMockAPITestCase):
                 "nobody@example.com": {"name": "Not a recipient for this message"},
             },
             merge_headers={
-                "alice@example.com": [
-                    {"Name": "List-Unsubscribe", "Value": "<https://example.com/a/>"},
-                    {"List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
-                ],
-                "nobody@example.com": [
-                    {
-                        "Name": "List-Unsubscribe",
-                        "Value": "<mailto:unsubscribe@example.com>",
-                    },
-                    {"List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
-                ],
+                "alice@example.com": {
+                    "List-Unsubscribe": "<https://example.com/a/>",
+                    "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+                },
+                "nobody@example.com": {
+                    "List-Unsubscribe": "<mailto:unsubscribe@example.com>",
+                    "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+                },
             },
             merge_global_data={"group": "Users", "site": "ExampleCo"},
             # (only works with AMAZON_SES_MESSAGE_TAG_NAME when using template):
@@ -722,7 +719,10 @@ class AmazonSESBackendAnymailFeatureTests(AmazonSESBackendMockAPITestCase):
             bulk_entries[0]["ReplacementHeaders"],
             [
                 {"Name": "List-Unsubscribe", "Value": "<https://example.com/a/>"},
-                {"List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
+                {
+                    "Name": "List-Unsubscribe-Post",
+                    "Value": "List-Unsubscribe=One-Click",
+                },
             ],
         )
         self.assertEqual(

--- a/tests/test_amazon_ses_backend.py
+++ b/tests/test_amazon_ses_backend.py
@@ -655,10 +655,15 @@ class AmazonSESBackendAnymailFeatureTests(AmazonSESBackendMockAPITestCase):
             },
             merge_headers={
                 "alice@example.com": [
-                    {"Name": "List-Unsubscribe-Post", "Value": "https://xyz.com/a/"}
+                    {"Name": "List-Unsubscribe", "Value": "<https://example.com/a/>"},
+                    {"List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
                 ],
                 "nobody@example.com": [
-                    {"Name": "List-Unsubscribe-Post", "Value": "https://xyz.com/b/"}
+                    {
+                        "Name": "List-Unsubscribe",
+                        "Value": "<mailto:unsubscribe@example.com>",
+                    },
+                    {"List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
                 ],
             },
             merge_global_data={"group": "Users", "site": "ExampleCo"},
@@ -712,9 +717,13 @@ class AmazonSESBackendAnymailFeatureTests(AmazonSESBackendMockAPITestCase):
             ),
             {"name": "Bob"},
         )
+
         self.assertEqual(
             bulk_entries[0]["ReplacementHeaders"],
-            [{"Name": "List-Unsubscribe-Post", "Value": "https://xyz.com/a/"}],
+            [
+                {"Name": "List-Unsubscribe", "Value": "<https://example.com/a/>"},
+                {"List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
+            ],
         )
         self.assertEqual(
             bulk_entries[1]["ReplacementHeaders"],

--- a/tests/test_amazon_ses_backend.py
+++ b/tests/test_amazon_ses_backend.py
@@ -605,9 +605,11 @@ class AmazonSESBackendAnymailFeatureTests(AmazonSESBackendMockAPITestCase):
             },
             merge_header_data={
                 "alice@example.com": [
-                    {"Name": "List-Unsubscribe-Post", "Value": "https://xyz.com/a/"}],
+                    {"Name": "List-Unsubscribe-Post", "Value": "https://xyz.com/a/"}
+                ],
                 "nobody@example.com": [
-                    {"Name": "List-Unsubscribe-Post", "Value": "https://xyz.com/b/"}]
+                    {"Name": "List-Unsubscribe-Post", "Value": "https://xyz.com/b/"}
+                ],
             },
             merge_global_data={"group": "Users", "site": "ExampleCo"},
             # (only works with AMAZON_SES_MESSAGE_TAG_NAME when using template):


### PR DESCRIPTION
Please check  ReplacementHeaders
https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendBulkEmail.html

This headers are very useful for the new requirements of email clients like gmail, yahoo, etc. 

Allows to add headers as a template. This enables, for example, to add an unique unique unsubscribe header for each email. 
