### PR TITLE
Update tests/CI for Django 5.2 release

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.config.python }}
+          cache: "pip"
       - name: Install tox
         run: |
           set -x

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -39,18 +39,18 @@ jobs:
         # Live API integration tests are run on only one representative Python/Django version
         # combination, to avoid rapidly consuming the testing accounts' entire send allotments.
         config:
-          - { tox: django41-py310-amazon_ses, python: "3.12" }
-          - { tox: django41-py310-brevo, python: "3.12" }
-          - { tox: django41-py310-mailersend, python: "3.12" }
-          - { tox: django41-py310-mailgun, python: "3.12" }
-          - { tox: django41-py310-mailjet, python: "3.12" }
-          - { tox: django41-py310-mandrill, python: "3.12" }
-          - { tox: django41-py310-postal, python: "3.12" }
-          - { tox: django41-py310-postmark, python: "3.12" }
-          - { tox: django41-py310-resend, python: "3.12" }
-          - { tox: django41-py310-sendgrid, python: "3.12" }
-          - { tox: django41-py310-sparkpost, python: "3.12" }
-          - { tox: django41-py310-unisender_go, python: "3.12" }
+          - { tox: django52-py313-amazon_ses, python: "3.13" }
+          - { tox: django52-py313-brevo, python: "3.13" }
+          - { tox: django52-py313-mailersend, python: "3.13" }
+          - { tox: django52-py313-mailgun, python: "3.13" }
+          - { tox: django52-py313-mailjet, python: "3.13" }
+          - { tox: django52-py313-mandrill, python: "3.13" }
+          - { tox: django52-py313-postal, python: "3.13" }
+          - { tox: django52-py313-postmark, python: "3.13" }
+          - { tox: django52-py313-resend, python: "3.13" }
+          - { tox: django52-py313-sendgrid, python: "3.13" }
+          - { tox: django52-py313-sparkpost, python: "3.13" }
+          - { tox: django52-py313-unisender_go, python: "3.13" }
 
     steps:
       - name: Get code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install build requirements
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - name: Get code
         uses: actions/checkout@v4
+      - name: Setup default Python
+        # Change default Python version to something consistent
+        # for installing/running tox
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - name: Install tox-gh-matrix
         run: |
           python -m pip install 'tox<4' 'tox-gh-matrix<0.3'
@@ -52,7 +58,7 @@ jobs:
         # for installing/running tox
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install tox
         run: |
           set -x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.tox.python.spec }}
+          cache: "pip"
       - name: Setup default Python
         # Change default Python version back to something consistent
         # for installing/running tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,7 +66,7 @@ Fixes
 Other
 ~~~~~
 
-* Test against Django 5.2 pre-release.
+* Officially support Django 5.2.
 
 * **Resend:** Remove Anymail's workaround for an earlier Resend API bug with
   punctuation in address display names. Resend has fixed the bug.

--- a/tox.ini
+++ b/tox.ini
@@ -5,27 +5,27 @@ envlist =
     # Factors: django-python-extras
     # Test lint, docs, earliest/latest Django first, to catch most errors early...
     lint
-    django51-py312-all
+    django52-py313-all
     django40-py38-all
     docs
     # ... then test all the other supported combinations:
+    # Django 5.2: Python 3.10, 3.11, 3.12 and 3.13 (3.13 is above)
+    django52-py{310,311,312}-all
     # Django 5.1: Python 3.10, 3.11, and 3.12
-    django51-py{310,311}-all
+    django51-py{310,311,312}-all
     # Django 5.0: Python 3.10, 3.11, and 3.12
     django50-py{310,311,312}-all
     # Django 4.2: Python 3.8, 3.9, 3.10, 3.11
     django42-py{38,39,310,311,py38,py39}-all
     # Django 4.1: Python 3.8, 3.9, 3.10
     django41-py{38,39,310,py38,py39}-all
-    # Django 4.0: Python 3.8, 3.9, 3.10
+    # Django 4.0: Python 3.8 (above), 3.9, 3.10
     django40-py{39,310,py38,py39}-all
     # ... then pre-releases (if available) and current development:
-    # Django 5.2 pre-release: Python 3.10, 3.11, 3.12 and 3.13
-    django52-py{310,311,312,313}-all
     # Django 6.0 dev: Python 3.12 and 3.13
     djangoDev-py{312,313}-all
     # ... then partial installation (limit extras):
-    django51-py312-{none,amazon_ses,postal,resend}
+    django52-py313-{none,amazon_ses,postal,resend}
 # tox requires isolated builds to use pyproject.toml build config:
 isolated_build = True
 
@@ -41,6 +41,7 @@ deps =
     django50: django~=5.0.0
     django51: django~=5.1.0
     django52: django~=5.2.0a0
+    # django60: django~=6.0.0a0
     djangoDev: https://github.com/django/django/tarball/main
 extras =
     # Install [esp-name] extras only when testing "all" or esp_name factor.

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ passenv =
     ANYMAIL_TEST_*
 
 [testenv:lint]
-basepython = python3.12
+basepython = python3.13
 skip_install = true
 passenv =
     CONTINUOUS_INTEGRATION
@@ -104,7 +104,7 @@ commands =
     pre-commit run --all-files
 
 [testenv:docs]
-basepython = python3.12
+basepython = python3.13
 passenv =
     CONTINUOUS_INTEGRATION
     GOOGLE_ANALYTICS_ID


### PR DESCRIPTION
Django 5.2 has been released.

(Also do some related CI/tests cleanup around Python and Django versions.)