### PR TITLE
SparkPost: error on features incompatible with template_id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,10 @@ Breaking changes
   (Anymail 10.0 switched to the SES v2 API by default. If your ``EMAIL_BACKEND``
   setting has ``amazon_sesv2``, change that to just ``amazon_ses``.)
 
+* **SparkPost:** When sending with a ``template_id``, Anymail now raises an
+  error if the message uses features that SparkPost will silently ignore. See
+  `docs <https://anymail.dev/en/latest/esps/sparkpost/#sparkpost-template-limitations>`__.
+
 Features
 ~~~~~~~~
 
@@ -162,7 +166,7 @@ Features
   should be no impact on your code. (Thanks to `@sblondon`_.)
 
 * **Brevo (Sendinblue):** Add support for inbound email. (See
-  `docs <https://anymail.dev/en/stable/esps/sendinblue/#sendinblue-inbound>`_.)
+  `docs <https://anymail.dev/en/stable/esps/sendinblue/#sendinblue-inbound>`__.)
 
 * **SendGrid:** Support multiple ``reply_to`` addresses.
   (Thanks to `@gdvalderrama`_ for pointing out the new API.)

--- a/docs/esps/sparkpost.rst
+++ b/docs/esps/sparkpost.rst
@@ -215,6 +215,29 @@ Limitations and quirks
   management headers. (The list of allowed custom headers does not seem
   to be documented.)
 
+.. _sparkpost-template-limitations:
+
+**Features incompatible with template_id**
+  When sending with a :attr:`~anymail.message.AnymailMessage.template_id`,
+  SparkPost doesn't support attachments, inline images, extra headers,
+  :attr:`!reply_to`, :attr:`!cc` recipients, or overriding the
+  :attr:`!from_email`, :attr:`!subject`, or body (text or html) when
+  sending the message. Some of these can be defined in the template itself,
+  but SparkPost (often) silently drops them when supplied to their
+  Transmissions send API.
+
+  .. versionchanged:: 11.0
+
+    Using features incompatible with :attr:`!template_id` will raise an
+    :exc:`~anymail.exceptions.AnymailUnsupportedFeature` error. In earlier
+    releases, Anymail would pass the incompatible content to SparkPost's
+    API, which in many cases would silently ignore it and send the message
+    anyway.
+
+  These limitations only apply when using stored templates (with a template_id),
+  not when using SparkPost's template language for on-the-fly templating
+  in a message's subject, body, etc.
+
 **Envelope sender may use domain only**
   Anymail's :attr:`~anymail.message.AnymailMessage.envelope_sender` is used to
   populate SparkPost's `'return_path'` parameter. Anymail supplies the full
@@ -246,7 +269,8 @@ and :ref:`batch sending <batch-send>` with per-recipient merge data.
 You can use a SparkPost stored template by setting a message's
 :attr:`~anymail.message.AnymailMessage.template_id` to the
 template's unique id. (When using a stored template, SparkPost prohibits
-setting the EmailMessage's subject, text body, or html body.)
+setting the EmailMessage's subject, text body, or html body, and has
+:ref:`several other limitations <sparkpost-template-limitations>`.)
 
 Alternatively, you can refer to merge fields directly in an EmailMessage's
 subject, body, and other fields---the message itself is used as an
@@ -264,6 +288,7 @@ message attributes.
           to=["alice@example.com", "Bob <bob@example.com>"]
       )
       message.template_id = "11806290401558530"  # SparkPost id
+      message.from_email = None  # must set after constructor (see below)
       message.merge_data = {
           'alice@example.com': {'name': "Alice", 'order_no': "12345"},
           'bob@example.com': {'name': "Bob", 'order_no': "54321"},
@@ -279,6 +304,9 @@ message attributes.
           },
       }
 
+When using a :attr:`~anymail.message.AnymailMessage.template_id`, you must set the
+message's :attr:`!from_email` to ``None`` as shown above. SparkPost does not permit
+specifying the from address at send time when using a stored template.
 
 See `SparkPost's substitutions reference`_ for more information on templates and
 batch send with SparkPost. If you need the special `"dynamic" keys for nested substitutions`_,

--- a/tests/test_sparkpost_integration.py
+++ b/tests/test_sparkpost_integration.py
@@ -153,6 +153,7 @@ class SparkPostBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
                 "order": "12345",
             },
         )
+        message.from_email = None  # from_email must come from stored template
         message.send()
         recipient_status = message.anymail_status.recipients
         self.assertEqual(


### PR DESCRIPTION
Raise an `AnymailUnsupportedFeature` error when trying to use a `template_id` along with other content payload fields that SparkPost silently ignores when template_id is present:

- attachments
- inline images
- extra headers
- cc recipients (uses extra headers)
- from_email
- reply_to

(It's unclear if these used to cause API errors, or if they were supported with templates at some point and then quietly dropped.)