### PR TITLE
MailerSend: support extra_headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,9 @@ Features
   and ``tags`` when sending with a ``template_id``.
   (Requires boto3 v1.34.98 or later.)
 
+* **MailerSend:** Allow all extra headers. (Note that MailerSend limits use
+  of this feature to "Enterprise accounts only.")
+
 Fixes
 ~~~~~
 

--- a/anymail/backends/mailersend.py
+++ b/anymail/backends/mailersend.py
@@ -242,8 +242,8 @@ class MailerSendPayload(RequestsPayload):
             self.data["reply_to"] = self.make_mailersend_email(emails[0])
 
     def set_extra_headers(self, headers):
-        # MailerSend doesn't support arbitrary email headers, but has
-        # individual API params for In-Reply-To and Precedence: bulk.
+        # MailerSend has individual API params for In-Reply-To and Precedence: bulk.
+        # The general "headers" option "is available to Enterprise accounts only".
         # (headers is a CaseInsensitiveDict, and is a copy so safe to modify.)
         in_reply_to = headers.pop("In-Reply-To", None)
         if in_reply_to is not None:
@@ -256,7 +256,9 @@ class MailerSendPayload(RequestsPayload):
             self.data["precedence_bulk"] = is_bulk
 
         if headers:
-            self.unsupported_feature("most extra_headers (see docs)")
+            self.data["headers"] = [
+                {"name": field, "value": value} for field, value in headers.items()
+            ]
 
     def set_text_body(self, body):
         self.data["text"] = body

--- a/docs/esps/mailersend.rst
+++ b/docs/esps/mailersend.rst
@@ -204,7 +204,12 @@ see :ref:`unsupported-features`.
   Anymail will use only the first one.
 
 **Limited extra headers**
-  MailerSend does not allow most extra headers. There are two exceptions:
+  MailerSend allows extra email headers for "Enterprise accounts only."
+  If you try to send :ref:`extra headers <message-headers>` with a non-enterprise
+  account, you may receive an API error.
+
+  However, MailerSend has special handling for two headers,
+  and *any* MailerSend account can send messages with them:
 
   * You can include :mailheader:`In-Reply-To` in extra headers, set to
     a message-id (without the angle brackets).
@@ -216,8 +221,11 @@ see :ref:`unsupported-features`.
     if your extra headers have :mailheader:`Precedence` set to ``"bulk"`` or
     ``"list"`` or ``"junk"``, or ``false`` for any other value.
 
-  Any other extra headers will raise an
-  :exc:`~anymail.exceptions.AnymailUnsupportedFeature` error.
+  .. versionchanged:: 11.0
+
+      In earlier releases, attempting to send other headers
+      (even with an enterprise account) would raise an
+      :exc:`~anymail.exceptions.AnymailUnsupportedFeature` error.
 
 **No merge headers support**
   MailerSend's API does not provide a way to support Anymail's

--- a/tests/test_mailersend_integration.py
+++ b/tests/test_mailersend_integration.py
@@ -81,8 +81,13 @@ class MailerSendBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             bcc=["test+bcc1@anymail.dev", "Blind Copy 2 <test+bcc2@anymail.dev>"],
             # MailerSend only supports single reply_to:
             reply_to=["Reply <reply@example.com>"],
-            # MailerSend supports very limited extra headers:
-            headers={"Precedence": "bulk", "In-Reply-To": "earlier-id@anymail.dev"},
+            headers={
+                # Special handling for these headers (available to all accounts):
+                "Precedence": "bulk",
+                "In-Reply-To": "earlier-id@anymail.dev",
+                # Only "enterprise accounts" can send other custom headers:
+                "X-Custom": "anymail test",
+            },
             send_at=send_at,
             tags=["tag 1", "tag 2"],
             track_clicks=False,


### PR DESCRIPTION
Add support for MailerSend's new(ish) "headers" field.