### PR TITLE
Postmark: Fix inbound ValueError with long, non-ASCII name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,9 @@ Fixes
   "queued" in the ``anymail_status`` (rather than throwing an error or reporting
   "sent"). (Thanks to `@jmduke`_ for reporting the issue.)
 
+* **Postmark:** Fix an error in inbound handling with long email address display
+  names that include non-ASCII characters.
+
 
 v12.0
 -----

--- a/anymail/utils.py
+++ b/anymail/utils.py
@@ -1,5 +1,6 @@
 import base64
 import mimetypes
+import re
 from base64 import b64encode
 from collections.abc import Mapping, MutableMapping
 from copy import copy, deepcopy
@@ -342,7 +343,10 @@ class EmailAddress:
             default None uses ascii if possible, else 'utf-8'
             (quoted-printable utf-8/base64)
         """
-        return sanitize_address((self.display_name, self.addr_spec), encoding)
+        sanitized = sanitize_address((self.display_name, self.addr_spec), encoding)
+        # sanitize_address() can introduce FWS with a long, non-ASCII display name.
+        # Must unfold it:
+        return re.sub(r"(\r|\n|\r\n)[ \t]", "", sanitized)
 
     def __str__(self):
         return self.address


### PR DESCRIPTION
Receiving a Postmark inbound message with a long From or recipient Name field could result in "ValueError: Header values may not contain linefeed or carriage return characters" if the name included non-ASCII characters.

Anymail's EmailAddress calls Django's sanitize_address(), which can introduce folding whitespace, causing an error in the AnymailInboundMessage constructor. Only Postmark inbound is affected, as no other webhooks construct an EmailAddress.

(Longer-term, Anymail should stop using the undocumented Django sanitize_address.)