### PR TITLE
Implement merge_headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,9 +44,12 @@ Breaking changes
 Features
 ~~~~~~~~
 
-* **Amazon SES:** Add new ``merge_headers`` option for per-recipient
-  headers with template sends. (Requires boto3 >= 1.34.98.)
-  (Thanks to `@carrerasrodrigo`_ the implementation.)
+* Add new ``merge_headers`` option for per-recipient headers with batch sends.
+  This can be helpful to send individual *List-Unsubscribe* headers (for example).
+  Supported for all current ESPs *except* MailerSend, Mandrill and Postal. See
+  `docs <https://anymail.dev/en/latest/sending/anymail_additions/#anymail.message.AnymailMessage.merge_headers>`__.
+  (Thanks to `@carrerasrodrigo`_ for the idea, and for the base and
+  Amazon SES implementations.)
 
 * **Amazon SES:** Allow extra headers, ``metadata``, ``merge_metadata``,
   and ``tags`` when sending with a ``template_id``.

--- a/anymail/backends/mailjet.py
+++ b/anymail/backends/mailjet.py
@@ -225,6 +225,13 @@ class MailjetPayload(RequestsPayload):
                     recipient_metadata = merge_metadata[email]
                 message["EventPayload"] = self.serialize_json(recipient_metadata)
 
+    def set_merge_headers(self, merge_headers):
+        self._burst_for_batch_send()
+        for message in self.data["Messages"]:
+            email = message["To"][0]["Email"]
+            if email in merge_headers:
+                message["Headers"] = merge_headers[email]
+
     def set_tags(self, tags):
         # The choices here are CustomID or Campaign, and Campaign seems closer
         # to how "tags" are handled by other ESPs -- e.g., you can view dashboard

--- a/docs/esps/amazon_ses.rst
+++ b/docs/esps/amazon_ses.rst
@@ -96,6 +96,14 @@ Limitations and quirks
 **No delayed sending**
   Amazon SES does not support :attr:`~anymail.message.AnymailMessage.send_at`.
 
+**Merge features require template_id**
+  Anymail's :attr:`~anymail.message.AnymailMessage.merge_headers`,
+  :attr:`~anymail.message.AnymailMessage.merge_metadata`,
+  :attr:`~anymail.message.AnymailMessage.merge_data`, and
+  :attr:`~anymail.message.AnymailMessage.merge_global_data` are only supported
+  when sending :ref:`templated messages <amazon-ses-templates>`
+  (using Anymail's :attr:`~anymail.message.AnymailMessage.template_id`).
+
 **No global send defaults for non-Anymail options**
   With the Amazon SES backend, Anymail's :ref:`global send defaults <send-defaults>`
   are only supported for Anymail's added message options (like

--- a/docs/esps/esp-feature-matrix.csv
+++ b/docs/esps/esp-feature-matrix.csv
@@ -1,8 +1,9 @@
 Email Service Provider,:ref:`amazon-ses-backend`,:ref:`brevo-backend`,:ref:`mailersend-backend`,:ref:`mailgun-backend`,:ref:`mailjet-backend`,:ref:`mandrill-backend`,:ref:`postal-backend`,:ref:`postmark-backend`,:ref:`resend-backend`,:ref:`sendgrid-backend`,:ref:`sparkpost-backend`,:ref:`unisender-go-backend`
 .. rubric:: :ref:`Anymail send options <anymail-send-options>`,,,,,,,,,,,,
 :attr:`~AnymailMessage.envelope_sender`,Yes,No,No,Domain only,Yes,Domain only,Yes,No,No,No,Yes,No
+:attr:`~AnymailMessage.merge_headers`,Yes*,Yes,No,Yes,Yes,No,No,Yes,Yes,Yes,Yes*,Yes*
 :attr:`~AnymailMessage.metadata`,Yes,Yes,No,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_metadata`,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes
+:attr:`~AnymailMessage.merge_metadata`,Yes*,Yes,No,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes
 :attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,Yes,No,No,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.tags`,Yes,Yes,Yes,Yes,Max 1 tag,Yes,Max 1 tag,Max 1 tag,Yes,Yes,Max 1 tag,Yes
 :attr:`~AnymailMessage.track_clicks`,No,No,Yes,Yes,Yes,Yes,No,Yes,No,Yes,Yes,Yes
@@ -10,8 +11,8 @@ Email Service Provider,:ref:`amazon-ses-backend`,:ref:`brevo-backend`,:ref:`mail
 :ref:`amp-email`,Yes,No,No,Yes,No,No,No,No,No,Yes,Yes,Yes
 .. rubric:: :ref:`templates-and-merge`,,,,,,,,,,,,
 :attr:`~AnymailMessage.template_id`,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_data`,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_global_data`,Yes,Yes,(emulated),(emulated),Yes,Yes,No,Yes,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.merge_data`,Yes*,Yes,Yes,Yes,Yes,Yes,No,Yes,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.merge_global_data`,Yes*,Yes,(emulated),(emulated),Yes,Yes,No,Yes,No,Yes,Yes,Yes
 .. rubric:: :ref:`Status <esp-send-status>` and :ref:`event tracking <event-tracking>`,,,,,,,,,,,,
 :attr:`~AnymailMessage.anymail_status`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes
 :class:`~anymail.signals.AnymailTrackingEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes

--- a/docs/esps/index.rst
+++ b/docs/esps/index.rst
@@ -48,6 +48,8 @@ The table below summarizes the Anymail features supported for each ESP.
     :widths: auto
     :class: sticky-left
 
+\* See ESP detail page for limitations and clarifications
+
 Trying to choose an ESP? Please **don't** start with this table. It's far more
 important to consider things like an ESP's deliverability stats, latency, uptime,
 and support for developers. The *number* of extra features an ESP offers is almost

--- a/docs/esps/mailersend.rst
+++ b/docs/esps/mailersend.rst
@@ -219,6 +219,10 @@ see :ref:`unsupported-features`.
   Any other extra headers will raise an
   :exc:`~anymail.exceptions.AnymailUnsupportedFeature` error.
 
+**No merge headers support**
+  MailerSend's API does not provide a way to support Anymail's
+  :attr:`~anymail.message.AnymailMessage.merge_headers`.
+
 **No metadata support**
   MailerSend does not support Anymail's
   :attr:`~anymail.message.AnymailMessage.metadata` or

--- a/docs/esps/mailgun.rst
+++ b/docs/esps/mailgun.rst
@@ -247,18 +247,23 @@ Limitations and quirks
   obvious reasons, only the domain portion applies. You can use anything before
   the @, and it will be ignored.
 
-**Using merge_metadata with merge_data**
+**Using merge_metadata and merge_headers with merge_data**
   If you use both Anymail's :attr:`~anymail.message.AnymailMessage.merge_data`
   and :attr:`~anymail.message.AnymailMessage.merge_metadata` features, make sure your
-  merge_data keys do not start with ``v:``. (It's a good idea anyway to avoid colons
-  and other special characters in merge_data keys, as this isn't generally portable
-  to other ESPs.)
+  :attr:`~!anymail.message.AnymailMessage.merge_data` keys do not start with ``v:``.
+
+  Similarly, if you use Anymail's :attr:`~anymail.message.AnymailMessage.merge_headers`
+  together with :attr:`~anymail.message.AnymailMessage.merge_data`, make sure your
+  :attr:`~!anymail.message.AnymailMessage.merge_data` keys do not start with ``h:``.
+
+  (It's a good idea anyway to avoid colons and other special characters in merge data
+  keys, as this isn't generally portable to other ESPs.)
 
   The same underlying Mailgun feature ("recipient-variables") is used to implement
-  both Anymail features. To avoid conflicts, Anymail prepends ``v:`` to recipient
-  variables needed for merge_metadata. (This prefix is stripped as Mailgun prepares
-  the message to send, so it won't be present in your Mailgun API logs or the metadata
-  that is sent to tracking webhooks.)
+  all three Anymail features. To avoid conflicts, Anymail prepends ``v:`` to recipient
+  variables needed for merge metadata, and ``h:`` for merge headers recipient variables.
+  (These prefixes are stripped as Mailgun prepares the message to send, so won't appear
+  in your Mailgun API logs or the metadata that is sent to tracking webhooks.)
 
 **Additional limitations on merge_data with template_id**
   If you are using Mailgun's stored handlebars templates (Anymail's

--- a/docs/esps/mandrill.rst
+++ b/docs/esps/mandrill.rst
@@ -143,6 +143,10 @@ Limitations and quirks
   (Verified and reported to MailChimp support 4/2022;
   see `Anymail discussion #257`_ for more details.)
 
+**No merge headers support**
+  Mandrill's API does not provide a way to support Anymail's
+  :attr:`~anymail.message.AnymailMessage.merge_headers`.
+
 **Envelope sender uses only domain**
   Anymail's :attr:`~anymail.message.AnymailMessage.envelope_sender` is used to
   populate Mandrill's `'return_path_domain'`---but only the domain portion.

--- a/docs/esps/postal.rst
+++ b/docs/esps/postal.rst
@@ -119,6 +119,13 @@ see :ref:`unsupported-features`.
 **Attachments must be named**
   Postal issues an `AttachmentMissingName` error when trying to send an attachment without name.
 
+**No merge features**
+  Because Postal does not support batch sending, Anymail's
+  :attr:`~anymail.message.AnymailMessage.merge_headers`,
+  :attr:`~anymail.message.AnymailMessage.merge_metadata`,
+  and :attr:`~anymail.message.AnymailMessage.merge_data`
+  are not supported.
+
 
 .. _postal-templates:
 

--- a/docs/esps/sparkpost.rst
+++ b/docs/esps/sparkpost.rst
@@ -206,6 +206,15 @@ Limitations and quirks
 
   .. versionadded:: 8.0
 
+**Extra header limitations**
+  SparkPost's API silently ignores certain email headers (specified via
+  Django's :ref:`headers or extra_headers <message-headers>` or Anymail's
+  :attr:`~anymail.message.AnymailMessage.merge_headers`). In particular,
+  attempts to provide a custom :mailheader:`List-Unsubscribe` header will
+  not work; the message will be sent with SparkPost's own subscription
+  management headers. (The list of allowed custom headers does not seem
+  to be documented.)
+
 **Envelope sender may use domain only**
   Anymail's :attr:`~anymail.message.AnymailMessage.envelope_sender` is used to
   populate SparkPost's `'return_path'` parameter. Anymail supplies the full

--- a/docs/esps/unisender_go.rst
+++ b/docs/esps/unisender_go.rst
@@ -212,6 +212,13 @@ Limitations and quirks
   :attr:`~anymail.message.AnymailMessage.merge_data` or
   :attr:`~anymail.message.AnymailMessage.merge_global_data`.
 
+**Limited merge headers support**
+  Unisender Go supports per-recipient :mailheader:`List-Unsubscribe` headers
+  (if your account has been approved to disable their unsubscribe link),
+  but trying to include any other field in Anymail's
+  :attr:`~anymail.message.AnymailMessage.merge_headers` will raise
+  an :exc:`~anymail.exceptions.AnymailUnsupportedFeature` error.
+
 **No envelope sender overrides**
   Unisender Go does not support overriding a message's
   :attr:`~anymail.message.AnymailMessage.envelope_sender`.

--- a/docs/sending/anymail_additions.rst
+++ b/docs/sending/anymail_additions.rst
@@ -101,6 +101,49 @@ an :ref:`unsupported feature <unsupported-features>` error.
         .. _how envelope sender relates to return path:
             https://www.postmastery.com/blog/about-the-return-path-header/
 
+    .. attribute:: merge_headers
+
+        .. versionadded:: 11.0
+
+        On a message with multiple recipients, if your ESP supports it,
+        you can set this to a `dict` of *per-recipient* extra email headers.
+        Each key in the dict is a recipient email (address portion only),
+        and its value is a dict of header fields and values for that recipient:
+
+        .. code-block:: python
+
+            message.to = ["wile@example.com", "R. Runner <rr@example.com>"]
+            message.extra_headers = {
+                # Headers for all recipients
+                "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+            }
+            message.merge_headers = {
+                # Per-recipient headers
+                "wile@example.com": {
+                    "List-Unsubscribe": "<https://example.com/unsubscribe/12345>",
+                },
+                "rr@example.com": {
+                    "List-Unsubscribe": "<https://example.com/unsubscribe/98765>",
+                },
+            }
+
+        When :attr:`!merge_headers` is set, Anymail will use the ESP's
+        :ref:`batch sending <batch-send>` option, so that each :attr:`to` recipient gets
+        an individual message (and doesn't see the other emails on the :attr:`to` list).
+
+        Many ESPs restrict which headers are allowed. Be sure to check Anymail's
+        :ref:`ESP-specific docs <supported-esps>` for your ESP.
+        (Also, :ref:`special handling <message-headers>` for :mailheader:`From`,
+        :mailheader:`To` and :mailheader:`Reply-To` headers does *not* apply
+        to :attr:`!merge_headers`.)
+
+        If :attr:`!merge_headers` defines a particular header for only some
+        recipients, the default for other recipients comes from the message's
+        :ref:`extra_headers <message-headers>`. If not defined there, behavior
+        varies by ESP: some will include the header field only for recipients
+        where you have provided it; other ESPs will send an empty header field
+        to the other recipients.
+
     .. attribute:: metadata
 
         If your ESP supports tracking arbitrary metadata, you can set this to

--- a/tests/test_brevo_integration.py
+++ b/tests/test_brevo_integration.py
@@ -113,6 +113,18 @@ class BrevoBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
                 "test+to1@anymail.dev": {"customer-id": "ZXK9123"},
                 "test+to2@anymail.dev": {"customer-id": "ZZT4192"},
             },
+            headers={
+                "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+                "List-Unsubscribe": "<mailto:unsubscribe@example.com>",
+            },
+            merge_headers={
+                "test+to1@anymail.dev": {
+                    "List-Unsubscribe": "<https://example.com/a/>",
+                },
+                "test+to2@anymail.dev": {
+                    "List-Unsubscribe": "<https://example.com/b/>",
+                },
+            },
         )
 
         message.attach("attachment1.txt", "Here is some\ntext", "text/plain")

--- a/tests/test_mailjet_integration.py
+++ b/tests/test_mailjet_integration.py
@@ -113,6 +113,23 @@ class MailjetBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
                 "test+to2@anymail.dev": {"value": "two"},
             },
             merge_global_data={"global": "global_value"},
+            metadata={"customer-id": "unknown", "meta2": 2},
+            merge_metadata={
+                "test+to1@anymail.dev": {"customer-id": "ZXK9123"},
+                "test+to2@anymail.dev": {"customer-id": "ZZT4192"},
+            },
+            headers={
+                "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+                "List-Unsubscribe": "<mailto:unsubscribe@example.com>",
+            },
+            merge_headers={
+                "test+to1@anymail.dev": {
+                    "List-Unsubscribe": "<https://example.com/a/>",
+                },
+                "test+to2@anymail.dev": {
+                    "List-Unsubscribe": "<https://example.com/b/>",
+                },
+            },
         )
         message.send()
         recipient_status = message.anymail_status.recipients

--- a/tests/test_postmark_integration.py
+++ b/tests/test_postmark_integration.py
@@ -68,13 +68,29 @@ class PostmarkBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             cc=["test+cc1@anymail.dev", "Copy 2 <test+cc2@anymail.dev>"],
             bcc=["test+bcc1@anymail.dev", "Blind Copy 2 <test+bcc2@anymail.dev>"],
             reply_to=["reply1@example.com", "Reply 2 <reply2@example.com>"],
-            headers={"X-Anymail-Test": "value"},
+            headers={
+                "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+                "List-Unsubscribe": "<mailto:unsubscribe@example.com>",
+            },
             # no send_at support
             metadata={"meta1": "simple string", "meta2": 2},
             tags=["tag 1"],  # max one tag
             track_opens=True,
             track_clicks=True,
-            merge_data={},  # force batch send (distinct message for each `to`)
+            # either of these merge_ options will force batch send
+            # (unique message for each "to" recipient)
+            merge_metadata={
+                "test+to1@anymail.dev": {"customer-id": "ZXK9123"},
+                "test+to2@anymail.dev": {"customer-id": "ZZT4192"},
+            },
+            merge_headers={
+                "test+to1@anymail.dev": {
+                    "List-Unsubscribe": "<https://example.com/a/>",
+                },
+                "test+to2@anymail.dev": {
+                    "List-Unsubscribe": "<https://example.com/b/>",
+                },
+            },
         )
         message.attach("attachment1.txt", "Here is some\ntext for you", "text/plain")
         message.attach("attachment2.csv", "ID,Name\n1,Amy Lina", "text/csv")

--- a/tests/test_resend_integration.py
+++ b/tests/test_resend_integration.py
@@ -87,7 +87,7 @@ class ResendBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         )  # non-empty string
 
     def test_batch_send(self):
-        # merge_metadata or merge_data will use batch send API
+        # merge_metadata, merge_headers, or merge_data will use batch send API
         message = AnymailMessage(
             subject="Anymail Resend batch sendintegration test",
             body="This is the text body",
@@ -99,6 +99,18 @@ class ResendBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
                 "test+to2@anymail.dev": {"meta3": "recipient 2"},
             },
             tags=["tag 1", "tag 2"],
+            headers={
+                "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+                "List-Unsubscribe": "<mailto:unsubscribe@example.com>",
+            },
+            merge_headers={
+                "test+to1@anymail.dev": {
+                    "List-Unsubscribe": "<https://example.com/a/>",
+                },
+                "test+to2@anymail.dev": {
+                    "List-Unsubscribe": "<https://example.com/b/>",
+                },
+            },
         )
         message.attach_alternative("<p>HTML content</p>", "text/html")
         message.attach("attachment1.txt", "Here is some\ntext for you", "text/plain")

--- a/tests/test_sendgrid_integration.py
+++ b/tests/test_sendgrid_integration.py
@@ -119,6 +119,23 @@ class SendGridBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             esp_extra={
                 "merge_field_format": "%{}%",
             },
+            metadata={"meta1": "simple string", "meta2": 2},
+            merge_metadata={
+                "to1@sink.sendgrid.net": {"meta3": "recipient 1"},
+                "to2@sink.sendgrid.net": {"meta3": "recipient 2"},
+            },
+            headers={
+                "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+                "List-Unsubscribe": "<mailto:unsubscribe@example.com>",
+            },
+            merge_headers={
+                "to1@sink.sendgrid.net": {
+                    "List-Unsubscribe": "<https://example.com/a/>",
+                },
+                "to2@sink.sendgrid.net": {
+                    "List-Unsubscribe": "<https://example.com/b/>",
+                },
+            },
         )
         message.send()
         recipient_status = message.anymail_status.recipients

--- a/tests/test_sparkpost_integration.py
+++ b/tests/test_sparkpost_integration.py
@@ -116,6 +116,19 @@ class SparkPostBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
                 "to2@test.sink.sparkpostmail.com": {"value": "two"},
             },
             merge_global_data={"global": "global_value"},
+            merge_metadata={
+                "to1@test.sink.sparkpostmail.com": {"meta1": "one"},
+                "to2@test.sink.sparkpostmail.com": {"meta1": "two"},
+            },
+            headers={
+                "X-Custom": "custom header default",
+            },
+            merge_headers={
+                # (Note that SparkPost doesn't support custom List-Unsubscribe headers)
+                "to1@test.sink.sparkpostmail.com": {
+                    "X-Custom": "custom header one",
+                },
+            },
         )
         message.send()
         recipient_status = message.anymail_status.recipients

--- a/tests/test_unisender_go_integration.py
+++ b/tests/test_unisender_go_integration.py
@@ -147,6 +147,18 @@ class UnisenderGoBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
                 "test+to1@anymail.dev": {"customer-id": "ZXK9123"},
                 "test+to2@anymail.dev": {"customer-id": "ZZT4192"},
             },
+            headers={
+                "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+                "List-Unsubscribe": "<mailto:unsubscribe@example.com>",
+            },
+            merge_headers={
+                "test+to1@anymail.dev": {
+                    "List-Unsubscribe": "<https://example.com/a/>",
+                },
+                "test+to2@anymail.dev": {
+                    "List-Unsubscribe": "<https://example.com/b/>",
+                },
+            },
         )
         message.from_email = None  # use template sender
         message.attach("attachment1.txt", "Here is some\ntext", "text/plain")


### PR DESCRIPTION
Implement and document `merge_headers`
for all other ESPs that can support it. (See #371 
for base and Amazon SES implementation.)

Closes #374
