### PR TITLE
SendGrid: better handling of event="dropped", reason="Bounced Address" webhook events.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,13 @@ Features
   and ``tags`` when sending with a ``template_id``.
   (Requires boto3 v1.34.98 or later.)
 
+Fixes
+~~~~~
+
+* **SendGrid:** In the tracking webhook, correctly report "bounced address"
+  (recipients dropped due to earlier bounces) as reject reason ``"bounced"``.
+  (Thanks to `@vitaliyf`_.)
+
 
 v10.3
 -----
@@ -1672,4 +1679,5 @@ Features
 .. _@Tobeyforce: https://github.com/Tobeyforce
 .. _@varche1: https://github.com/varche1
 .. _@vgrebenschikov: https://github.com/vgrebenschikov
+.. _@vitaliyf: https://github.com/vitaliyf
 .. _@yourcelf: https://github.com/yourcelf

--- a/anymail/webhooks/sendgrid.py
+++ b/anymail/webhooks/sendgrid.py
@@ -46,6 +46,7 @@ class SendGridTrackingWebhookView(AnymailBaseWebhookView):
         "invalid": RejectReason.INVALID,
         "unsubscribed address": RejectReason.UNSUBSCRIBED,
         "bounce": RejectReason.BOUNCED,
+        "bounced address": RejectReason.BOUNCED,
         "blocked": RejectReason.BLOCKED,
         "expired": RejectReason.TIMED_OUT,
     }


### PR DESCRIPTION
According https://www.twilio.com/docs/sendgrid/for-developers/tracking-events/event#dropped the correct "reason" value for bouncing addresses is "Bounced Address" and that seems to be what I am seeing in SendGrid logs. Without this change those events were being normalized by anymail to `type=dropped, reject_reason=other` and not `reject_reason=bounced`.

I used sample event from their docs, and kept original mapping value since I'm not sure if that may actually show up in other situations.