### PR TITLE
All ESPs: Unicode header handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,66 @@ Release history
 ^^^^^^^^^^^^^^^
     ..  This extra heading level keeps the ToC from becoming unmanageably long
 
+vNext
+-----
+
+*Unreleased changes*
+
+This release improves handling of non-ASCII characters everywhere email messages
+allow them, based on extensive testing of Unicode handling for all supported
+ESPs. There are several new workarounds for ESP bugs and a handful of new
+errors to help you avoid bugs that don't have workarounds. See
+`International email <https://anymail.dev/en/latest/tips/international_email/#idna>`_
+in the docs for more information.
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* **International domain names:** When sending email to a non-ASCII domain name,
+  use IDNA 2008 with UTS-46 pre-processing rather than obsolete IDNA 2003
+  encoding. This ensures email can be sent to newer domains enabled by IDNA 2008.
+
+  This change should make no difference for virtually all real-world email
+  addresses that worked with earlier Anymail releases. But trying to send to
+  emoji domains or others no longer allowed by IDNA 2008 will now raise an
+  ``AnymailInvalidAddress`` error.
+
+  To restore the old behavior or select a different encoding, use the new
+  ``IDNA_ENCODER`` setting. See
+  `Domains (IDNA) <https://anymail.dev/en/latest/tips/international_email/#idna>`_
+  in the docs.
+
+  As part of this change, Anymail now has a direct dependency on the ``idna``
+  package. (It was already being installed as a sub-dependency of ``requests``.)
+
+* **Brevo:** Raise an error if metadata or custom header values include non-ASCII
+  characters. This avoids a Brevo API bug that sends unencoded 8-bit headers,
+  which can cause bounces or dropped messages.
+
+* **Mailgun:** Raise an error if the ``from_email`` uses EAI (has a non-ASCII
+  local part). This avoids a Mailgun API bug that generates undeliverable
+  messages.
+
+* **Scaleway TEM:** Raise an error if any address field uses EAI (has a non-ASCII
+  local part). This avoids a Scaleway API bug that generates undeliverable messages.
+
+Fixes
+~~~~~
+
+* **Brevo:** Work around a Brevo API bug which loses non-ASCII display names
+  that also contain a comma or certain other punctuation.
+
+Other
+~~~~~
+
+* **Mandrill:** Document a Mandrill API bug that can cause an address with a
+  non-ASCII display name to display incorrectly in some email clients.
+
+* **Unisender Go:** Document a Unisender Go API bug that can cause an Reply-To
+  address (only) with a non-ASCII display name to display incorrectly in some
+  email clients.
+
+
 v13.1
 -----
 

--- a/anymail/_idna.py
+++ b/anymail/_idna.py
@@ -1,0 +1,53 @@
+# Pre-packaged IDNA_ENCODER options
+import idna
+
+from anymail.exceptions import AnymailImproperlyInstalled, _LazyError
+
+try:
+    from uts46 import encode as uts46_encode
+except ImportError:
+    uts46_encode = _LazyError(
+        AnymailImproperlyInstalled("uts46", "<your-esp>,uts46", 'IDNA_ENCODER="uts46"')
+    )
+
+__all__ = ["idna2003", "idna2008", "uts46", "none"]
+
+
+def idna2003(domain: str) -> str:
+    """
+    Encode domain (if necessary) using IDNA 2003 standard.
+    This matches Django's own behavior and requires no extra libraries.
+    But it will fail to encode some newer IDNs that require IDNA 2008, and
+    it will use obsolete encoding for IDNs that contain deviation characters.
+    """
+    return domain.encode("idna").decode("ascii")
+
+
+def idna2008(domain: str) -> str:
+    """
+    Encode domain (if necessary) using the IDNA 2008 standard
+    with UTS46 preprocessing. (Preprocessing is required to handle
+    case insensitivity most users would expect.)
+
+    Will reject some domains (e.g., emojis) that browsers allow.
+    Relies on the third-party 'idna' package (installed with django-anymail).
+    """
+    return idna.encode(domain, uts46=True).decode("ascii")
+
+
+def uts46(domain: str) -> str:
+    """
+    Encode domain (if necessary) using the UTS46 standard.
+    This is the encoding used by all modern browsers.
+
+    Requires the 'uts46' package (installable via 'django-anymail[uts46]' extra).
+    """
+    return uts46_encode(domain).decode("ascii")
+
+
+def none(domain: str) -> str:
+    """
+    Leaves domain as unencoded Unicode characters.
+    Can be used with an ESP whose API correctly handles IDNA encoding.
+    """
+    return domain

--- a/anymail/backends/mailersend.py
+++ b/anymail/backends/mailersend.py
@@ -213,10 +213,7 @@ class MailerSendPayload(RequestsPayload):
 
     def make_mailersend_email(self, email):
         """Return MailerSend email/name object for an EmailAddress"""
-        obj = {"email": email.addr_spec}
-        if email.display_name:
-            obj["name"] = email.display_name
-        return obj
+        return email.as_dict(idna_encode=self.backend.idna_encode)
 
     def init_payload(self):
         self.data = {}  # becomes json

--- a/anymail/backends/mailgun.py
+++ b/anymail/backends/mailgun.py
@@ -320,8 +320,15 @@ class MailgunPayload(RequestsPayload):
         self.headers = {}
 
     def set_from_email_list(self, emails):
+        # Mailgun generates invalid headers for EAI, which results
+        # in undeliverable messages in the From header.
+        if any(email.uses_eai for email in emails):
+            self.unsupported_feature("EAI in from_email")
+
         # Mailgun supports multiple From email addresses
-        self.data["from"] = [email.address for email in emails]
+        self.data["from"] = [
+            email.format(idna_encode=self.backend.idna_encode) for email in emails
+        ]
         if self.sender_domain is None and len(emails) > 0:
             # try to intuit sender_domain from first from_email
             self.sender_domain = emails[0].domain or None
@@ -329,7 +336,9 @@ class MailgunPayload(RequestsPayload):
     def set_recipients(self, recipient_type, emails):
         assert recipient_type in ["to", "cc", "bcc"]
         if emails:
-            self.data[recipient_type] = [email.address for email in emails]
+            self.data[recipient_type] = [
+                email.format(idna_encode=self.backend.idna_encode) for email in emails
+            ]
             # used for backend.parse_recipient_status:
             self.all_recipients += emails
         if recipient_type == "to":
@@ -341,7 +350,9 @@ class MailgunPayload(RequestsPayload):
 
     def set_reply_to(self, emails):
         if emails:
-            reply_to = ", ".join([str(email) for email in emails])
+            reply_to = ", ".join(
+                [email.format(idna_encode=self.backend.idna_encode) for email in emails]
+            )
             self.data["h:Reply-To"] = reply_to
 
     def set_extra_headers(self, headers):

--- a/anymail/backends/mailjet.py
+++ b/anymail/backends/mailjet.py
@@ -130,13 +130,11 @@ class MailjetPayload(RequestsPayload):
             to_recipients = self.data["Messages"][0].get("To", [])
             self.data["Messages"] = [{"To": [to]} for to in to_recipients]
 
-    @staticmethod
-    def _mailjet_email(email):
+    def _mailjet_email(self, email):
         """Expand an Anymail EmailAddress into Mailjet's {"Email", "Name"} dict"""
-        result = {"Email": email.addr_spec}
-        if email.display_name:
-            result["Name"] = email.display_name
-        return result
+        return email.as_dict(
+            name="Name", email="Email", idna_encode=self.backend.idna_encode
+        )
 
     def set_from_email(self, email):
         self.data["Globals"]["From"] = self._mailjet_email(email)

--- a/anymail/backends/postal.py
+++ b/anymail/backends/postal.py
@@ -65,25 +65,33 @@ class PostalPayload(RequestsPayload):
         return self.serialize_json(self.data)
 
     def set_from_email(self, email):
-        self.data["from"] = str(email)
+        self.data["from"] = email.format(idna_encode=self.backend.idna_encode)
 
     def set_subject(self, subject):
         self.data["subject"] = subject
 
     def set_to(self, emails):
-        self.data["to"] = [str(email) for email in emails]
+        self.data["to"] = [
+            email.format(idna_encode=self.backend.idna_encode) for email in emails
+        ]
 
     def set_cc(self, emails):
-        self.data["cc"] = [str(email) for email in emails]
+        self.data["cc"] = [
+            email.format(idna_encode=self.backend.idna_encode) for email in emails
+        ]
 
     def set_bcc(self, emails):
-        self.data["bcc"] = [str(email) for email in emails]
+        self.data["bcc"] = [
+            email.format(idna_encode=self.backend.idna_encode) for email in emails
+        ]
 
     def set_reply_to(self, emails):
         if len(emails) > 1:
             self.unsupported_feature("multiple reply_to addresses")
         if len(emails) > 0:
-            self.data["reply_to"] = str(emails[0])
+            self.data["reply_to"] = emails[0].format(
+                idna_encode=self.backend.idna_encode
+            )
 
     def set_extra_headers(self, headers):
         self.data["headers"] = headers

--- a/anymail/backends/postmark.py
+++ b/anymail/backends/postmark.py
@@ -307,13 +307,17 @@ class PostmarkPayload(RequestsPayload):
     def set_from_email_list(self, emails):
         # Postmark accepts multiple From email addresses
         # (though truncates to just the first, on their end, as of 4/2017)
-        self.data["From"] = ", ".join([email.address for email in emails])
+        self.data["From"] = ", ".join(
+            [email.format(idna_encode=self.backend.idna_encode) for email in emails]
+        )
 
     def set_recipients(self, recipient_type, emails):
         assert recipient_type in ["to", "cc", "bcc"]
         if emails:
             field = recipient_type.capitalize()
-            self.data[field] = ", ".join([email.address for email in emails])
+            self.data[field] = ", ".join(
+                [email.format(idna_encode=self.backend.idna_encode) for email in emails]
+            )
             if recipient_type == "to":
                 self.to_emails = emails
             else:
@@ -324,7 +328,9 @@ class PostmarkPayload(RequestsPayload):
 
     def set_reply_to(self, emails):
         if emails:
-            reply_to = ", ".join([email.address for email in emails])
+            reply_to = ", ".join(
+                [email.format(idna_encode=self.backend.idna_encode) for email in emails]
+            )
             self.data["ReplyTo"] = reply_to
 
     def set_extra_headers(self, headers):

--- a/anymail/backends/resend.py
+++ b/anymail/backends/resend.py
@@ -130,13 +130,15 @@ class ResendPayload(RequestsPayload):
         self.data = {}  # becomes json
 
     def set_from_email(self, email):
-        self.data["from"] = email.address
+        self.data["from"] = email.format(idna_encode=self.backend.idna_encode)
 
     def set_recipients(self, recipient_type, emails):
         assert recipient_type in ["to", "cc", "bcc"]
         if emails:
             field = recipient_type
-            self.data[field] = [email.address for email in emails]
+            self.data[field] = [
+                email.format(idna_encode=self.backend.idna_encode) for email in emails
+            ]
             self.recipients += emails
             if recipient_type == "to":
                 self.to_recipients = emails
@@ -146,7 +148,9 @@ class ResendPayload(RequestsPayload):
 
     def set_reply_to(self, emails):
         if emails:
-            self.data["reply_to"] = [email.address for email in emails]
+            self.data["reply_to"] = [
+                email.format(idna_encode=self.backend.idna_encode) for email in emails
+            ]
 
     def set_extra_headers(self, headers):
         # Resend requires header values to be strings (not integers) as of 2023-10-20.

--- a/anymail/backends/scaleway.py
+++ b/anymail/backends/scaleway.py
@@ -99,21 +99,22 @@ class ScalewayPayload(RequestsPayload):
             "project_id": self.project_id,
         }
 
-    def _scaleway_email(self, email):
-        """Expand an Anymail EmailAddress into Scaleway's {"email", "name"} dict"""
-        result = {"email": email.addr_spec}
-        if email.display_name:
-            result["name"] = email.display_name
-        return result
-
     def set_from_email(self, email):
-        self.data["from"] = self._scaleway_email(email)
+        # Scaleway generates an invalid message (that bounces or gets lost)
+        # if any address header uses EAI.
+        if email.uses_eai:
+            self.unsupported_feature("EAI in from_email")
+        self.data["from"] = email.as_dict(idna_encode=self.backend.idna_encode)
 
     def set_recipients(self, recipient_type, emails):
         assert recipient_type in {"to", "cc", "bcc"}
+        # Scaleway generates an invalid message (that bounces or gets lost)
+        # if any address header uses EAI.
+        if any(email.uses_eai for email in emails):
+            self.unsupported_feature(f"EAI in {recipient_type}")
         if emails:
             self.data[recipient_type] = [
-                self._scaleway_email(email) for email in emails
+                email.as_dict(idna_encode=self.backend.idna_encode) for email in emails
             ]
 
     def set_subject(self, subject):
@@ -145,8 +146,17 @@ class ScalewayPayload(RequestsPayload):
         )
 
     def set_reply_to(self, emails):
+        # Scaleway generates an invalid message (that bounces or gets lost)
+        # if any address header uses EAI.
+        if any(email.uses_eai for email in emails):
+            self.unsupported_feature("EAI in reply_to")
         if emails:
-            reply_to_string = ", ".join([str(email) for email in emails])
+            reply_to_string = ", ".join(
+                [
+                    email.format(use_rfc2047=True, idna_encode=self.backend.idna_encode)
+                    for email in emails
+                ]
+            )
             self.data.setdefault("additional_headers", []).append(
                 {"key": "Reply-To", "value": reply_to_string}
             )

--- a/anymail/backends/sendgrid.py
+++ b/anymail/backends/sendgrid.py
@@ -245,13 +245,9 @@ class SendGridPayload(RequestsPayload):
     # Payload construction
     #
 
-    @staticmethod
-    def email_object(email):
+    def email_object(self, email):
         """Converts EmailAddress to SendGrid API {email, name} dict"""
-        obj = {"email": email.addr_spec}
-        if email.display_name:
-            obj["name"] = email.display_name
-        return obj
+        return email.as_dict(idna_encode=self.backend.idna_encode)
 
     def set_from_email(self, email):
         self.data["from"] = self.email_object(email)

--- a/anymail/backends/unisender_go.py
+++ b/anymail/backends/unisender_go.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import re
 import typing
 import uuid
 from datetime import datetime, timezone
-from email.charset import QP, Charset
-from email.headerregistry import Address
 
 from django.core.mail import EmailMessage
 from requests import Response
@@ -13,12 +10,14 @@ from requests.structures import CaseInsensitiveDict
 
 from anymail.backends.base_requests import AnymailRequestsBackend, RequestsPayload
 from anymail.message import AnymailRecipientStatus
-from anymail.utils import Attachment, EmailAddress, get_anymail_setting, update_deep
-
-# Used to force RFC-2047 encoded word
-# in address formatting workaround
-QP_CHARSET = Charset("utf-8")
-QP_CHARSET.header_encoding = QP
+from anymail.utils import (
+    Attachment,
+    EmailAddress,
+    get_anymail_setting,
+    has_specials,
+    rfc2047_encode,
+    update_deep,
+)
 
 
 class EmailBackend(AnymailRequestsBackend):
@@ -184,9 +183,15 @@ class UnisenderGoPayload(RequestsPayload):
     #
 
     def set_from_email(self, email: EmailAddress) -> None:
-        self.data["from_email"] = email.addr_spec
-        if email.display_name:
-            self.data["from_name"] = email.display_name
+        self.data.update(
+            email.as_dict(
+                email="from_email",
+                name="from_name",
+                idna_encode=self.backend.idna_encode,
+            )
+        )
+
+    _display_name_bug_chars = set(",<>@")
 
     def _format_email_address(self, address):
         """
@@ -205,23 +210,21 @@ class UnisenderGoPayload(RequestsPayload):
         properly formats commas and other characters in `to_name` and `from_name`.
         (But see set_reply_to for a related issue.)
         """
-        formatted = address.address
-        if self.backend.workaround_display_name_bugs:
-            # Workaround: force RFC-2047 QP encoded word for display_name if it has
-            # prohibited chars (and isn't already encoded in the formatted address)
-            display_name = address.display_name
-            if re.search(r"[,<>@]", display_name) and display_name in formatted:
-                formatted = str(
-                    Address(
-                        display_name=QP_CHARSET.header_encode(address.display_name),
-                        addr_spec=address.addr_spec,
-                    )
-                )
-        return formatted
+        use_rfc2047 = True
+        if (
+            self.backend.workaround_display_name_bugs
+            and not self._display_name_bug_chars.isdisjoint(address.display_name)
+        ):
+            use_rfc2047 = "force"
+        return address.format(
+            use_rfc2047=use_rfc2047, idna_encode=self.backend.idna_encode
+        )
 
     def set_recipients(self, recipient_type: str, emails: list[EmailAddress]):
         for email in emails:
-            recipient = {"email": email.addr_spec}
+            recipient = {
+                "email": email.format_addr_spec(idna_encode=self.backend.idna_encode)
+            }
             if email.display_name:
                 recipient["substitutions"] = {"to_name": email.display_name}
             self.data["recipients"].append(recipient)
@@ -244,22 +247,42 @@ class UnisenderGoPayload(RequestsPayload):
             self.unsupported_feature("multiple reply_to addresses")
         if len(emails) > 0:
             reply_to = emails[0]
-            self.data["reply_to"] = reply_to.addr_spec
+            self.data["reply_to"] = reply_to.format_addr_spec(
+                idna_encode=self.backend.idna_encode
+            )
             display_name = reply_to.display_name
             if display_name:
+                use_rfc2047 = False
                 if self.backend.workaround_display_name_bugs:
-                    # Unisender Go doesn't properly "quote" (RFC 5322) a `reply_to_name`
-                    # containing special characters (comma, parens, etc.), resulting
-                    # in an invalid Reply-To header that can cause problems when the
-                    # recipient tries to reply. (They *do* properly handle special chars
-                    # in `to_name` and `from_name`; this only affects `reply_to_name`.)
-                    if reply_to.address.startswith('"'):  # requires quoted syntax
-                        # Workaround: force RFC-2047 encoded word
-                        display_name = QP_CHARSET.header_encode(display_name)
-                self.data["reply_to_name"] = display_name
+                    # Unisender Go has two bugs with display names in their generated
+                    # Reply-To headers:
+                    # - Non-ASCII display names are sent as unencoded (8-bit)
+                    #   ISO-8859-1, which can interfere with delivery.
+                    # - Display names with special characters (comma, parens, etc.) are
+                    #   not properly quoted (per RFC 5322), resulting in an invalid
+                    #   Reply-To header that can cause problems when the recipient
+                    #   tries to reply.
+                    # These issues only affect the reply_to_name. Unisender Go correctly
+                    # encodes display names in other address headers.
+                    if not display_name.isascii() or has_specials(display_name):
+                        use_rfc2047 = "force"
+                self.data["reply_to_name"] = reply_to.format_display_name(
+                    use_rfc2047=use_rfc2047
+                )
 
     def set_extra_headers(self, headers: dict[str, str]) -> None:
-        self.data["headers"].update(headers)
+        # Unisender Go incorrectly converts non-ASCII extra headers to ISO-8859-1
+        # and sends them as 8-bit content. Work around by converting to RFC 2047.
+        self.data["headers"].update(
+            {
+                field: (
+                    rfc2047_encode(value)
+                    if isinstance(value, str) and not value.isascii()
+                    else value
+                )
+                for field, value in headers.items()
+            }
+        )
 
     def set_text_body(self, body: str) -> None:
         if body:

--- a/anymail/exceptions.py
+++ b/anymail/exceptions.py
@@ -171,13 +171,13 @@ class AnymailConfigurationError(ImproperlyConfigured):
 class AnymailImproperlyInstalled(AnymailConfigurationError, ImportError):
     """Exception for Anymail missing package dependencies"""
 
-    def __init__(self, missing_package, install_extra="<esp>"):
+    def __init__(self, missing_package, install_extra="<esp>", feature="this ESP"):
         # install_extra must be the package "optional extras name" for the ESP
         # (not the backend's esp_name)
         message = (
-            "The %s package is required to use this ESP, but isn't installed.\n"
-            '(Be sure to use `pip install "django-anymail[%s]"` '
-            "with your desired ESP name(s).)" % (missing_package, install_extra)
+            f"The {missing_package} package isn't installed"
+            f" but is needed for {feature}.\n"
+            f'(Be sure to use `pip install "django-anymail[{install_extra}]"`.)'
         )
         super().__init__(message)
 

--- a/docs/esps/amazon_ses.rst
+++ b/docs/esps/amazon_ses.rst
@@ -137,6 +137,10 @@ Limitations and quirks
   Messages sent with templates have some additional limitations, such as not
   supporting attachments. See :ref:`amazon-ses-templates` below.
 
+**No non-ASCII mailboxes (EAI)**
+  Amazon SES does not support sending from or to Unicode mailboxes (the *user*
+  part of *user\@domain*---see :ref:`EAI <eai>`). Trying to use one will cause
+  a boto3 error message, "Local address contains control or whitespace."
 
 .. _throttles sending:
    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/manage-sending-limits.html

--- a/docs/esps/brevo.rst
+++ b/docs/esps/brevo.rst
@@ -167,6 +167,39 @@ Brevo can handle.
   This header is included in the sent message, so **metadata will be visible to
   message recipients** if they view the raw message source.
 
+**Metadata and extra_headers values must be ASCII**
+  Brevo's API incorrectly handles non-ASCII Unicode characters in custom email
+  headers, sending them as raw utf-8. Unencoded 8-bit values in an email header
+  are usually invalid, and can cause bounces or silently undelivered messages.
+
+  Anymail is not able to work around this problem, so will raise an
+  :exc:`AnymailUnsupportedFeature` error for non-ASCII ``extra_headers`` or
+  :attr:`~anymail.message.AnymailMessage.merge_headers` values.
+
+  Because Anymail's metadata uses Brevo's :mailheader:`X-Mailin-custom` header,
+  this also affects :attr:`~anymail.message.AnymailMessage.metadata` and
+  :attr:`~anymail.message.AnymailMessage.merge_metadata`.
+
+  .. versionchanged:: vNext
+
+     Earlier releases did not detect this situation and could send
+     undeliverable messages with non-ASCII headers or metadata.
+
+**Avoid mixing non-ASCII characters and punctuation in Reply-To**
+  Brevo's API incorrectly handles non-ASCII characters combined with commas and
+  certain other punctuation in address header display names.
+
+  Anymail is able to work around the problem in ``to``, ``cc`` and ``bcc`` names.
+  It applies the same workaround to ``reply_to`` names, but this triggers another
+  Brevo bug that may cause some recipients to see an RFC 2047 encoded-word
+  (``=?utf-8?...``) in their email client .
+
+  .. versionchanged:: vNext
+
+     Earlier releases did not include the workaround, resulting in Brevo
+     sending messages with potentially missing display names in ``to``, ``cc``
+     and ``bcc`` and possibly undeliverable messages for ``reply_to``.
+
 **Special headers**
   Brevo uses special email headers to control certain features.
   You can set these using Django's
@@ -202,6 +235,18 @@ Brevo can handle.
 **No envelope sender overrides**
   Brevo does not support overriding :attr:`~anymail.message.AnymailMessage.envelope_sender`
   on individual messages.
+
+**Non-ASCII mailboxes (EAI)**
+  Brevo partially supports sending from or to Unicode mailboxes (the *user* part
+  of *user\@domain*---see :ref:`EAI <eai>`). Messages are delivered correctly,
+  but in the ``to`` field any display name with an EAI address will be missing
+  from the delivered message. And if any EAI address appears in the ``cc`` field,
+  the entire :mailheader:`Cc` header will be omitted, making it effectively a ``bcc``.
+
+  Also, Brevo does not properly verify the receiving SMTP server supports EAI
+  (smtputf8). For valid EAI recipient addresses, this generally shouldn't cause
+  problems. For an EAI ``from_email`` or ``reply_to`` this could result in lost
+  or undeliverable messages.
 
 
 .. _brevo-templates:

--- a/docs/esps/mailersend.rst
+++ b/docs/esps/mailersend.rst
@@ -258,6 +258,9 @@ see :ref:`unsupported-features`.
 .. _rate limit headers:
    https://developers.mailersend.com/general.html#rate-limits
 
+**No non-ASCII mailboxes (EAI)**
+  Mailersend does not support sending from or to Unicode mailboxes (the *user* part
+  of *user\@domain*---see :ref:`EAI <eai>`). Trying to use one will cause an API error.
 
 
 .. _mailersend-templates:

--- a/docs/esps/mailgun.rst
+++ b/docs/esps/mailgun.rst
@@ -288,6 +288,17 @@ Limitations and quirks
 
   .. versionadded:: 8.2
 
+**Non-ASCII mailboxes (EAI)**
+  Mailgun partially supports Unicode mailboxes (the *user* part of
+  *user\@domain*---see :ref:`EAI <eai>`). EAI recipient addresses (to, cc, bcc)
+  are delivered correctly, but Mailgun generates invalid header fields that may
+  display as empty or garbled, depending on the email app.
+
+  For an EAI ``from_email``, the invalid :mailheader:`From` header Mailgun
+  generates can prevent delivery and cause confusing bounce messages. To avoid
+  this, Anymail raises an :exc:`~anymail.exceptions.AnymailUnsupportedFeature`
+  error if you attempt to send *from* an EAI address using Mailgun.
+
 .. _Anymail issue #270:
     https://github.com/anymail/django-anymail/issues/270
 .. _undocumented API requirement:

--- a/docs/esps/mailjet.rst
+++ b/docs/esps/mailjet.rst
@@ -153,19 +153,25 @@ Limitations and quirks
      Earlier Anymail versions would default to an empty string, resulting in
      a Mailjet API error.
 
+**Non-ASCII mailboxes (EAI)**
+  Mailjet fully supports sending from or to Unicode mailboxes (the *user* part
+  of *user\@domain*---see :ref:`EAI <eai>`). Messages with EAI addresses are
+  delivered correctly to receiving SMTP servers that support EAI, and will
+  bounce as expected for those that don't.
+
 **Older limitations**
 
-.. versionchanged:: 6.0
+    .. versionchanged:: 6.0
 
-    Earlier versions of Anymail were unable to mix ``cc`` or ``bcc`` fields
-    and :attr:`~anymail.message.AnymailMessage.merge_data` in the same Mailjet message.
-    This limitation was removed in Anymail 6.0.
+        Earlier versions of Anymail were unable to mix ``cc`` or ``bcc`` fields
+        and :attr:`~anymail.message.AnymailMessage.merge_data` in the same Mailjet message.
+        This limitation was removed in Anymail 6.0.
 
-.. versionchanged:: 8.0
+    .. versionchanged:: 8.0
 
-    Earlier Anymail versions had special handling to work around a Mailjet v3 API bug
-    with commas in recipient display names. Anymail 8.0 uses Mailjet's v3.1 API, which
-    does not have the bug.
+        Earlier Anymail versions had special handling to work around a Mailjet v3 API bug
+        with commas in recipient display names. Anymail 8.0 uses Mailjet's v3.1 API, which
+        does not have the bug.
 
 
 .. _mailjet-templates:

--- a/docs/esps/mandrill.rst
+++ b/docs/esps/mandrill.rst
@@ -143,6 +143,12 @@ Limitations and quirks
   (Verified and reported to MailChimp support 4/2022;
   see `Anymail discussion #257`_ for more details.)
 
+**Non-ASCII display names may display incorrectly**
+  Mandrill's API incorrectly formats email addresses with display names that
+  include non-ASCII characters. Gmail overlooks the mistake, but some email
+  clients may display the name as an RFC 2047 encoded-word (``=?utf-8?...``)
+  rather than the intended text.
+
 **Cc and bcc depend on "preserve_recipients"**
   Mandrill's handing of ``cc`` and ``bcc`` addresses depends on whether its
   ``preserve_recipients`` option is enabled for the message.
@@ -177,6 +183,18 @@ Limitations and quirks
   Anymail's :attr:`~anymail.message.AnymailMessage.envelope_sender` is used to
   populate Mandrill's `'return_path_domain'`---but only the domain portion.
   (Mandrill always generates its own encoded mailbox for the envelope sender.)
+
+**Non-ASCII mailboxes (EAI)**
+  Mandrill partially supports sending from or to Unicode mailboxes (the *user*
+  part of *user\@domain*---see :ref:`EAI <eai>`). Messages are correctly
+  delivered, but the :mailheader:`To` header is incorrectly formatted and will
+  display garbled (or not at all) in most email apps.
+
+  Also, Mandrill does not properly verify the receiving SMTP server supports EAI
+  (smtputf8). For valid EAI recipient addresses, this generally shouldn't cause
+  problems. For an EAI ``from_email`` or ``reply_to`` this could result in lost
+  or undeliverable messages.
+
 
 .. _Anymail discussion #257:
      https://github.com/anymail/django-anymail/discussions/257

--- a/docs/esps/postmark.rst
+++ b/docs/esps/postmark.rst
@@ -149,6 +149,10 @@ see :ref:`unsupported-features`.
   on individual messages. (You can configure custom return paths for each sending domain in
   the Postmark control panel.)
 
+**No non-ASCII mailboxes (EAI)**
+  Postmark does not support sending from or to Unicode mailboxes (the *user* part of
+  *user\@domain*---see :ref:`EAI <eai>`). Trying to use one will cause an API error.
+
 
 .. _postmark-templates:
 

--- a/docs/esps/resend.rst
+++ b/docs/esps/resend.rst
@@ -178,6 +178,10 @@ anyway---see :ref:`unsupported-features`.
   Resend's status webhooks do not identify which recipient applies
   for an event. See the :ref:`note below <resend-tracking-recipient>`.
 
+**No non-ASCII mailboxes (EAI)**
+  Resend does not support sending from or to Unicode mailboxes (the *user* part of
+  *user\@domain*---see :ref:`EAI <eai>`). Trying to use one will cause an API error.
+
 
 .. _resend-api-rate-limits:
 

--- a/docs/esps/scaleway.rst
+++ b/docs/esps/scaleway.rst
@@ -160,6 +160,15 @@ anyway---see :ref:`unsupported-features`.
   Scaleway does not support setting
   :attr:`~anymail.message.AnymailMessage.envelope_sender`.
 
+**No non-ASCII mailboxes (EAI)**
+  Scaleway incorrectly handles attempts to send from or to Unicode mailboxes
+  (the *user* part of *user\@domain*---see :ref:`EAI <eai>`). The resulting
+  message is lost or bounces internally within Scaleway's infrastructure,
+  presumably due to incorrectly formatted header fields.
+
+  To avoid this, Anymail raises an :exc:`~anymail.exceptions.AnymailUnsupportedFeature`
+  error if you attempt to send a message using an EAI address with Scaleway.
+
 
 .. _scaleway-templates:
 

--- a/docs/esps/sparkpost.rst
+++ b/docs/esps/sparkpost.rst
@@ -257,6 +257,12 @@ Limitations and quirks
 
   .. versionchanged:: 8.2
 
+**Non-ASCII mailboxes (EAI)**
+  SparkPost supports sending from or to Unicode mailboxes (the *user* part of
+  *user\@domain*---see :ref:`EAI <eai>`), but does not properly verify the
+  receiving SMTP server supports them (smtputf8). For valid EAI recipient
+  addresses, this generally shouldn't cause problems. For an EAI ``from_email``
+  or ``reply_to`` this could result in lost or undeliverable messages.
 
 .. _sparkpost-templates:
 

--- a/docs/esps/unisender_go.rst
+++ b/docs/esps/unisender_go.rst
@@ -174,6 +174,15 @@ Limitations and quirks
   ESPs, bcc recipients in a batch send *won't* receive a separate copy of the
   message personalized for each :attr:`to` email.)
 
+**Non-ASCII Reply-To name may display incorrectly**
+  Unisender Go's API has a bug in handling non-ASCII characters in a display
+  name for ``reply_to`` addresses (but not other address fields). Anymail
+  applies a workaround to ensure the message can be delivered and won't arrive
+  garbled, but this workaround runs into another Unisender Go limitation that
+  can cause the Reply-To name to display as an RFC 2047 encoded-word
+  (``=?utf8?...``) in some email clients. To prevent the problem, avoid
+  using a reply address with non-ASCII characters in the name.
+
 **AMP for Email**
   Unisender Go supports sending AMPHTML email content. To include it, use
   ``message.attach_alternative("...AMPHTML content...", "text/x-amp-html")``
@@ -223,6 +232,10 @@ Limitations and quirks
   Unisender Go does not support overriding a message's
   :attr:`~anymail.message.AnymailMessage.envelope_sender`.
 
+**No non-ASCII mailboxes (EAI)**
+  Unisender Go does not support sending from or to Unicode mailboxes (the *user*
+  part of *user\@domain*---see :ref:`EAI <eai>`). Trying to use one will cause
+  an API error.
 
 .. _unisender-go-templates:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -238,6 +238,14 @@ See the :ref:`supported ESPs <supported-esps>` section for details.
 Here are the other settings Anymail supports:
 
 
+.. rubric:: IDNA_ENCODER
+
+.. versionadded:: vNext
+
+Controls the encoding used for international domain names (with non-ASCII
+characters) in email addresses. The default is ``"idna2008"``. See :ref:`idna`.
+
+
 .. setting:: ANYMAIL_IGNORE_RECIPIENT_STATUS
 
 .. rubric:: IGNORE_RECIPIENT_STATUS

--- a/docs/tips/index.rst
+++ b/docs/tips/index.rst
@@ -11,5 +11,6 @@ done with Anymail:
    multiple_backends
    django_templates
    securing_webhooks
+   international_email
    testing
    performance

--- a/docs/tips/international_email.rst
+++ b/docs/tips/international_email.rst
@@ -1,0 +1,416 @@
+.. _intl-email:
+
+International email (Unicode)
+=============================
+
+Anymail's goal is to fully support non-ASCII Unicode characters everywhere
+permitted by the relevant email specifications.
+
+.. sidebar:: tl;dr
+
+    If you want to work with email using characters other than 7-bit ASCII,
+    review the "Limitations and quirks" section of your ESP's page in
+    Anymail's :ref:`supported-esps` documentation.
+
+Using Unicode characters in email involves a confusing patchwork of standards,
+with multiple, sometimes conflicting revisions. But you shouldn't need to
+understand all of that: you're paying your ESP for their expertise.
+Unfortunately, ESPs (and the libraries they build on) often find the world
+of email specifications as complex as you would.
+**ESP bugs involving non-ASCII characters are extremely common.**
+
+As of vNext (December 2025), Anymail's developers have performed detailed
+Unicode handling tests on each "fully supported" ESP. Similar tests will be
+run on new ESPs during their initial integration.
+
+For tests that uncover problems with the ESP's API, we:
+
+* Report the issue to the ESP (if they have a way to report API bugs)
+
+* Try to implement a workaround in Anymail's code, if possible
+
+* If a workaround is not possible, document the behavior on Anymail's page
+  for that ESP (see :ref:`supported-esps`) under "Limitations and quirks"
+
+* In rare cases, raise an Anymail error to help you avoid particularly
+  problematic ESP behavior that could interfere with message delivery
+
+This page goes into more detail on handling non-ASCII characters in specific
+parts of an email message:
+
+.. contents::
+    :local:
+    :depth: 1
+
+.. _eai:
+.. _intl-email-address:
+.. _intl-display-name:
+
+Email addresses
+---------------
+
+An email address includes at least a mailbox and domain, and possibly
+a human-friendly "display name":
+
+    ``mailbox@domain`` or ``"Display Name" <mailbox@domain>``
+
+Each of these three parts uses a different specification for handling non-ASCII
+characters, making it especially confusing. (In email standards, the *mailbox*
+is sometimes called *local-part* or *username*. And *mailbox\@domain* is called
+an *addr-spec*.)
+
+Display name
+    ESP bugs in display name handling are pretty common, especially if you mix
+    Unicode characters and commas or other characters that have special meaning
+    in an address header.
+
+    Anymail has workarounds for *most* of the bugs, but be sure to check your
+    ESP's "Limitations and quirks" under :ref:`supported-esps`.
+
+Mailbox (EAI)
+    Unicode in an email mailbox is a relatively recent standard and not yet
+    widely adopted. This is part of "EAI"---email address internationalization
+    (defined in :rfc:`6532` and its peer specifications).
+
+    ESP support for EAI is mixed: some allow Unicode in any email mailbox, some
+    support it for recipients but not the *From* address, and some reject EAI
+    completely. A small number of ESPs accept Unicode mailboxes in API
+    requests but generate undeliverable messages; Anymail raises an error in
+    this situation.
+
+    If you want to support EAI in your Django app, it's important to review
+    your ESP-specific "Limitations and quirks" under :ref:`supported-esps`.
+    Also note that most browsers' ``<input type="email">`` controls reject EAI
+    emails as invalid. So does Django's own EmailValidator (Django
+    `ticket-27029`_) and SMTP EmailBackend (`ticket-35714`_).
+
+Domain
+    Most ESPs don't directly support Unicode characters in an email address
+    domain name. So for consistency, Anymail (by default) encodes non-ASCII
+    email domains for *all* ESPs before calling their APIs, using IDNA 2008.
+    But this is a complex topic, covered in detail in the next section:
+    :ref:`idna`.
+
+    .. versionchanged:: vNext
+
+        Earlier Anymail releases encoded email domains using IDNA 2003.
+
+.. _ticket-27029: https://code.djangoproject.com/ticket/27029
+.. _ticket-35714: https://code.djangoproject.com/ticket/35714
+
+.. _safe-email-address:
+
+.. caution::
+
+    **Never** try to construct an email address from parts using string
+    formatting. This opens you to an **email header injection vulnerability**
+    (similar to SQL or HTML injection). Attackers will exploit it to make your
+    app send email to or from addresses you didn't intend.
+
+    .. code-block:: python
+
+        # SECURITY VULNERABILITY: never do this!
+        address = f"{name} <{email}>"  # allows email header injection
+
+    Instead, you can safely construct a formatted address from a name and
+    email using Python's :class:`email.headerregistry.Address` object:
+
+    .. code-block:: python
+
+        # This is the safe way to combine a name and email:
+        from email.headerregistry import Address
+
+        address = str(Address(display_name=name, addr_spec=email))
+
+
+.. _idna:
+.. _intl-domain:
+
+Email address domains (IDNA)
+----------------------------
+
+An international domain name (IDN, with Unicode characters) must be converted
+to ASCII for DNS lookup: e.g., ``テスト.example.jp`` becomes ``xn--zckzah.example.jp``.
+This conversion is known as IDNA (IDN for Applications), and uses the special
+prefix *xn-\-* with "Punycode" encoded ASCII.
+
+You'll find a mix of IDNA approaches currently in use by different email
+clients and services:
+
+* The original `IDNA 2003`_, now considered obsolete (but email infrastructure
+  moves slowly)
+
+* The updated `IDNA 2008`_, which added support for characters used by several
+  active languages (but removed support for symbols---including emoji---that
+  were allowed before)
+
+* Unicode's `UTS46`_ standard, which tries to strike a practical balance
+  between the two IDNA versions (and is used by all modern web browsers)
+
+Most ESPs don't handle IDNA, and those that do vary on their choice of encoding.
+For consistency, Anymail normally encodes IDNs in email addresses before
+sending them through your ESP.
+
+By default, Anymail uses IDNA 2008 with UTS46 preprocessing. IDNA 2008 supports
+newer domains, and is unlikely to cause problems for other domains used in
+real-world email addresses.  (UTS46 "preprocessing" provides case-insensitivity
+users expect, but rejects emoji domains that browsers would allow.)
+
+If you need different behavior, you can change IDNA encoders or defer encoding
+to your ESP.
+
+.. versionchanged:: vNext
+
+    Earlier Anymail releases used IDNA 2003 encoding, matching Django.
+    (Django's SMTP EmailBackend still uses IDNA 2003.)
+
+.. _IDNA 2003: https://datatracker.ietf.org/doc/html/rfc3490.html
+.. _IDNA 2008: https://datatracker.ietf.org/doc/html/rfc5890.html
+.. _UTS46: https://www.unicode.org/reports/tr46/
+
+
+.. setting:: ANYMAIL_IDNA_ENCODER
+
+.. rubric:: IDNA_ENCODER
+
+.. versionadded:: vNext
+
+Controls the IDNA encoding used for email domains that contain non-ASCII
+characters. The default is ``"idna2008"``. To select a different option,
+in your settings.py add:
+
+  .. code-block:: python
+
+      ANYMAIL = {
+          ...
+          "IDNA_ENCODER": "uts46",
+      }
+
+
+The value of ``IDNA_ENCODER`` can be:
+
+* ``"idna2008"`` (default): Uses IDNA 2008 with UTS46 preprocessing
+
+  Recommended for most uses. Handles newer domains enabled by IDNA 2008.
+  But it will reject some existing domains that IDNA 2003 allowed. (If this
+  causes compatibility issues that affect you, consider ``"uts46"`` as an
+  alternative.)
+
+  Implemented with the widely-used, third-party :pypi:`idna` package, which
+  is included with django-anymail installation.
+
+* ``"idna2003"``: Uses obsolete IDNA 2003
+
+  Use *only* if you need exact compatibility with Django's SMTP EmailBackend
+  or backwards compatibility with earlier versions of Anymail. IDNA 2003
+  cannot handle newer domains that were enabled by IDNA 2008.
+
+  IDNA 2003 is built into Python and requires no additional libraries.
+
+* ``"uts46"``: Uses UTS46 (full, not just preprocessing)
+
+  Consider using if you have problems with IDNA 2008 rejecting certain domains.
+  UTS46 is what all current web browsers use for IDN encoding. It combines
+  IDNA 2008's support for newer domains with somewhat relaxed restrictions on
+  allowable domains.
+
+  This implementation uses *nontransitional* processing, the current standard.
+  If you want UTS46 with obsolete *transitional* compatibility mapping, use a
+  custom function as shown below. (The difference is explained in
+  `UTS46 section 1.3.2 Deviations`_.)
+
+  Requires the experimental, third-party :pypi:`uts46` package. You can
+  install this as an optional extra with django-anymail:
+  :command:`pip install "django-anymail[<your-esp>,uts46]"`
+
+* ``"none"``: Performs no IDNA encoding
+
+  Calls your ESP with email addresses using the original, unencoded Unicode IDN.
+  (Note this is the string ``"none"``, not the `None` value.)
+
+  May be helpful if you are also calling your ESP's APIs directly and want to
+  avoid Anymail encoding domain names differently. Your ESP must support IDN
+  encoding. (If not, you'll either get an API error, a bounce, or possibly
+  the message will just disappear without a trace.)
+
+* **Custom function:** A callable or string dotted import path to a function
+
+  The custom encoder function must take and return string domain names
+  (don't return bytes). It should raise :exc:`!ValueError` (or a subclass like
+  :exc:`!UnicodeError`) for encoding problems.
+
+  For example, if you wanted to use UTS46 with obsolete transitional processing:
+
+      .. code-block:: python
+
+          # settings.py:
+          ANYMAIL = {
+              ...
+              "IDNA_ENCODER": "path.to.custom.uts46_transitional",
+          }
+
+          # path/to/custom.py:
+          import uts46
+
+          def uts46_transitional(domain: str) -> str:
+              return uts46.encode(domain, transitional_processing=True).decode("ascii")
+
+.. _UTS46 section 1.3.2 Deviations: https://www.unicode.org/reports/tr46/#Deviations
+
+.. _intl-subject:
+.. _intl-header:
+
+Subjects and other headers
+--------------------------
+
+All ESPs supported by Anymail correctly handle non-ASCII characters in
+the email subject.
+
+Nearly all ESPs correctly handle Unicode in other email header fields such as
+custom headers. Anymail implements workarounds for *most* of the ones that
+don't, but check your ESP's "Limitations and quirks" in :ref:`supported-esps`.
+
+(Email specifications do not permit Unicode characters in custom header
+*names,* only in the values.)
+
+.. _intl-body:
+
+Body text
+---------
+
+All ESPs supported by Anymail correctly handle non-ASCII characters in
+plaintext and HTML message bodies.
+
+
+.. _intl-attachment:
+
+Attachments
+-----------
+
+Attachment filenames
+    The bad news: nearly all of Anymail's supported ESPs have bugs in how they
+    handle non-ASCII attachment filenames and generate technically out-of-spec
+    attachment headers. And Anymail generally can't work around ESP filename
+    encoding bugs.
+
+    The good news: bugs in attachment filename encoding are so common that many
+    email apps are tolerant of the errors and display the names as intended.
+
+    A few ESPs don't identify what character set they use for non-ASCII
+    filenames, which causes them to display incorrectly in some email apps.
+    Check your ESP's "Limitations and quirks" to see, and if you want to ensure
+    no recipient will see garbled filenames, stick to ASCII-only.
+
+    Otherwise, as a general rule it should be safe to use Unicode attachment
+    filenames (and rely on email client workarounds for the ESP spec violations).
+
+Attachment text content
+    In text attachments nearly all of Anymail's supported ESPs correctly handle
+    non-ASCII characters. For a few ESPs whose APIs don't have a way to specify
+    text attachment character set, Anymail uses utf-8. This is a reasonable
+    choice for modern email clients, but there is a slight risk of `mojibake`_
+    in very old email apps.
+
+As always, check for exceptions under "Limitations and quirks" on Anymail's
+page for your ESP, in :ref:`supported-esps` .
+
+.. _mojibake: https://en.wikipedia.org/wiki/Mojibake
+
+
+What Anymail tests
+------------------
+
+For interested readers (or ESP engineers), here is what Anymail looks for when
+testing Unicode handling. Italicized terms are from the various RFCs.
+
+*   **Email addresses** (:mailheader:`From/To/Cc/Bcc/Reply-To`)
+
+    *   *display-name:* A non-ASCII *display-name* must be sent using an
+        :rfc:`2047` *encoded-word*. An ASCII-only *display-name* that contains
+        *specials* (like comma or parentheses) must be sent as an :rfc:`5322`
+        *quoted-string.*
+
+    *   *local-part:* A non-ASCII *local-part* (EAI) can only be sent to an
+        SMTP server that supports the smtputf8 extension, :rfc:`6531`. Per
+        :rfc:`6532` it must appear in headers as 8-bit utf-8. (There is no
+        valid 7-bit encoding for a Unicode *local-part*.)
+
+    *   *domain:* A non-ASCII *domain* (IDN) must be encoded, ideally with
+        `IDNA 2008`_ or `UTS46`_ non-transitional. Anymail's tests also treat
+        `IDNA 2003`_ or UTS46 transitional as acceptable, though outdated. IDNA
+        must be applied to both SMTP envelope addresses and (unless the
+        receiving server supports smtputf8) domains in email header fields.
+
+        (Because Anymail by default provides its own IDNA encoding, whether and
+        how each ESP handles IDNs is noted but not treated as a limitation.)
+
+    Common Unicode address mistakes:
+
+    *   Wrapping an *encoded-word* in a *quoted-string*; using an *encoded-word*
+        for the *local-part* and/or *domain* (*addr-spec*); encoding the entire
+        header as a single *encoded-word*---all "must not" per :rfc:`2047`
+        section 5(3)
+
+    *   Returning API errors or generating invalid headers when a *display-name*
+        includes both *specials* and Unicode characters
+
+    *   Handling :mailheader:`Reply-To` as an *unstructured header* rather than
+        a *structured* address header
+
+    *   Sending a raw, 8-bit utf-8 *addr-spec* without verifying the receiving
+        SMTP server supports smtputf8
+
+*   **Subject and custom headers:** Non-ASCII must be sent using an :rfc:`2047`
+    *encoded-word*.
+
+    (All supported ESPs handle Unicode subjects correctly.)
+
+    Common custom header mistakes:
+
+    *   Wrapping an *encoded-word* in a *quoted-string*---a "must not" per
+        :rfc:`2047` section 5(3)
+
+    *   Sending raw, 8-bit utf-8 (without verifying the receiving SMTP server
+        supports smtputf8)
+
+*   **Body parts** (text and html): The non-ASCII encoding must be identified with
+    a ``charset`` parameter in the :mailheader:`Content-Type` header. The
+    correct :mailheader:`Content-Transfer-Encoding` header must be present.
+
+    (All supported ESPs handle Unicode body parts correctly.)
+
+*   **Attachments**
+
+    *   Filenames: In the :mailheader:`Content-Disposition` and
+        :mailheader:`Content-Type` attachment headers, MIME parameters like
+        ``filename`` and ``name`` must use :rfc:`2231` (section 4) parameter
+        value syntax for non-ASCII characters. E.g. (note the ``*=utf-8'...``,
+        *not* RFC 2047's ``=?utf-8?...``):
+
+            :samp:`Content-Disposition: attachment; filename*=utf-8''skr%C3%A1.txt`
+
+    *   Content: as with body parts, text/* attachments must identify the
+        specific non-ASCII encoding used with a ``charset`` parameter in the
+        :mailheader:`Content-Type` header.
+
+    Common attachment mistakes:
+
+    *   Using an *encoded-word* in the ``filename`` or ``name`` parameter---a
+        "must not" in MIME parameter values per :rfc:`2047` section 5(3)
+        (though many email apps tolerate this error)
+
+        (Using RFC 2047 here might be a misapplication of the obsolete
+        :rfc:`2388`, which applied only to HTTP multipart/form-data, *not*
+        attachments in a multipart/mixed email message.)
+
+    *   Sending raw, 8-bit utf-8 in the MIME header, which leads to mojibake
+        filenames in email clients that assume some other encoding
+
+        (Using 8-bit here might be a misapplication of :rfc:`7578`, which
+        applies only to HTTP multipart/form-data, *not* attachments in a
+        multipart/mixed email message.)
+
+    *   Omitting the ``charset`` MIME parameter for text attachments, or not
+        providing a way for API users to specify it, or overriding one given
+        in the API call (without re-encoding the attachment content to
+        match)---any of which can result in mojibake content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "django>=4.0",
+    "idna",
     "requests>=2.4.3",
     "urllib3>=1.25.0",  # requests dependency: fixes RFC 7578 header encoding
 ]
@@ -98,6 +99,9 @@ sendgrid = [
 sendinblue = []
 sparkpost = []
 unisender-go = []
+
+# Optional dependencies for IDNA encoding.
+uts46 = ["uts46"]
 
 [project.urls]
 Homepage = "https://github.com/anymail/django-anymail"

--- a/tests/test_amazon_ses_backend.py
+++ b/tests/test_amazon_ses_backend.py
@@ -5,7 +5,6 @@ from email.mime.application import MIMEApplication
 from unittest.mock import ANY, patch
 
 from django.core import mail
-from django.core.mail import BadHeaderError
 from django.test import SimpleTestCase, override_settings, tag
 
 from anymail import __version__ as ANYMAIL_VERSION
@@ -170,41 +169,48 @@ class AmazonSESBackendStandardEmailTests(AmazonSESBackendMockAPITestCase):
         self.assertEqual(
             params["Destination"],
             {
-                "ToAddresses": [
-                    "to1@example.com",
-                    '"Recipient, second" <to2@example.com>',
-                ],
-                "CcAddresses": ["cc1@example.com", "Also cc <cc2@example.com>"],
-                "BccAddresses": ["bcc1@example.com", "BCC 2 <bcc2@example.com>"],
+                "ToAddresses": ["to1@example.com", "to2@example.com"],
+                "CcAddresses": ["cc1@example.com", "cc2@example.com"],
+                "BccAddresses": ["bcc1@example.com", "bcc2@example.com"],
             },
         )
         # Bcc's shouldn't appear in the message itself:
         self.assertNotIn(b"bcc", params["Content"]["Raw"]["Data"])
 
     def test_non_ascii_headers(self):
-        self.message.subject = "Thử tin nhắn"  # utf-8 in subject header
-        self.message.to = ['"Người nhận" <to@example.com>']  # utf-8 in display name
-        self.message.cc = ["cc@thư.example.com"]  # utf-8 in domain
-        self.message.send()
+        # Amazon SES requires a flattened 7-bit message, including rfc2047
+        # encoded-words and IDNA encoding where appropriate.
+        # (SES does not support EAI non-ASCII local-part.)
+        email = mail.EmailMessage(
+            from_email='"Odesílatel, z adresy" <from@příklad.example.cz>',
+            to=['"Příjemce, na adresu" <to@příklad.example.cz>'],
+            cc=["cc@މިސާލު.example.mv"],
+            subject="Předmět e-mailu",
+            reply_to=['"Odpověď, adresa" <reply@příklad.example.cz>'],
+            headers={"X-Extra": "Další"},
+            body="Prostý text",
+        )
+        email.send()
+
         params = self.get_send_params()
         raw_mime = params["Content"]["Raw"]["Data"]
-        # Non-ASCII headers must use MIME encoded-word syntax:
-        self.assertIn(b"\nSubject: =?utf-8?b?VGjhu60gdGluIG5o4bqvbg==?=\n", raw_mime)
-        # Non-ASCII display names as well:
-        self.assertIn(
-            b"\nTo: =?utf-8?b?TmfGsOG7nWkgbmjhuq1u?= <to@example.com>\n", raw_mime
-        )
-        # Non-ASCII address domains must use Punycode:
-        self.assertIn(b"\nCc: cc@xn--th-e0a.example.com\n", raw_mime)
-        # SES doesn't support non-ASCII in the username@ part
-        # (RFC 6531 "SMTPUTF8" extension)
+        self.assertTrue(raw_mime.isascii(), "8bit Content.Raw.Data not allowed")
+        # Non-ASCII headers must use MIME encoded-word syntax.
+        # Python's email generator should handle this correctly, but spot check a few:
+        self.assertIn(b"\nSubject: =?utf-8?b?UMWZZWRtxJt0IGUtbWFpbHU=?=\n", raw_mime)
+        self.assertIn(b"\nFrom: =?utf-8?q?Odes=C3=ADlatel=2C_z_adresy?=", raw_mime)
+        # Non-ASCII address domains must use IDNA
+        # (and it should be IDNA_ENCODER default idna2008):
+        self.assertIn(b"\nCc: cc@xn--qqbii6gdp.example.mv\n", raw_mime)
+        # Body must use a 7-bit encoding, probably quoted-printable
+        self.assertIn(b"\nProst=C3=BD=20text", raw_mime)
 
-        # Destinations must include all recipients (addr-spec only, must use Punycode):
+        # Destinations must include all recipients (addr-spec only, must use IDNA):
         self.assertEqual(
             params["Destination"],
             {
-                "ToAddresses": ["=?utf-8?b?TmfGsOG7nWkgbmjhuq1u?= <to@example.com>"],
-                "CcAddresses": ["cc@xn--th-e0a.example.com"],
+                "ToAddresses": ["to@xn--pklad-zsa96e.example.cz"],
+                "CcAddresses": ["cc@xn--qqbii6gdp.example.mv"],
             },
         )
 
@@ -446,25 +452,25 @@ class AmazonSESBackendStandardEmailTests(AmazonSESBackendMockAPITestCase):
         # Since we build the raw MIME message, we're responsible for preventing header
         # injection. django.core.mail.EmailMessage.message() implements most of that
         # (for the SMTP backend); spot check some likely cases just to be sure...
-        with self.assertRaises(BadHeaderError):
+        with self.assertRaises(ValueError):
             mail.send_mail(
                 "Subject\r\ninjected", "Body", "from@example.com", ["to@example.com"]
             )
-        with self.assertRaises(BadHeaderError):
+        with self.assertRaises(ValueError):
             mail.send_mail(
                 "Subject",
                 "Body",
                 '"Display-Name\nInjected" <from@example.com>',
                 ["to@example.com"],
             )
-        with self.assertRaises(BadHeaderError):
+        with self.assertRaises(ValueError):
             mail.send_mail(
                 "Subject",
                 "Body",
                 "from@example.com",
                 ['"Display-Name\rInjected" <to@example.com>'],
             )
-        with self.assertRaises(BadHeaderError):
+        with self.assertRaises(ValueError):
             mail.EmailMessage(
                 "Subject",
                 "Body",
@@ -497,7 +503,7 @@ class AmazonSESBackendAnymailFeatureTests(AmazonSESBackendMockAPITestCase):
         raw_mime = params["Content"]["Raw"]["Data"]
         self.assertEqual(
             params["Destination"],
-            {"ToAddresses": ["Envelope <envelope-to@example.com>"]},
+            {"ToAddresses": ["envelope-to@example.com"]},
         )
         self.assertIn(b"\nTo: Spoofed <spoofed-to@elsewhere.example.org>\n", raw_mime)
         self.assertNotIn(b"envelope-to@example.com", raw_mime)

--- a/tests/test_general_backend.py
+++ b/tests/test_general_backend.py
@@ -1,3 +1,4 @@
+import unittest
 from datetime import datetime, timezone
 from email.mime.text import MIMEText
 
@@ -17,9 +18,18 @@ from anymail.exceptions import (
     AnymailUnsupportedFeature,
 )
 from anymail.message import AnymailMessage
-from anymail.utils import get_anymail_setting
+from anymail.utils import EmailAddress, get_anymail_setting
 
 from .utils import AnymailTestMixin
+
+
+def uts46_installed():
+    try:
+        import uts46  # NOQA: F401
+    except ImportError:
+        return False
+    else:
+        return True
 
 
 class SettingsTestBackend(TestBackend):
@@ -409,7 +419,7 @@ class CatchCommonErrorsTests(TestBackendTestCase):
         self.message.from_email = ""
         with self.assertRaisesMessage(
             AnymailInvalidAddress,
-            "Invalid email address '' parsed from '' in `from_email`.",
+            "Invalid email address '' in `from_email` parsed from ''",
         ):
             self.message.send()
         self.message.from_email = "from@example.com"
@@ -418,7 +428,8 @@ class CatchCommonErrorsTests(TestBackendTestCase):
         self.message.to = ["ok@example.com", "oops"]
         with self.assertRaisesMessage(
             AnymailInvalidAddress,
-            "Invalid email address 'oops' parsed from 'ok@example.com, oops' in `to`.",
+            "Invalid email address 'oops' in `to`"
+            " parsed from 'ok@example.com, oops'",
         ):
             self.message.send()
         self.message.to = ["test@example.com"]
@@ -437,9 +448,9 @@ class CatchCommonErrorsTests(TestBackendTestCase):
         self.message.extra_headers["From"] = "Mail, Inc. <mail@example.com>"
         with self.assertRaisesMessage(
             AnymailInvalidAddress,
-            "Invalid email address 'Mail' parsed from"
-            " 'Mail, Inc. <mail@example.com>' in `extra_headers['From']`."
-            " (Maybe missing quotes around a display-name?)",
+            "Invalid email address 'Mail' in `extra_headers['From']`"
+            " parsed from 'Mail, Inc. <mail@example.com>' (maybe missing quotes"
+            " around a display-name?)",
         ):
             self.message.send()
 
@@ -545,6 +556,20 @@ class SpecialHeaderTests(TestBackendTestCase):
             AnymailUnsupportedFeature, "spoofing `To` header"
         ):
             self.message.send()
+
+    def test_eai_address(self):
+        """Unicode local-parts should survive Anymail's address normalization."""
+        self.message.from_email = "відправник@example.com"
+        self.message.to = ["Recipient <одержувач@example.com>"]
+        self.message.send()
+        params = self.get_send_params()
+        self.assertEqual(
+            params["from"], EmailAddress(addr_spec="відправник@example.com")
+        )
+        self.assertEqual(
+            params["to"],
+            [EmailAddress(display_name="Recipient", addr_spec="одержувач@example.com")],
+        )
 
 
 class AlternativePartsTests(TestBackendTestCase):
@@ -657,3 +682,92 @@ class BatchSendDetectionTestCase(TestBackendTestCase):
             AssertionError, "Cannot call is_batch before all attributes processed"
         ):
             connection.send_messages([self.message])
+
+
+def custom_encoder(domain):
+    """For test_custom_idna_dotted_path"""
+    return f"CUSTOM:{domain}"
+
+
+class IDNAEncoderTests(TestBackendTestCase):
+    """
+    Check IDNA_ENCODER setting and built-in options.
+    (This is not attempting to comprehensively test IDNA encoding,
+    but just verify that swappable encoders work as expected.)
+    """
+
+    def test_default_encode(self):
+        """Default encoder is idna2008."""
+        connection = mail.get_connection()
+        self.assertEqual(connection.idna_encode("faß.example"), "xn--fa-hia.example")
+        self.assertEqual(
+            connection.idna_encode("idna2008.މިސާލު.example"),
+            "idna2008.xn--qqbii6gdp.example",
+        )
+        with self.assertRaisesMessage(
+            AnymailInvalidAddress,
+            "Cannot encode '✉.example' using IDNA_ENCODER='idna2008'",
+        ):
+            connection.idna_encode("✉.example")
+
+    @override_settings(ANYMAIL={"IDNA_ENCODER": "idna2003"})
+    def test_idna2003_encode(self):
+        """idna2003 provides strict compatibility with Django and earlier releases."""
+        connection = mail.get_connection()
+        self.assertEqual(connection.idna_encode("faß.example"), "fass.example")
+        self.assertEqual(connection.idna_encode("✉.example"), "xn--4bi.example")
+        self.assertEqual(connection.idna_encode("✉ß.example"), "xn--ss-ufy.example")
+        with self.assertRaisesMessage(
+            AnymailInvalidAddress,
+            "Cannot encode 'idna2008.މިސާލު.example' using IDNA_ENCODER='idna2003'",
+        ):
+            connection.idna_encode("idna2008.މިސާލު.example")
+
+    @unittest.skipUnless(uts46_installed(), "uts46 package not installed")
+    @override_settings(ANYMAIL={"IDNA_ENCODER": "uts46"})
+    def test_uts46_encode(self):
+        """uts46 handles some domains rejected by idna2008."""
+        connection = mail.get_connection()
+        self.assertEqual(connection.idna_encode("faß.example"), "xn--fa-hia.example")
+        self.assertEqual(
+            connection.idna_encode("idna2008.މިސާލު.example"),
+            "idna2008.xn--qqbii6gdp.example",
+        )
+        self.assertEqual(connection.idna_encode("✉.example"), "xn--4bi.example")
+        self.assertEqual(connection.idna_encode("✉ß.example"), "xn--zca356q.example")
+
+    @override_settings(ANYMAIL={"IDNA_ENCODER": "none"})
+    def test_none_encode(self):
+        """No encoding, for ESPs that can handle IDNA themselves."""
+        connection = mail.get_connection()
+        self.assertEqual(
+            connection.idna_encode("idna2008.މިސާލު.example"), "idna2008.މިސާލު.example"
+        )
+
+    @override_settings(ANYMAIL={"IDNA_ENCODER": f"{__name__}.custom_encoder"})
+    def test_custom_idna_dotted_path(self):
+        """IDNA_ENCODER can be set to a dotted import path to a custom function."""
+        connection = mail.get_connection()
+        self.assertEqual(connection.idna_encode("example.com"), "CUSTOM:example.com")
+
+    @override_settings(ANYMAIL={"IDNA_ENCODER": custom_encoder})
+    def test_custom_idna_callable(self):
+        """IDNA_ENCODER can be set directly to a callable."""
+        connection = mail.get_connection()
+        self.assertEqual(connection.idna_encode("example.com"), "CUSTOM:example.com")
+
+    def test_custom_idna_param(self):
+        """IDNA_ENCODER can be overridden in backend initialization params."""
+        connection = mail.get_connection(idna_encoder=custom_encoder)
+        self.assertEqual(connection.idna_encode("example.com"), "CUSTOM:example.com")
+
+    @override_settings(
+        ANYMAIL={
+            "IDNA_ENCODER": "raw",
+            "TEST_IDNA_ENCODER": "idna2003",  # (The TestBackend's esp_name is "test".)
+        }
+    )
+    def test_esp_specific_encoder(self):
+        """<ESP_NAME>_IDNA_ENCODER takes precedence over IDNA_ENCODER."""
+        connection = mail.get_connection()
+        self.assertEqual(connection.idna_encode("✉.example"), "xn--4bi.example")

--- a/tests/test_postal_backend.py
+++ b/tests/test_postal_backend.py
@@ -197,6 +197,31 @@ class PostalBackendStandardEmailTests(PostalBackendMockAPITestCase):
         with self.assertRaises(AnymailUnsupportedFeature):
             email.send()
 
+    def test_non_ascii_headers(self):
+        # Postal is believed to handle RFC 2047 encoding in headers,
+        # but Anymail applies IDNA encoding for non-ASCII domain names.
+        email = mail.EmailMessage(
+            from_email='"Odesílatel, z adresy" <from@příklad.example.cz>',
+            to=['"Příjemce, na adresu" <to@příklad.example.cz>'],
+            subject="Předmět e-mailu",
+            reply_to=['"Odpověď, adresa" <reply@příklad.example.cz>'],
+            headers={"X-Extra": "Další"},
+            body="Prostý text",
+        )
+        email.send()
+        data = self.get_api_call_json()
+        self.assertEqual(
+            data["from"], '"Odesílatel, z adresy" <from@xn--pklad-zsa96e.example.cz>'
+        )
+        self.assertEqual(
+            data["to"], ['"Příjemce, na adresu" <to@xn--pklad-zsa96e.example.cz>']
+        )
+        self.assertEqual(data["subject"], "Předmět e-mailu")
+        self.assertEqual(
+            data["reply_to"], '"Odpověď, adresa" <reply@xn--pklad-zsa96e.example.cz>'
+        )
+        self.assertEqual(data["headers"], {"X-Extra": "Další"})
+
     def test_attachments(self):
         text_content = "* Item one\n* Item two\n* Item three"
         self.message.attach(

--- a/tests/test_resend_backend.py
+++ b/tests/test_resend_backend.py
@@ -179,6 +179,31 @@ class ResendBackendStandardEmailTests(ResendBackendMockAPITestCase):
             data["reply_to"], ["reply@example.com", "Other <reply2@example.com>"]
         )
 
+    def test_non_ascii_headers(self):
+        # Resend correctly encodes non-ASCII display-names and other headers
+        # (but requires IDNA encoding for non-ASCII domain names).
+        email = mail.EmailMessage(
+            from_email='"Odesílatel, z adresy" <from@příklad.example.cz>',
+            to=['"Příjemce, na adresu" <to@příklad.example.cz>'],
+            subject="Předmět e-mailu",
+            reply_to=['"Odpověď, adresa" <reply@příklad.example.cz>'],
+            headers={"X-Extra": "Další"},
+            body="Prostý text",
+        )
+        email.send()
+        data = self.get_api_call_json()
+        self.assertEqual(
+            data["from"], '"Odesílatel, z adresy" <from@xn--pklad-zsa96e.example.cz>'
+        )
+        self.assertEqual(
+            data["to"], ['"Příjemce, na adresu" <to@xn--pklad-zsa96e.example.cz>']
+        )
+        self.assertEqual(data["subject"], "Předmět e-mailu")
+        self.assertEqual(
+            data["reply_to"], ['"Odpověď, adresa" <reply@xn--pklad-zsa96e.example.cz>']
+        )
+        self.assertEqual(data["headers"], {"X-Extra": "Další"})
+
     def test_attachments(self):
         text_content = "* Item one\n* Item two\n* Item three"
         self.message.attach(

--- a/tests/test_scaleway_backend.py
+++ b/tests/test_scaleway_backend.py
@@ -171,6 +171,74 @@ class ScalewayBackendStandardEmailTests(ScalewayBackendMockAPITestCase):
             ],
         )
 
+    def test_non_ascii_headers(self):
+        # Scaleway correctly encodes non-ASCII display-names and most headers.
+        # Anymail must handle RFC 2047 encoding for the constructed Reply-To header
+        # and perform IDNA encoding for non-ASCII domain names.
+        # Scaleway doesn't support EAI (see next test).
+        email = mail.EmailMessage(
+            from_email='"Odesílatel, z adresy" <from@příklad.example.cz>',
+            to=['"Příjemce, na adresu" <to@příklad.example.cz>'],
+            subject="Předmět e-mailu",
+            reply_to=['"Odpověď, adresa" <reply@příklad.example.cz>'],
+            headers={"X-Extra": "Další"},
+            body="Prostý text",
+        )
+        email.send()
+        data = self.get_api_call_json()
+        self.assertEqual(
+            data["from"],
+            {
+                "name": "Odesílatel, z adresy",
+                "email": "from@xn--pklad-zsa96e.example.cz",
+            },
+        )
+        self.assertEqual(
+            data["to"],
+            [
+                {
+                    "name": "Příjemce, na adresu",
+                    "email": "to@xn--pklad-zsa96e.example.cz",
+                }
+            ],
+        )
+        self.assertEqual(data["subject"], "Předmět e-mailu")
+        self.assertCountEqual(
+            data["additional_headers"],
+            [
+                {"key": "X-Extra", "value": "Další"},
+                {
+                    "key": "Reply-To",
+                    "value": "=?utf-8?b?T2Rwb3bEm8SPLCBhZHJlc2E=?="
+                    " <reply@xn--pklad-zsa96e.example.cz>",
+                },
+            ],
+        )
+
+    def test_eai_unsupported(self):
+        """
+        Scaleway generates an undeliverable message (that seems to bounce or
+        get dropped within Scaleway's own infrastructure) if any address header
+        uses EAI. To prevent delivery problems, Anymail treats EAI as unsupported.
+        """
+        with self.subTest(field="from_email"):
+            self.message.from_email = "тест@example.com"
+            with self.assertRaisesMessage(
+                AnymailUnsupportedFeature, "EAI in from_email"
+            ):
+                self.message.send()
+
+        for field in ["to", "cc", "bcc", "reply_to"]:
+            message = mail.EmailMultiAlternatives(
+                "Subject", "Text Body", "from@example.com", ["to@example.com"]
+            )
+            with self.subTest(field=field):
+                setattr(message, field, ["тест@example.com"])
+                with self.assertRaisesMessage(
+                    AnymailUnsupportedFeature, f"EAI in {field}"
+                ):
+                    message.send()
+
     def test_attachments(self):
         text_content = "* Item one\n* Item two\n* Item three"
         self.message.attach(

--- a/tests/test_sendgrid_backend.py
+++ b/tests/test_sendgrid_backend.py
@@ -276,6 +276,42 @@ class SendGridBackendStandardEmailTests(SendGridBackendMockAPITestCase):
         )
         self.assertNotIn("reply_to", data)  # not allowed with reply_to_list
 
+    def test_non_ascii_headers(self):
+        # SendGrid correctly encodes non-ASCII display-names and other headers
+        # (but requires IDNA encoding for non-ASCII domain names).
+        email = mail.EmailMessage(
+            from_email='"Odesílatel, z adresy" <from@příklad.example.cz>',
+            to=['"Příjemce, na adresu" <to@příklad.example.cz>'],
+            subject="Předmět e-mailu",
+            reply_to=['"Odpověď, adresa" <reply@příklad.example.cz>'],
+            headers={"X-Extra": "Další"},
+            body="Prostý text",
+        )
+        email.send()
+        data = self.get_api_call_json()
+        self.assertEqual(
+            data["from"],
+            {
+                "name": "Odesílatel, z adresy",
+                "email": "from@xn--pklad-zsa96e.example.cz",
+            },
+        )
+        self.assertEqual(
+            data["personalizations"][0]["to"],
+            [
+                {
+                    "name": "Příjemce, na adresu",
+                    "email": "to@xn--pklad-zsa96e.example.cz",
+                }
+            ],
+        )
+        self.assertEqual(data["subject"], "Předmět e-mailu")
+        self.assertEqual(
+            data["reply_to_list"],
+            [{"name": "Odpověď, adresa", "email": "reply@xn--pklad-zsa96e.example.cz"}],
+        )
+        self.assertEqual(data["headers"], {"X-Extra": "Další"})
+
     def test_attachments(self):
         text_content = "* Item one\n* Item two\n* Item three"
         self.message.attach(

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ envlist =
     djangoDev-py{312,313}-all
     # ... then partial installation (limit extras):
     django52-py313-{none,amazon_ses,postal,resend,sendgrid}
+    django52-py313-none-uts46
 # tox requires isolated builds to use pyproject.toml build config:
 isolated_build = True
 
@@ -51,6 +52,8 @@ extras =
     all,postal: postal
     all,resend: resend
     all,sendgrid: sendgrid
+    # Install optional extras only when testing that factor (not for "all").
+    uts46: uts46
 setenv =
     # tell runtests.py to limit some test tags based on extras factor
     # (resend and sendgrid should work with or without their extras, so aren't in none)


### PR DESCRIPTION
Based on testing each ESP's handling of Unicode in their API, update Anymail's ESP documentation, tests, and (where necessary) EmailBackends to ensure correct handling of non-ASCII characters in email headers.

As part of this work:
- Remove use of Django's internal, deprecated sanitize_address() function (fixes #444)
- Introduce an `IDNA_ENCODER` Anymail setting allowing control of IDNA for Unicode domains (IDNs), defaulting to idna2008
- Add unsupported feature errors for a handful of cases where a particular ESP mishandles Unicode characters in a way that can interfere with delivery

(Unicode attachment handling will be covered in a separate issue and PR.)
