### PR TITLE
Postal (docs): Clarify Postal API URL documentation

### DIFF
--- a/docs/esps/postal.rst
+++ b/docs/esps/postal.rst
@@ -46,7 +46,14 @@ nor ``ANYMAIL_POSTAL_API_KEY`` is set.
 
 .. rubric:: POSTAL_API_URL
 
-Required. The base url for calling the Postal API.
+Required. The base URL of your Postal server (without /api/v1 or any API paths). Anymail will automatically append the required API paths.
+
+  .. code-block:: python
+
+      ANYMAIL = {
+          ...
+          "POSTAL_API_URL": "https://yourpostal.example.com",
+      }
 
 
 .. setting:: ANYMAIL_POSTAL_WEBHOOK_KEY

--- a/docs/esps/postal.rst
+++ b/docs/esps/postal.rst
@@ -46,7 +46,7 @@ nor ``ANYMAIL_POSTAL_API_KEY`` is set.
 
 .. rubric:: POSTAL_API_URL
 
-Required. The base URL of your Postal server (without /api/v1 or any API paths). 
+Required. The base URL of your Postal server (without /api/v1 or any API paths).
 Anymail will automatically append the required API paths.
 
   .. code-block:: python

--- a/docs/esps/postal.rst
+++ b/docs/esps/postal.rst
@@ -46,7 +46,8 @@ nor ``ANYMAIL_POSTAL_API_KEY`` is set.
 
 .. rubric:: POSTAL_API_URL
 
-Required. The base URL of your Postal server (without /api/v1 or any API paths). Anymail will automatically append the required API paths.
+Required. The base URL of your Postal server (without /api/v1 or any API paths). 
+Anymail will automatically append the required API paths.
 
   .. code-block:: python
 


### PR DESCRIPTION
POSTAL_API_URL should be the base URL without API paths, as Anymail appends these automatically.

Clarifying as the current name and docs make it ambiguous.

Spent an hour debugging after https://mypostalserver.example.com/api/v1 value didn't work and want to save this for others :)