### PR TITLE
Scaleway: cleanup and enable integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,6 +48,7 @@ jobs:
           - { tox: django52-py313-postal, python: "3.13" }
           - { tox: django52-py313-postmark, python: "3.13" }
           - { tox: django52-py313-resend, python: "3.13" }
+          - { tox: django52-py313-scaleway, python: "3.13" }
           # - { tox: django52-py313-sendgrid, python: "3.13" }
           - { tox: django52-py313-sparkpost, python: "3.13" }
           - { tox: django52-py313-unisender_go, python: "3.13" }
@@ -95,6 +96,9 @@ jobs:
           ANYMAIL_TEST_POSTMARK_TEMPLATE_ID: ${{ secrets.ANYMAIL_TEST_POSTMARK_TEMPLATE_ID }}
           ANYMAIL_TEST_RESEND_API_KEY: ${{ secrets.ANYMAIL_TEST_RESEND_API_KEY }}
           ANYMAIL_TEST_RESEND_DOMAIN: ${{ secrets.ANYMAIL_TEST_RESEND_DOMAIN }}
+          ANYMAIL_TEST_SCALEWAY_DOMAIN: ${{ vars.ANYMAIL_TEST_SCALEWAY_DOMAIN }}
+          ANYMAIL_TEST_SCALEWAY_PROJECT_ID: ${{ secrets.ANYMAIL_TEST_SCALEWAY_PROJECT_ID }}
+          ANYMAIL_TEST_SCALEWAY_SECRET_KEY: ${{ secrets.ANYMAIL_TEST_SCALEWAY_SECRET_KEY }}
           ANYMAIL_TEST_SENDGRID_API_KEY: ${{ secrets.ANYMAIL_TEST_SENDGRID_API_KEY }}
           ANYMAIL_TEST_SENDGRID_DOMAIN: ${{ vars.ANYMAIL_TEST_SENDGRID_DOMAIN }}
           ANYMAIL_TEST_SENDGRID_TEMPLATE_ID: ${{ secrets.ANYMAIL_TEST_SENDGRID_TEMPLATE_ID }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 description = """\
 Django email backends and webhooks for Amazon SES, Brevo,
  MailerSend, Mailgun, Mailjet, Mandrill, Postal, Postmark, Resend,
- SendGrid, SparkPost, Unisender Go and Scaleway
+ Scaleway TEM, SendGrid, SparkPost, and Unisender Go
  (EmailBackend, transactional email tracking and inbound email signals)\
 """
 # readme: see tool.hatch.metadata.hooks.custom below
@@ -30,10 +30,7 @@ keywords = [
     "Postal",
     "Postmark", "ActiveCampaign",
     "Resend",
-    "SendGrid", "Twilio",
-    "SparkPost", "Bird",
-    "Resend",
-    "Scaleway",
+    "Scaleway", "Scaleway TEM",
     "SendGrid", "Twilio",
     "SparkPost", "Bird",
     "Unisender Go",
@@ -81,6 +78,13 @@ mailersend = []
 mailgun = []
 mailjet = []
 mandrill = []
+postal = [
+    # Postal requires cryptography for verifying webhooks.
+    # Cryptography's wheels are broken on darwin-arm64 before Python 3.9,
+    # and unbuildable on PyPy 3.8 due to PyO3 limitations. Since cpython 3.8
+    # has also passed EOL, just require Python 3.9+ with Postal.
+    "cryptography; python_version >= '3.9'"
+]
 postmark = []
 resend = ["svix"]
 scaleway = []
@@ -94,13 +98,6 @@ sendgrid = [
 sendinblue = []
 sparkpost = []
 unisender-go = []
-postal = [
-    # Postal requires cryptography for verifying webhooks.
-    # Cryptography's wheels are broken on darwin-arm64 before Python 3.9,
-    # and unbuildable on PyPy 3.8 due to PyO3 limitations. Since cpython 3.8
-    # has also passed EOL, just require Python 3.9+ with Postal.
-    "cryptography; python_version >= '3.9'"
-]
 
 [project.urls]
 Homepage = "https://github.com/anymail/django-anymail"

--- a/tox.ini
+++ b/tox.ini
@@ -64,10 +64,10 @@ setenv =
     postal: ANYMAIL_ONLY_TEST=postal
     postmark: ANYMAIL_ONLY_TEST=postmark
     resend: ANYMAIL_ONLY_TEST=resend
-    sendgrid: ANYMAIL_ONLY_TEST=sendgrid
-    unisender_go: ANYMAIL_ONLY_TEST=unisender_go
-    sparkpost: ANYMAIL_ONLY_TEST=sparkpost
     scaleway: ANYMAIL_ONLY_TEST=scaleway
+    sendgrid: ANYMAIL_ONLY_TEST=sendgrid
+    sparkpost: ANYMAIL_ONLY_TEST=sparkpost
+    unisender_go: ANYMAIL_ONLY_TEST=unisender_go
 ignore_outcome =
     # CI that wants to handle errors itself can set TOX_OVERRIDE_IGNORE_OUTCOME=false
     djangoDev: {env:TOX_OVERRIDE_IGNORE_OUTCOME:true}


### PR DESCRIPTION
- Fix accidental ESP duplication in pyproject.toml keywords
- Alphabetize ESP names in pyproject.toml, tox.ini
- Enable scaleway in integration-test.yml