### PR TITLE
Mailjet: Don't try to parse non-JSON responses as JSON.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,8 @@ Fixes
 * **Mailjet:** Avoid a Mailjet API error when sending an inline image without a
   filename. (Anymail now substitutes ``"attachment"`` for the missing filename.)
   (Thanks to `@chickahoona`_ for reporting the issue.)
+* **Mailjet:** Fix a JSON parsing error on Mailjet 429 "too many requests" API
+  responses. (Thanks to `@rodrigondec`_ for reporting the issue.)
 
 
 v12.0
@@ -1779,6 +1781,7 @@ Features
 .. _@originell: https://github.com/originell
 .. _@puru02: https://github.com/puru02
 .. _@RignonNoel: https://github.com/RignonNoel
+.. _@rodrigondec: https://github.com/rodrigondec
 .. _@sblondon: https://github.com/sblondon
 .. _@scur-iolus: https://github.com/scur-iolus
 .. _@sdarwin: https://github.com/sdarwin

--- a/anymail/backends/mailjet.py
+++ b/anymail/backends/mailjet.py
@@ -34,7 +34,10 @@ class EmailBackend(AnymailRequestsBackend):
         return MailjetPayload(message, defaults, self)
 
     def raise_for_status(self, response, payload, message):
-        if 400 <= response.status_code <= 499:
+        content_type = (
+            response.headers.get("content-type", "").split(";")[0].strip().lower()
+        )
+        if 400 <= response.status_code <= 499 and content_type == "application/json":
             # Mailjet uses 4xx status codes for partial failure in batch send;
             # we'll determine how to handle below in parse_recipient_status.
             return


### PR DESCRIPTION
Fixes #409.