### PR TITLE
Mailjet: Prevent empty attachment filename

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,13 @@ Breaking changes
   (Postal's signature verification uses the "cryptography" package, which is no
   longer reliably installable with Python 3.8.)
 
+Fixes
+~~~~~
+
+* **Mailjet:** Avoid a Mailjet API error when sending an inline image without a
+  filename. (Anymail now substitutes ``"attachment"`` for the missing filename.)
+  (Thanks to `@chickahoona`_ for reporting the issue.)
+
 
 v12.0
 -----
@@ -1737,6 +1744,7 @@ Features
 .. _@b0d0nne11: https://github.com/b0d0nne11
 .. _@calvin: https://github.com/calvin
 .. _@carrerasrodrigo: https://github.com/carrerasrodrigo
+.. _@chickahoona: https://github.com/chickahoona
 .. _@chrisgrande: https://github.com/chrisgrande
 .. _@cjsoftuk: https://github.com/cjsoftuk
 .. _@costela: https://github.com/costela

--- a/anymail/backends/mailjet.py
+++ b/anymail/backends/mailjet.py
@@ -195,7 +195,8 @@ class MailjetPayload(RequestsPayload):
     def add_attachment(self, attachment):
         att = {
             "ContentType": attachment.mimetype,
-            "Filename": attachment.name or "",
+            # Mailjet requires a non-empty Filename.
+            "Filename": attachment.name or "attachment",
             "Base64Content": attachment.b64content,
         }
         if attachment.inline:

--- a/docs/esps/mailjet.rst
+++ b/docs/esps/mailjet.rst
@@ -144,6 +144,15 @@ Limitations and quirks
   :ref:`esp-send-status`, because Mailjet's other (statistics, event tracking)
   APIs don't yet support MessageUUID.
 
+**Attachments require filenames**
+  Mailjet requires that all attachments and inline images have filenames. If you
+  don't supply a filename, Anymail will use ``"attachment"`` as the filename.
+
+  .. versionchanged:: 13.0
+
+     Earlier Anymail versions would default to an empty string, resulting in
+     a Mailjet API error.
+
 **Older limitations**
 
 .. versionchanged:: 6.0

--- a/tests/test_mailjet_integration.py
+++ b/tests/test_mailjet_integration.py
@@ -7,7 +7,7 @@ from django.test import SimpleTestCase, override_settings, tag
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin, sample_image_path
+from .utils import AnymailTestMixin, sample_image_content
 
 ANYMAIL_TEST_MAILJET_API_KEY = os.getenv("ANYMAIL_TEST_MAILJET_API_KEY")
 ANYMAIL_TEST_MAILJET_SECRET_KEY = os.getenv("ANYMAIL_TEST_MAILJET_SECRET_KEY")
@@ -91,7 +91,7 @@ class MailjetBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         )
         message.attach("attachment1.txt", "Here is some\ntext for you", "text/plain")
         message.attach("attachment2.csv", "ID,Name\n1,Amy Lina", "text/csv")
-        cid = message.attach_inline_image_file(sample_image_path())
+        cid = message.attach_inline_image(sample_image_content())
         message.attach_alternative(
             "<p><b>HTML:</b> with <a href='http://example.com'>link</a>"
             "and image: <img src='cid:%s'></div>" % cid,


### PR DESCRIPTION
Mailjet requires all attachments/inlines have a non-empty Filename field. Substitute `"attachment"` for missing filenames.

Fixes #407.