### PR TITLE
SendGrid: change to "unsupported" status

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,7 +48,7 @@ jobs:
           - { tox: django52-py313-postal, python: "3.13" }
           - { tox: django52-py313-postmark, python: "3.13" }
           - { tox: django52-py313-resend, python: "3.13" }
-          - { tox: django52-py313-sendgrid, python: "3.13" }
+          # - { tox: django52-py313-sendgrid, python: "3.13" }
           - { tox: django52-py313-sparkpost, python: "3.13" }
           - { tox: django52-py313-unisender_go, python: "3.13" }
 
@@ -96,7 +96,7 @@ jobs:
           ANYMAIL_TEST_RESEND_API_KEY: ${{ secrets.ANYMAIL_TEST_RESEND_API_KEY }}
           ANYMAIL_TEST_RESEND_DOMAIN: ${{ secrets.ANYMAIL_TEST_RESEND_DOMAIN }}
           ANYMAIL_TEST_SENDGRID_API_KEY: ${{ secrets.ANYMAIL_TEST_SENDGRID_API_KEY }}
-          ANYMAIL_TEST_SENDGRID_DOMAIN: ${{ secrets.ANYMAIL_TEST_SENDGRID_DOMAIN }}
+          ANYMAIL_TEST_SENDGRID_DOMAIN: ${{ vars.ANYMAIL_TEST_SENDGRID_DOMAIN }}
           ANYMAIL_TEST_SENDGRID_TEMPLATE_ID: ${{ secrets.ANYMAIL_TEST_SENDGRID_TEMPLATE_ID }}
           ANYMAIL_TEST_SPARKPOST_API_KEY: ${{ secrets.ANYMAIL_TEST_SPARKPOST_API_KEY }}
           ANYMAIL_TEST_SPARKPOST_DOMAIN: ${{ secrets.ANYMAIL_TEST_SPARKPOST_DOMAIN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,10 +25,21 @@ Release history
 ^^^^^^^^^^^^^^^
     ..  This extra heading level keeps the ToC from becoming unmanageably long
 
-vNext
------
+v13.0.1
+-------
 
 *Unreleased changes*
+
+Breaking changes (external)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* **SendGrid:** Anymail no longer officially supports SendGrid, because we are
+  unable to test it. Although it will *probably* keep working, you'll get
+  warnings about this change in status. See `#432`_ for details, and the
+  `docs <https://anymail.dev/en/stable/esps/sendgrid/>`__ if you want
+  to suppress the warnings. (Since this breaking change is due to external
+  causes and impacts SendGrid users on all versions of Anymail, it is being
+  handled as a minor patch rather than a semver major version change.)
 
 Fixes
 ~~~~~
@@ -1777,6 +1788,7 @@ Features
 .. _#148: https://github.com/anymail/django-anymail/issues/148
 .. _#153: https://github.com/anymail/django-anymail/issues/153
 .. _#304: https://github.com/anymail/django-anymail/issues/304
+.. _#432: https://github.com/anymail/django-anymail/issues/432
 
 .. _@ailionx: https://github.com/ailionx
 .. _@alee: https://github.com/alee

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Anymail currently supports these ESPs:
 * **Postal** (self-hosted ESP)
 * **Postmark** (ActiveCampaign transactional email)
 * **Resend**
-* **SendGrid** (Twilio transactional email)
+* **SendGrid** (Twilio transactional email; no longer tested)
 * **SparkPost** (Bird transactional email)
 * **Unisender Go**
 
@@ -94,7 +94,7 @@ Anymail 1-2-3
 .. This quickstart section is also included in docs/quickstart.rst
 
 Here's how to send a message.
-This example uses Mailgun, but you can substitute Mailjet or Postmark or SendGrid
+This example uses Mailgun, but you can substitute Amazon SES or Mailjet or Postmark
 or SparkPost or any other supported ESP where you see "mailgun":
 
 1. Install Anymail from PyPI:
@@ -122,7 +122,7 @@ or SparkPost or any other supported ESP where you see "mailgun":
             "MAILGUN_API_KEY": "<your Mailgun key>",
             "MAILGUN_SENDER_DOMAIN": 'mg.example.com',  # your Mailgun domain, if needed
         }
-        EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"  # or sendgrid.EmailBackend, or...
+        EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"  # or amazon_ses.EmailBackend, or...
         DEFAULT_FROM_EMAIL = "you@example.com"  # if you don't already have this in settings
         SERVER_EMAIL = "your-server@example.com"  # ditto (default from-email for Django errors)
 

--- a/anymail/backends/sendgrid.py
+++ b/anymail/backends/sendgrid.py
@@ -5,6 +5,7 @@ from requests.structures import CaseInsensitiveDict
 
 from ..exceptions import (
     AnymailConfigurationError,
+    AnymailNotSupportedWarning,
     AnymailSerializationError,
     AnymailWarning,
 )
@@ -23,6 +24,12 @@ class EmailBackend(AnymailRequestsBackend):
     def __init__(self, **kwargs):
         """Init options from Django settings"""
         esp_name = self.esp_name
+
+        warnings.warn(
+            "django-anymail has dropped official support for SendGrid."
+            " See https://github.com/anymail/django-anymail/issues/432.",
+            AnymailNotSupportedWarning,
+        )
 
         # Warn if v2-only username or password settings found
         username = get_anymail_setting(

--- a/anymail/checks.py
+++ b/anymail/checks.py
@@ -31,6 +31,18 @@ def check_deprecated_settings(app_configs, **kwargs):
             )
         )
 
+    if (
+        getattr(settings, "EMAIL_BACKEND", "")
+        == "anymail.backends.sendgrid.EmailBackend"
+    ):
+        errors.append(
+            checks.Warning(
+                "django-anymail has dropped official support for SendGrid.",
+                hint="See https://github.com/anymail/django-anymail/issues/432.",
+                id="anymail.W003",
+            )
+        )
+
     return errors
 
 

--- a/anymail/exceptions.py
+++ b/anymail/exceptions.py
@@ -197,6 +197,10 @@ class AnymailDeprecationWarning(AnymailWarning, DeprecationWarning):
     """Warning for deprecated Anymail features"""
 
 
+class AnymailNotSupportedWarning(AnymailWarning):
+    """Warning for ESP integrations that are no longer being tested"""
+
+
 # Helpers
 
 

--- a/anymail/webhooks/sendgrid.py
+++ b/anymail/webhooks/sendgrid.py
@@ -1,8 +1,10 @@
 import json
+import warnings
 from datetime import datetime, timezone
 from email.parser import BytesParser
 from email.policy import default as default_policy
 
+from ..exceptions import AnymailNotSupportedWarning
 from ..inbound import AnymailInboundMessage
 from ..signals import (
     AnymailInboundEvent,
@@ -20,6 +22,14 @@ class SendGridTrackingWebhookView(AnymailBaseWebhookView):
 
     esp_name = "SendGrid"
     signal = tracking
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        warnings.warn(
+            "django-anymail has dropped official support for SendGrid."
+            " See https://github.com/anymail/django-anymail/issues/432.",
+            AnymailNotSupportedWarning,
+        )
 
     def parse_events(self, request):
         esp_events = json.loads(request.body.decode("utf-8"))
@@ -135,6 +145,14 @@ class SendGridInboundWebhookView(AnymailBaseWebhookView):
 
     esp_name = "SendGrid"
     signal = inbound
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        warnings.warn(
+            "django-anymail has dropped official support for SendGrid."
+            " See https://github.com/anymail/django-anymail/issues/432.",
+            AnymailNotSupportedWarning,
+        )
 
     def parse_events(self, request):
         return [self.esp_to_anymail_event(request)]

--- a/docs/esps/esp-feature-matrix.csv
+++ b/docs/esps/esp-feature-matrix.csv
@@ -1,4 +1,5 @@
 Email Service Provider,:ref:`amazon-ses-backend`,:ref:`brevo-backend`,:ref:`mailersend-backend`,:ref:`mailgun-backend`,:ref:`mailjet-backend`,:ref:`mandrill-backend`,:ref:`postal-backend`,:ref:`postmark-backend`,:ref:`resend-backend`,:ref:`sendgrid-backend`,:ref:`sparkpost-backend`,:ref:`unisender-go-backend`
+Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Limited,Limited,Full,Full,**Unsupported**,Full,Full
 .. rubric:: :ref:`Anymail send options <anymail-send-options>`,,,,,,,,,,,,
 :attr:`~AnymailMessage.envelope_sender`,Yes,No,No,Domain only,Yes,Domain only,Yes,No,No,No,Yes,No
 :attr:`~AnymailMessage.merge_headers`,Yes [#caveats]_,Yes,No,Yes,Yes,No,No,Yes,Yes,Yes,Yes [#caveats]_,Yes [#caveats]_

--- a/docs/esps/index.rst
+++ b/docs/esps/index.rst
@@ -48,6 +48,14 @@ The table below summarizes the Anymail features supported for each ESP.
     :widths: auto
     :class: sticky-left
 
+.. [#support-status]
+    "Full" support indicates the Anymail project has an account with the ESP and
+    regularly runs live integration tests against their API. "Limited" indicates
+    Anymail has access to the ESP for testing and debugging issues, but doesn't
+    run integration tests regularly. "Unsupported" means Anymail does not have
+    testing access to the ESP. (The ESP's detail page will provide more details
+    on "Limited" and "Unsupported".)
+
 .. [#caveats]
     Some restrictions apply---see the ESP detail page
     (usually under "Limitations and Quirks").
@@ -56,8 +64,8 @@ The table below summarizes the Anymail features supported for each ESP.
     The ESP supports tracking, but Anymail can't enable/disable it
     for individual messages. See the ESP detail page for more information.
 
-Trying to choose an ESP? Please **don't** start with this table. It's far more
-important to consider things like an ESP's deliverability stats, latency, uptime,
+Trying to choose an ESP? Please **don't** start with the feature checklist. It's far
+more important to consider things like an ESP's deliverability stats, latency, uptime,
 and support for developers. The *number* of extra features an ESP offers is almost
 meaningless. (And even specific features don't matter if you don't plan to use them.)
 

--- a/docs/esps/sendgrid.rst
+++ b/docs/esps/sendgrid.rst
@@ -3,9 +3,34 @@
 SendGrid
 ========
 
-Anymail integrates with the Twilio `SendGrid`_ email service, using their `Web API v3`_.
+Anymail integrates with the Twilio `SendGrid`_ email service, using their `Web API`_.
 
-.. important::
+.. warning:: **Unsupported since June 2025**
+
+    Anymail's SendGrid integration hasn't been tested against the live SendGrid API
+    since June 2025. As a result, SendGrid is no longer officially supported in
+    django-anymail. See `issue #432`_ for background and recommendations.
+
+    Although it will *probably* keep working, future bugs will likely be discovered
+    in production, by users like you, and we won't be able to verify proposed fixes.
+
+    To alert users to the change in support status, django-anymail 13.0.1 and later
+    will issue warnings when SendGrid features are used. If you are comfortable using
+    code that is no longer fully tested, you can disable these warnings by adding this
+    to your settings.py:
+
+    .. code-block:: python
+
+        SILENCED_SYSTEM_CHECKS = ["anymail.W003"]
+
+        import warnings
+        warnings.filterwarnings(
+            "ignore",
+            message="django-anymail has dropped official support for SendGrid",
+        )
+
+
+.. note::
 
     **Troubleshooting:**
     If your SendGrid messages aren't being delivered as expected, be sure to look for
@@ -15,7 +40,8 @@ Anymail integrates with the Twilio `SendGrid`_ email service, using their `Web A
     to succeed, and reports these errors as drop events.
 
 .. _SendGrid: https://sendgrid.com/
-.. _Web API v3: https://www.twilio.com/docs/sendgrid/api-reference
+.. _Web API: https://www.twilio.com/docs/sendgrid/api-reference
+.. _issue #432: https://github.com/anymail/django-anymail/issues/432
 .. _activity feed: https://app.sendgrid.com/email_activity?events=drops
 
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -38,6 +38,20 @@ class DeprecatedSettingsTests(AnymailTestMixin, SimpleTestCase):
             ],
         )
 
+    @override_settings(EMAIL_BACKEND="anymail.backends.sendgrid.EmailBackend")
+    def test_sendgrid_unsupported(self):
+        errors = check_deprecated_settings(None)
+        self.assertEqual(
+            errors,
+            [
+                checks.Warning(
+                    "django-anymail has dropped official support for SendGrid.",
+                    hint="See https://github.com/anymail/django-anymail/issues/432.",
+                    id="anymail.W003",
+                )
+            ],
+        )
+
 
 class InsecureSettingsTests(AnymailTestMixin, SimpleTestCase):
     @override_settings(ANYMAIL={"DEBUG_API_REQUESTS": True})

--- a/tests/test_sendgrid_backend.py
+++ b/tests/test_sendgrid_backend.py
@@ -7,7 +7,7 @@ from email.mime.image import MIMEImage
 from unittest.mock import patch
 
 from django.core import mail
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, ignore_warnings, override_settings, tag
 from django.utils.timezone import (
     get_fixed_timezone,
     override as override_current_timezone,
@@ -16,6 +16,7 @@ from django.utils.timezone import (
 from anymail.exceptions import (
     AnymailAPIError,
     AnymailConfigurationError,
+    AnymailNotSupportedWarning,
     AnymailSerializationError,
     AnymailUnsupportedFeature,
     AnymailWarning,
@@ -39,6 +40,7 @@ from .utils import (
     EMAIL_BACKEND="anymail.backends.sendgrid.EmailBackend",
     ANYMAIL={"SENDGRID_API_KEY": "test_api_key"},
 )
+@ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridBackendMockAPITestCase(RequestsBackendMockAPITestCase):
     # SendGrid v3 success responses are empty:
     DEFAULT_RAW_RESPONSE = b""
@@ -63,8 +65,16 @@ class SendGridBackendMockAPITestCase(RequestsBackendMockAPITestCase):
 
 
 @tag("sendgrid")
+@ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridBackendStandardEmailTests(SendGridBackendMockAPITestCase):
     """Test backend support for Django standard email features"""
+
+    def test_not_supported_warning(self):
+        with self.assertWarns(
+            AnymailNotSupportedWarning,
+            msg="django-anymail has dropped official support for SendGrid.",
+        ):
+            mail.get_connection()
 
     def test_send_mail(self):
         """Test basic API for simple send"""
@@ -461,6 +471,7 @@ class SendGridBackendStandardEmailTests(SendGridBackendMockAPITestCase):
 
 
 @tag("sendgrid")
+@ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
     """Test backend support for Anymail added features"""
 
@@ -1298,6 +1309,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
 
 
 @tag("sendgrid")
+@ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridBackendRecipientsRefusedTests(SendGridBackendMockAPITestCase):
     """
     Should raise AnymailRecipientsRefused when *all* recipients are rejected or invalid
@@ -1310,6 +1322,7 @@ class SendGridBackendRecipientsRefusedTests(SendGridBackendMockAPITestCase):
 
 
 @tag("sendgrid")
+@ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridBackendSessionSharingTestCase(
     SessionSharingTestCases, SendGridBackendMockAPITestCase
 ):
@@ -1320,6 +1333,7 @@ class SendGridBackendSessionSharingTestCase(
 
 @tag("sendgrid")
 @override_settings(EMAIL_BACKEND="anymail.backends.sendgrid.EmailBackend")
+@ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
     """Test ESP backend without required settings in place"""
 
@@ -1330,6 +1344,7 @@ class SendGridBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase)
 
 @tag("sendgrid")
 @override_settings(EMAIL_BACKEND="anymail.backends.sendgrid.EmailBackend")
+@ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridBackendDisallowsV2Tests(AnymailTestMixin, SimpleTestCase):
     """Using v2-API-only features should cause errors with v3 backend"""
 

--- a/tests/test_sendgrid_inbound.py
+++ b/tests/test_sendgrid_inbound.py
@@ -3,8 +3,9 @@ from io import BytesIO
 from textwrap import dedent
 from unittest.mock import ANY
 
-from django.test import tag
+from django.test import ignore_warnings, tag
 
+from anymail.exceptions import AnymailNotSupportedWarning
 from anymail.inbound import AnymailInboundMessage
 from anymail.signals import AnymailInboundEvent
 from anymail.webhooks.sendgrid import SendGridInboundWebhookView
@@ -20,7 +21,15 @@ from .webhook_cases import WebhookTestCase
 
 
 @tag("sendgrid")
+@ignore_warnings(category=AnymailNotSupportedWarning)
 class SendgridInboundTestCase(WebhookTestCase):
+    def test_not_supported_warning(self):
+        with self.assertWarns(
+            AnymailNotSupportedWarning,
+            msg="django-anymail has dropped official support for SendGrid.",
+        ):
+            self.client.post("/anymail/sendgrid/inbound/", data={"email": ""})
+
     def test_inbound_basics(self):
         raw_event = {
             "headers": dedent(

--- a/tests/test_sendgrid_webhooks.py
+++ b/tests/test_sendgrid_webhooks.py
@@ -2,8 +2,9 @@ import json
 from datetime import datetime, timezone
 from unittest.mock import ANY
 
-from django.test import tag
+from django.test import ignore_warnings, tag
 
+from anymail.exceptions import AnymailNotSupportedWarning
 from anymail.signals import AnymailTrackingEvent
 from anymail.webhooks.sendgrid import SendGridTrackingWebhookView
 
@@ -11,6 +12,7 @@ from .webhook_cases import WebhookBasicAuthTestCase, WebhookTestCase
 
 
 @tag("sendgrid")
+@ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridWebhookSecurityTestCase(WebhookBasicAuthTestCase):
     def call_webhook(self):
         return self.client.post(
@@ -23,7 +25,19 @@ class SendGridWebhookSecurityTestCase(WebhookBasicAuthTestCase):
 
 
 @tag("sendgrid")
+@ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridDeliveryTestCase(WebhookTestCase):
+    def test_not_supported_warning(self):
+        with self.assertWarns(
+            AnymailNotSupportedWarning,
+            msg="django-anymail has dropped official support for SendGrid.",
+        ):
+            self.client.post(
+                "/anymail/sendgrid/tracking/",
+                content_type="application/json",
+                data=json.dumps([]),
+            )
+
     def test_processed_event(self):
         raw_events = [
             {


### PR DESCRIPTION
* Update docs to indicate SendGrid is no longer regularly tested, so is officially unsupported
* Disable SendGrid live integration tests (which have been failing due to disabled testing account)
* Add warning messages in SendGrid EmailBackend, inbound and tracking webhooks, and Django system checks when Anymail SendGrid features are used
* Add "Anymail support status" line to ESP feature matrix in the docs

Closes #432 