### PR TITLE
Test Django 5.1 on Python 3.12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist =
     docs
     # ... then test all the other supported combinations:
     # Django 5.1: Python 3.10, 3.11, and 3.12
-    django51-py{310,311}-all
+    django51-py{310,311,312}-all
     # Django 5.0: Python 3.10, 3.11, and 3.12
     django50-py{310,311,312}-all
     # Django 4.2: Python 3.8, 3.9, 3.10, 3.11


### PR DESCRIPTION
It's supported and the comment suggests it's supposed to be there already.