### PR TITLE
Remove outdated workarounds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Among other things, this means that minor updates (1.x to 1.y)
 should always be backwards-compatible, and breaking changes will
 always increment the major version number (1.x to 2.0).
 
-.. _semver: http://semver.org
+.. _semver: https://semver.org
 
 
 ..  This changelog is designed to be readable standalone on GitHub,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,12 @@ Fixes
 * **Postmark:** Fix an error in inbound handling with long email address display
   names that include non-ASCII characters.
 
+Other
+~~~~~
+
+* **SendGrid:** Remove Anymail's workaround for an earlier SendGrid API bug with
+  punctuation in address display names. SendGrid has fixed the bug.
+
 
 v12.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,6 +59,9 @@ Fixes
 Other
 ~~~~~
 
+* **Resend:** Remove Anymail's workaround for an earlier Resend API bug with
+  punctuation in address display names. Resend has fixed the bug.
+
 * **SendGrid:** Remove Anymail's workaround for an earlier SendGrid API bug with
   punctuation in address display names. SendGrid has fixed the bug.
 

--- a/anymail/backends/sendgrid.py
+++ b/anymail/backends/sendgrid.py
@@ -1,6 +1,5 @@
 import uuid
 import warnings
-from email.utils import quote as rfc822_quote
 
 from requests.structures import CaseInsensitiveDict
 
@@ -45,15 +44,6 @@ class EmailBackend(AnymailRequestsBackend):
             "merge_field_format", esp_name=esp_name, kwargs=kwargs, default=None
         )
 
-        # Undocumented setting to disable workaround for SendGrid display-name quoting
-        # bug (see below). If/when SendGrid fixes their API, recipient names will end up
-        # with extra double quotes until Anymail is updated to remove the workaround.
-        # In the meantime, you can disable it by adding
-        # `"SENDGRID_WORKAROUND_NAME_QUOTE_BUG": False` to your `ANYMAIL` settings.
-        self.workaround_name_quote_bug = get_anymail_setting(
-            "workaround_name_quote_bug", esp_name=esp_name, kwargs=kwargs, default=True
-        )
-
         # This is SendGrid's newer Web API v3
         api_url = get_anymail_setting(
             "api_url",
@@ -85,7 +75,6 @@ class SendGridPayload(RequestsPayload):
     def __init__(self, message, defaults, backend, *args, **kwargs):
         self.all_recipients = []  # used for backend.parse_recipient_status
         self.generate_message_id = backend.generate_message_id
-        self.workaround_name_quote_bug = backend.workaround_name_quote_bug
         self.use_dynamic_template = False  # how to represent merge_data
         self.message_ids = {}  # recipient -> generated message_id mapping
         self.merge_field_format = backend.merge_field_format
@@ -232,18 +221,11 @@ class SendGridPayload(RequestsPayload):
     #
 
     @staticmethod
-    def email_object(email, workaround_name_quote_bug=False):
+    def email_object(email):
         """Converts EmailAddress to SendGrid API {email, name} dict"""
         obj = {"email": email.addr_spec}
         if email.display_name:
-            # Work around SendGrid API bug: v3 fails to properly quote display-names
-            # containing commas or semicolons in personalizations (but not in from_email
-            # or reply_to). See https://github.com/sendgrid/sendgrid-python/issues/291.
-            # We can work around the problem by quoting the name for SendGrid.
-            if workaround_name_quote_bug:
-                obj["name"] = '"%s"' % rfc822_quote(email.display_name)
-            else:
-                obj["name"] = email.display_name
+            obj["name"] = email.display_name
         return obj
 
     def set_from_email(self, email):
@@ -252,11 +234,10 @@ class SendGridPayload(RequestsPayload):
     def set_recipients(self, recipient_type, emails):
         assert recipient_type in ["to", "cc", "bcc"]
         if emails:
-            workaround_name_quote_bug = self.workaround_name_quote_bug
             # Normally, exactly one "personalizations" entry for all recipients
             # (Exception: with merge_data; will be burst apart later.)
             self.data["personalizations"][0][recipient_type] = [
-                self.email_object(email, workaround_name_quote_bug) for email in emails
+                self.email_object(email) for email in emails
             ]
             self.all_recipients += emails  # used for backend.parse_recipient_status
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,10 +24,9 @@ See the `contributor chart`_ for a list of some of the people who have helped
 improve Anymail.
 
 Anymail evolved from the `Djrill`_ project. Special thanks to the
-folks from `brack3t`_ who developed the original version of Djrill.
+folks from Brack3t who developed the original version of Djrill.
 
 .. _contributor chart: https://github.com/anymail/django-anymail/graphs/contributors
-.. _brack3t: http://brack3t.com/
 .. _Djrill: https://github.com/brack3t/Djrill
 
 

--- a/tests/test_sendgrid_backend.py
+++ b/tests/test_sendgrid_backend.py
@@ -118,27 +118,25 @@ class SendGridBackendStandardEmailTests(SendGridBackendMockAPITestCase):
         )
 
         # single message (single "personalization") sent to all those recipients
-        # (note workaround for SendGrid v3 API bug quoting display-name
-        # in personalizations)
         self.assertEqual(len(data["personalizations"]), 1)
         self.assertEqual(
             data["personalizations"][0]["to"],
             [
-                {"name": '"Recipient #1"', "email": "to1@example.com"},
+                {"name": "Recipient #1", "email": "to1@example.com"},
                 {"email": "to2@example.com"},
             ],
         )
         self.assertEqual(
             data["personalizations"][0]["cc"],
             [
-                {"name": '"Carbon Copy"', "email": "cc1@example.com"},
+                {"name": "Carbon Copy", "email": "cc1@example.com"},
                 {"email": "cc2@example.com"},
             ],
         )
         self.assertEqual(
             data["personalizations"][0]["bcc"],
             [
-                {"name": '"Blind Copy"', "email": "bcc1@example.com"},
+                {"name": "Blind Copy", "email": "bcc1@example.com"},
                 {"email": "bcc2@example.com"},
             ],
         )
@@ -166,15 +164,15 @@ class SendGridBackendStandardEmailTests(SendGridBackendMockAPITestCase):
                 {
                     "to": [
                         {"email": "to1@example.com"},
-                        {"email": "to2@example.com", "name": '"Also To"'},
+                        {"email": "to2@example.com", "name": "Also To"},
                     ],
                     "cc": [
                         {"email": "cc1@example.com"},
-                        {"email": "cc2@example.com", "name": '"Also CC"'},
+                        {"email": "cc2@example.com", "name": "Also CC"},
                     ],
                     "bcc": [
                         {"email": "bcc1@example.com"},
-                        {"email": "bcc2@example.com", "name": '"Also BCC"'},
+                        {"email": "bcc2@example.com", "name": "Also BCC"},
                     ],
                     # make sure custom Message-ID also added to custom_args
                     "custom_args": {"anymail_id": "mocked-uuid-1"},
@@ -610,7 +608,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
                     },
                 },
                 {
-                    "to": [{"email": "bob@example.com", "name": '"Bob"'}],
+                    "to": [{"email": "bob@example.com", "name": "Bob"}],
                     "cc": [{"email": "cc@example.com"}],
                     "custom_args": {"anymail_id": "mocked-uuid-2"},
                     "dynamic_template_data": {
@@ -733,7 +731,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
                     },
                 },
                 {
-                    "to": [{"email": "bob@example.com", "name": '"Bob"'}],
+                    "to": [{"email": "bob@example.com", "name": "Bob"}],
                     "cc": [{"email": "cc@example.com"}],
                     "custom_args": {"anymail_id": "mocked-uuid-2"},
                     "substitutions": {
@@ -779,7 +777,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
                     },
                 },
                 {
-                    "to": [{"email": "bob@example.com", "name": '"Bob"'}],
+                    "to": [{"email": "bob@example.com", "name": "Bob"}],
                     "custom_args": {"anymail_id": "mocked-uuid-2"},
                     "substitutions": {":name": "Bob", ":site": "ExampleCo"},
                 },
@@ -811,7 +809,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
                     },
                 },
                 {
-                    "to": [{"email": "bob@example.com", "name": '"Bob"'}],
+                    "to": [{"email": "bob@example.com", "name": "Bob"}],
                     "custom_args": {"anymail_id": "mocked-uuid-2"},
                     "substitutions": {"*|name|*": "Bob", "*|site|*": "ExampleCo"},
                 },
@@ -850,7 +848,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
                     "custom_args": {"anymail_id": "mocked-uuid-1", "order_id": "123"},
                 },
                 {
-                    "to": [{"email": "bob@example.com", "name": '"Bob"'}],
+                    "to": [{"email": "bob@example.com", "name": "Bob"}],
                     "custom_args": {
                         "anymail_id": "mocked-uuid-2",
                         "order_id": "678",
@@ -881,7 +879,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
                     "custom_args": {"anymail_id": "mocked-uuid-1", "order_id": "123"},
                 },
                 {
-                    "to": [{"email": "bob@example.com", "name": '"Bob"'}],
+                    "to": [{"email": "bob@example.com", "name": "Bob"}],
                     "custom_args": {
                         "anymail_id": "mocked-uuid-2",
                         "order_id": "678",
@@ -932,7 +930,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
                     "custom_args": {"anymail_id": "mocked-uuid-1", "order_id": "123"},
                 },
                 {
-                    "to": [{"email": "bob@example.com", "name": '"Bob"'}],
+                    "to": [{"email": "bob@example.com", "name": "Bob"}],
                     "cc": [{"email": "cc@example.com"}],
                     "dynamic_template_data": {
                         "name": "Bob",
@@ -994,7 +992,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
                     },
                 },
                 {
-                    "to": [{"email": "bob@example.com", "name": '"Bob"'}],
+                    "to": [{"email": "bob@example.com", "name": "Bob"}],
                     "cc": [{"email": "cc@example.com"}],
                     "custom_args": {
                         "anymail_id": "mocked-uuid-2",
@@ -1130,7 +1128,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
             data["personalizations"],
             [
                 {
-                    "to": [{"email": "first@example.com", "name": '"First recipient"'}],
+                    "to": [{"email": "first@example.com", "name": "First recipient"}],
                     "custom_args": {"anymail_id": "mocked-uuid-1"},
                     "future_feature": "works",
                 },
@@ -1247,26 +1245,6 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
         self.assertIn("Don't know how to send this data to SendGrid", str(err))
         # original message:
         self.assertRegex(str(err), r"Decimal.*is not JSON serializable")
-
-    @override_settings(ANYMAIL_SENDGRID_WORKAROUND_NAME_QUOTE_BUG=False)
-    def test_undocumented_workaround_name_quote_bug_setting(self):
-        mail.send_mail(
-            "Subject",
-            "Body",
-            '"Sender, Inc." <from@example.com',
-            ['"Recipient, Ltd." <to@example.com>'],
-        )
-        data = self.get_api_call_json()
-        self.assertEqual(
-            data["personalizations"][0]["to"][0],
-            {
-                "email": "to@example.com",
-                "name": "Recipient, Ltd.",  # no extra quotes on name
-            },
-        )
-        self.assertEqual(
-            data["from"], {"email": "from@example.com", "name": "Sender, Inc."}
-        )
 
 
 @tag("sendgrid")


### PR DESCRIPTION
Remove Anymail workarounds for SendGrid and Resend API bugs that have since been fixed.
