### PR TITLE
SendGrid: Handle non-string data in legacy substitutions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,13 @@ Fixes
 * **Postmark:** Fix an error in inbound handling with long email address display
   names that include non-ASCII characters.
 
+* **SendGrid:** Improve handling of non-string values in ``merge_data`` when using
+  legacy templates or inline merge fields. To avoid a confusing SendGrid API error
+  message, Anymail now converts numeric merge data values to strings, but will raise
+  an AnymailSerializationError for other non-string data in SendGrid substitutions.
+  (SendGrid's newer *dynamic* transactional templates do not have this limitation.)
+  (Thanks to `@PlusAsh`_ for reporting the issue.)
+
 Other
 ~~~~~
 
@@ -1798,6 +1805,7 @@ Features
 .. _@mwheels: https://github.com/mwheels
 .. _@nuschk: https://github.com/nuschk
 .. _@originell: https://github.com/originell
+.. _@PlusAsh: https://github.com/PlusAsh
 .. _@puru02: https://github.com/puru02
 .. _@RignonNoel: https://github.com/RignonNoel
 .. _@rodrigondec: https://github.com/rodrigondec


### PR DESCRIPTION
SendGrid returns a cryptic "Bad Request" error (with no other details) when legacy substitutions values are anything other than string or null. (This only applies to substitutions, for legacy templates and on-the-fly merge fields.)

Convert numeric types to string (per Anymail's documented `merge_data` behavior), and raise an AnymailSerializationError for other unsupported substitutions values.

Fixes #420