### PR TITLE
Improve handling of non-ASCII characters in attachments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -76,19 +76,38 @@ Features
 ~~~~~~~~
 
 * **Resend:** Add support for inline images. Identify attachment content type
-  using new API parameter. (See related Resend breaking change above.)
+  using new API parameter, including accurately specifying charset for
+  non-ASCII text attachments. (See related Resend breaking change above.)
 
 Fixes
 ~~~~~
 
+* Handle sending attached messages (e.g., forwarded emails) consistently with
+  Django's SMTP EmailBackend.
+
+* **Brevo, Mailgun, Mandrill, Postal, Postmark, Scaleway TEM, Unisender Go:**
+  Fix Anymail bugs that could cause text attachments with non-ASCII content
+  to display incorrectly in some email clients.
+
 * **Brevo:** Work around a Brevo API bug which loses non-ASCII display names
   that also contain a comma or certain other punctuation.
+
+* **Mailgun:** Use ``"attachment"`` as the default attachment filename (rather
+  than raising an error) for consistency with Anymail's handling of missing
+  attachment filenames in other ESPs.
 
 Other
 ~~~~~
 
+* **Brevo:** Document a Brevo API bug that causes non-ASCII attachment
+  filenames to display incorrectly in some email clients.
+
 * **Mandrill:** Document a Mandrill API bug that can cause an address with a
   non-ASCII display name to display incorrectly in some email clients.
+
+* **SendGrid:** Document a SendGrid API bug that causes non-ASCII attachment
+  filenames to display incorrectly in some email clients. Clarify handling and
+  documentation of SendGrid API bugs around text attachment content encoding.
 
 * **Unisender Go:** Document a Unisender Go API bug that can cause an Reply-To
   address (only) with a non-ASCII display name to display incorrectly in some

--- a/anymail/backends/base.py
+++ b/anymail/backends/base.py
@@ -1,7 +1,6 @@
 import json
 from datetime import date, datetime, timezone
 
-from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 from django.utils.module_loading import import_string
 from django.utils.timezone import get_current_timezone, is_naive, make_aware
@@ -477,11 +476,8 @@ class BasePayload:
         ]
 
     def prepped_attachments(self, attachments):
-        str_encoding = self.message.encoding or settings.DEFAULT_CHARSET
-        return [
-            Attachment(attachment, str_encoding)  # (handles lazy content, filename)
-            for attachment in attachments
-        ]
+        # (handles lazy content, filename, charset)
+        return [Attachment(attachment) for attachment in attachments]
 
     def aware_datetime(self, value):
         """Converts a date or datetime or timestamp to an aware datetime.

--- a/anymail/backends/brevo.py
+++ b/anymail/backends/brevo.py
@@ -242,9 +242,12 @@ class BrevoPayload(RequestsPayload):
 
     def add_attachment(self, attachment):
         """Converts attachments to Brevo API {name, base64} array"""
+        # Brevo guesses content type from the name
+        # and returns a useful API error for an empty name.
+        # Text content must be utf-8 (Brevo adds `charset=utf-8`).
         att = {
             "name": attachment.name or "",
-            "content": attachment.b64content,
+            "content": attachment.b64content_utf8,
         }
 
         if attachment.inline:

--- a/anymail/backends/mailersend.py
+++ b/anymail/backends/mailersend.py
@@ -268,10 +268,13 @@ class MailerSendPayload(RequestsPayload):
         self.data["html"] = body
 
     def add_attachment(self, attachment):
-        # Add a MailerSend attachments[] object for attachment:
+        # Add a MailerSend attachments[] object for attachment.
+        # MailerSend guesses content type from filename. It doesn't have
+        # a way to specify charset for text attachments and does not include
+        # charset in the Content-Type header. Use utf-8 and hope for the best.
         attachment_object = {
             "filename": attachment.name,
-            "content": attachment.b64content,
+            "content": attachment.b64content_utf8,
             "disposition": "attachment",
         }
         if not attachment_object["filename"]:

--- a/anymail/backends/mailgun.py
+++ b/anymail/backends/mailgun.py
@@ -378,7 +378,7 @@ class MailgunPayload(RequestsPayload):
             super().add_alternative(content, mimetype)
 
     def add_attachment(self, attachment):
-        # http://docs.python-requests.org/en/v2.4.3/user/advanced/#post-multiple-multipart-encoded-files
+        # https://requests.readthedocs.io/en/stable/user/advanced/#post-multiple-multipart-encoded-files
         if attachment.inline:
             field = "inline"
             name = attachment.cid
@@ -386,10 +386,10 @@ class MailgunPayload(RequestsPayload):
                 self.unsupported_feature("inline attachments without Content-ID")
         else:
             field = "attachment"
-            name = attachment.name
-            if not name:
-                self.unsupported_feature("attachments without filenames")
-        self.files.append((field, (name, attachment.content, attachment.mimetype)))
+            name = attachment.name or "attachment"
+        self.files.append(
+            (field, (name, attachment.content_bytes, attachment.content_type))
+        )
 
     def set_envelope_sender(self, email):
         # Only the domain is used

--- a/anymail/backends/mailjet.py
+++ b/anymail/backends/mailjet.py
@@ -194,11 +194,13 @@ class MailjetPayload(RequestsPayload):
             self.data["Globals"]["HTMLPart"] = body
 
     def add_attachment(self, attachment):
+        # Mailjet adds `charset=utf-8` to text/* ContentType (even if charset
+        # already there), so omit charset and always use utf-8 for text content.
+        # Mailjet requires a non-empty Filename.
         att = {
-            "ContentType": attachment.mimetype,
-            # Mailjet requires a non-empty Filename.
+            "ContentType": attachment.mimetype,  # (not content_type with charset)
             "Filename": attachment.name or "attachment",
-            "Base64Content": attachment.b64content,
+            "Base64Content": attachment.b64content_utf8,
         }
         if attachment.inline:
             field = "InlinedAttachments"

--- a/anymail/backends/mandrill.py
+++ b/anymail/backends/mandrill.py
@@ -149,7 +149,7 @@ class MandrillPayload(RequestsPayload):
             name = attachment.name or ""
         self.data["message"].setdefault(field, []).append(
             {
-                "type": attachment.mimetype,
+                "type": attachment.content_type,
                 "name": name,
                 "content": attachment.b64content,
             }

--- a/anymail/backends/postal.py
+++ b/anymail/backends/postal.py
@@ -109,7 +109,7 @@ class PostalPayload(RequestsPayload):
         att = {
             "name": attachment.name or "",
             "data": attachment.b64content,
-            "content_type": attachment.mimetype,
+            "content_type": attachment.content_type,
         }
         if attachment.inline:
             # see https://github.com/postalhq/postal/issues/731

--- a/anymail/backends/postmark.py
+++ b/anymail/backends/postmark.py
@@ -353,7 +353,7 @@ class PostmarkPayload(RequestsPayload):
         att = {
             "Name": attachment.name or "",
             "Content": attachment.b64content,
-            "ContentType": attachment.mimetype,
+            "ContentType": attachment.content_type,
         }
         if attachment.inline:
             att["ContentID"] = "cid:%s" % attachment.cid

--- a/anymail/backends/scaleway.py
+++ b/anymail/backends/scaleway.py
@@ -135,7 +135,7 @@ class ScalewayPayload(RequestsPayload):
         self.data.setdefault("attachments", []).append(
             {
                 "name": attachment.name,
-                "type": attachment.mimetype,
+                "type": attachment.content_type,
                 "content": attachment.b64content,
             }
         )

--- a/anymail/backends/sendgrid.py
+++ b/anymail/backends/sendgrid.py
@@ -1,5 +1,6 @@
 import uuid
 import warnings
+from email.message import MIMEPart
 
 from requests.structures import CaseInsensitiveDict
 
@@ -317,9 +318,19 @@ class SendGridPayload(RequestsPayload):
         )
 
     def add_attachment(self, attachment):
+        # SendGrid strips charset from `type` and doesn't include `charset`
+        # in the Content-Type header, so use utf-8 encoding for text and hope
+        # for the best. (See issue #150.)
+        content_type = attachment.content_type
+        if attachment.charset and attachment.charset != "utf-8":
+            # Rebuild content_type with charset=utf-8 to match what we'll send
+            temp = MIMEPart()
+            temp.add_header("Content-Type", attachment.mimetype, charset="utf-8")
+            content_type = temp["Content-Type"]
+
         att = {
-            "content": attachment.b64content,
-            "type": attachment.mimetype,
+            "content": attachment.b64content_utf8,
+            "type": content_type,
             # (filename is required -- submit empty string if unknown)
             "filename": attachment.name or "",
         }

--- a/anymail/backends/unisender_go.py
+++ b/anymail/backends/unisender_go.py
@@ -304,7 +304,7 @@ class UnisenderGoPayload(RequestsPayload):
         name = attachment.cid if attachment.inline else attachment.name
         att = {
             "content": attachment.b64content,
-            "type": attachment.mimetype,
+            "type": attachment.content_type,
             "name": name or "",  # required - submit empty string if unknown
         }
         if attachment.inline:

--- a/docs/esps/brevo.rst
+++ b/docs/esps/brevo.rst
@@ -155,6 +155,12 @@ Brevo can handle.
   Anymail has no way to communicate an attachment's desired content-type
   to the Brevo API if the name is not set correctly.
 
+**Non-ASCII attachment filenames will be garbled**
+  Brevo's API does not properly encode Unicode characters in attachment
+  filenames. Some email clients will display those characters incorrectly.
+  The only workaround is to limit attachment filenames to ASCII when sending
+  through Brevo.
+
 **Single Reply-To**
   Brevo's v3 API only supports a single Reply-To address.
 

--- a/docs/esps/mailersend.rst
+++ b/docs/esps/mailersend.rst
@@ -188,12 +188,19 @@ see :ref:`unsupported-features`.
   And it determines the content type of the attachment from the filename extension.
 
   If you try to send an attachment without a filename, Anymail will substitute
-  "attachment*.ext*" using an appropriate *.ext* for the content type.
+  "attachment.ext" using an appropriate *.ext* for the content type.
 
   If you try to send an attachment whose content type doesn't match its filename
   extension, MailerSend will change the content type to match the extension.
   (E.g., the filename "data.txt" will always be sent as "text/plain",
   even if you specified a "text/csv" content type.)
+
+**Non-ASCII text attachments may be garbled**
+  MailerSend's API does not provide a way to identify the character set used
+  for text attachment content, and it does not include a ``charset`` parameter
+  in the sent message. Anymail uses utf-8 encoding for MailerSend text attachments.
+  This will display incorrectly or cause errors in email clients that assume
+  some other encoding when the message doesn't identify the charset.
 
 **Single Reply-To**
   MailerSend only supports a single Reply-To address.

--- a/docs/esps/mailgun.rst
+++ b/docs/esps/mailgun.rst
@@ -209,28 +209,15 @@ Limitations and quirks
 **Attachments require filenames**
   Mailgun has an `undocumented API requirement`_ that every attachment must have a
   filename. Attachments with missing filenames are silently dropped from the sent
-  message. Similarly, every inline attachment must have a :mailheader:`Content-ID`.
+  message.
 
-  To avoid unexpected behavior, Anymail will raise an
-  :exc:`~anymail.exceptions.AnymailUnsupportedFeature` error if you attempt to send
-  a message through Mailgun with any attachments that don't have filenames (or inline
-  attachments that don't have :mailheader:`Content-ID`\s).
+  To avoid unexpected behavior, Anymail will use ``"attachment"`` as the filename
+  if you don't supply a filename.
 
-  Ensure your attachments have filenames by using
-  :class:`message.attach_file(filename) <django.core.mail.EmailMessage>`,
-  :class:`message.attach(content, filename="...") <django.core.mail.EmailMessage>`,
-  or if you are constructing your own MIME objects to attach,
-  :meth:`mimeobj.add_header("Content-Disposition", "attachment", filename="...") <email.message.Message.add_header>`.
+  .. versionchanged:: vNext
 
-  Ensure your inline attachments have Content-IDs by using Anymail's
-  :ref:`inline image helpers <inline-images>`, or if you are constructing your own MIME objects,
-  :meth:`mimeobj.add_header("Content-ID", "...") <email.message.Message.add_header>` and
-  :meth:`mimeobj.add_header("Content-Disposition", "inline") <email.message.Message.add_header>`.
-
-  .. versionchanged:: 4.3
-
-      Earlier Anymail releases did not check for these cases, and attachments
-      without filenames/Content-IDs would be ignored by Mailgun without notice.
+     Earlier Anymail versions raised :exc:`~anymail.exceptions.AnymailUnsupportedFeature`
+     if you attempted to send an attachment through Mailgun without a filename.
 
 **Display name problems with punctuation and non-ASCII characters**
   Mailgun does not correctly handle certain display names in :mailheader:`From`,

--- a/docs/esps/sendgrid.rst
+++ b/docs/esps/sendgrid.rst
@@ -281,25 +281,32 @@ Limitations and quirks
 
   (Tested March, 2016)
 
-**Wrong character set on text attachments**
-  Under some conditions, SendGrid incorrectly identifies text attachments (text/plain,
-  text/calendar, etc.) as using ISO-8859-1 encoding, and forces ``charset="iso-8859-1"``
-  into the attachments' MIME headers. This generally causes any non-ASCII characters in
-  the attachments to be replaced with incorrect or illegal characters in the recipient's
-  email client.
+**Non-ASCII text attachments may be garbled**
+  SendGrid's API ignores the character set used for text attachment content.
+  It either strips the ``charset`` parameter from the :mailheader:`Content-Type`
+  attachment header or arbitrarily changes it to ``charset="iso-8859-1"``,
+  even when some other charset is specified. This will display incorrectly or
+  cause errors in many email clients.
 
-  The behavior is unpredictable, and may vary by SendGrid account or change over time.
-  There is no reliable, general workaround that Anymail could implement. You may be able
-  to counteract the issue by enabling open and/or click tracking in your SendGrid
-  account. The only way to completely avoid the problem is switching to a non-text
-  attachment type (e.g., application/pdf) or limiting your text attachments to use only
+  The behavior is unpredictable and may vary by SendGrid account or change over
+  time. It has been reported to SendGrid repeatedly. You may be able to counteract
+  the issue by enabling open and/or click tracking in your SendGrid account. The
+  only way to completely avoid the problem is switching to a non-text attachment
+  type (e.g., application/pdf) or limiting your text attachments to use only
   ASCII characters. See `issue 150 <https://github.com/anymail/django-anymail/issues/150>`_
   for more information and other possible workarounds.
 
-  If this impacts your usage, it's helpful to report it to SendGrid support, so they can
-  quantify customers affected and prioritize a fix.
+  .. versionchanged:: vNext
 
-  (Noted June, 2019 and December, 2019)
+      Anymail forces utf-8 encoding for text attachments and specifically includes
+      that charset in the appropriate SendGrid API parameter. (Even with this change,
+      SendGrid seems to ignore the charset and implement its own logic.)
+
+**Non-ASCII attachment filenames will be garbled**
+  SendGrid does not properly encode Unicode characters in attachment
+  filenames. Some email clients will display those characters incorrectly.
+  The only workaround is to limit attachment filenames to ASCII when sending
+  through SendGrid.
 
 **Arbitrary alternative parts allowed**
   SendGrid is one of the few ESPs that *does* support sending arbitrary alternative

--- a/tests/test_brevo_backend.py
+++ b/tests/test_brevo_backend.py
@@ -1,9 +1,6 @@
 import json
-from base64 import b64decode, b64encode
 from datetime import date, datetime, timezone
 from decimal import Decimal
-from email.mime.base import MIMEBase
-from email.mime.image import MIMEImage
 
 from django.core import mail
 from django.test import SimpleTestCase, override_settings, tag
@@ -18,17 +15,17 @@ from anymail.exceptions import (
     AnymailSerializationError,
     AnymailUnsupportedFeature,
 )
-from anymail.message import AnymailMessage, attach_inline_image_file
+from anymail.message import AnymailMessage, attach_inline_image
 
 from .mock_requests_backend import (
     RequestsBackendMockAPITestCase,
     SessionSharingTestCases,
 )
 from .utils import (
-    SAMPLE_IMAGE_FILENAME,
     AnymailTestMixin,
+    create_text_attachment,
+    decode_att,
     sample_image_content,
-    sample_image_path,
 )
 
 
@@ -309,99 +306,37 @@ class BrevoBackendStandardEmailTests(BrevoBackendMockAPITestCase):
         )
 
     def test_attachments(self):
-        text_content = "* Item one\n* Item two\n* Item three"
+        # Brevo guesses content type from the filename extension. It adds
+        # `charset=utf-8` to text content types, unconditionally.
+        # Brevo accepts non-ASCII filenames but incorrectly sends them
+        # as 8-bit utf-8 (without using RFC 2231 encoding).
+        # Brevo doesn't support inline images.
+        text_content = "pièce jointe\n"
         self.message.attach(
-            filename="test.txt", content=text_content, mimetype="text/plain"
+            create_text_attachment("pièce jointe\n", charset="iso-8859-1")
         )
-
-        # Should guess mimetype if not provided...
-        png_content = b"PNG\xb4 pretend this is the contents of a png file"
-        self.message.attach(filename="test.png", content=png_content)
-
-        # Should work with a MIMEBase object (also tests no filename)...
-        pdf_content = b"PDF\xb4 pretend this is valid pdf data"
-        mimeattachment = MIMEBase("application", "pdf")
-        mimeattachment.set_payload(pdf_content)
-        self.message.attach(mimeattachment)
+        self.message.attach("émoticône.img", b";-)", "image/x-emoticon")
 
         self.message.send()
         data = self.get_api_call_json()
-        self.assertEqual(len(data["attachment"]), 3)
 
         attachments = data["attachment"]
+        self.assertEqual(len(attachments), 2)
+        # Anymail sends an empty filename if none specified, rather than
+        # trying to guess an extension. This will cause a Brevo API error.
+        self.assertEqual(attachments[0]["name"], "")  # no filename
+        # Text content *must* be utf-8 encoded.
         self.assertEqual(
-            attachments[0],
-            {
-                "name": "test.txt",
-                "content": b64encode(text_content.encode("utf-8")).decode("ascii"),
-            },
+            decode_att(attachments[0]["content"]).decode("utf-8"), text_content
         )
-        self.assertEqual(
-            attachments[1],
-            {"name": "test.png", "content": b64encode(png_content).decode("ascii")},
-        )
-        self.assertEqual(
-            attachments[2],
-            {"name": "", "content": b64encode(pdf_content).decode("ascii")},
-        )
-
-    def test_unicode_attachment_correctly_decoded(self):
-        self.message.attach(
-            "Une pièce jointe.html", "<p>\u2019</p>", mimetype="text/html"
-        )
-        self.message.send()
-        attachment = self.get_api_call_json()["attachment"][0]
-        self.assertEqual(attachment["name"], "Une pièce jointe.html")
-        self.assertEqual(
-            b64decode(attachment["content"]).decode("utf-8"), "<p>\u2019</p>"
-        )
+        self.assertEqual(attachments[1]["name"], "émoticône.img")
+        self.assertEqual(decode_att(attachments[1]["content"]), b";-)")
 
     def test_embedded_images(self):
-        # Brevo doesn't support inline image
-        # inline image are just added as a content attachment
-
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-
-        cid = attach_inline_image_file(self.message, image_path)  # Read from a png file
-        html_content = (
-            '<p>This has an <img src="cid:%s" alt="inline" /> image.</p>' % cid
-        )
-        self.message.attach_alternative(html_content, "text/html")
-
-        with self.assertRaises(AnymailUnsupportedFeature):
+        # Brevo doesn't support inline images
+        attach_inline_image(self.message, sample_image_content(), "test.png")
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "inline attachments"):
             self.message.send()
-
-    def test_attached_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        # option 1: attach as a file
-        self.message.attach_file(image_path)
-
-        # option 2: construct the MIMEImage and attach it directly
-        image = MIMEImage(image_data)
-        self.message.attach(image)
-
-        self.message.send()
-
-        image_data_b64 = b64encode(image_data).decode("ascii")
-        data = self.get_api_call_json()
-        self.assertEqual(
-            data["attachment"][0],
-            {
-                "name": image_filename,  # the named one
-                "content": image_data_b64,
-            },
-        )
-        self.assertEqual(
-            data["attachment"][1],
-            {
-                "name": "",  # the unnamed one
-                "content": image_data_b64,
-            },
-        )
 
     def test_multiple_html_alternatives(self):
         self.message.body = "Text body"

--- a/tests/test_mailersend_backend.py
+++ b/tests/test_mailersend_backend.py
@@ -1,8 +1,6 @@
 from calendar import timegm
 from datetime import date, datetime
 from decimal import Decimal
-from email.mime.base import MIMEBase
-from email.mime.image import MIMEImage
 
 from django.core import mail
 from django.test import override_settings, tag
@@ -18,15 +16,10 @@ from anymail.exceptions import (
     AnymailSerializationError,
     AnymailUnsupportedFeature,
 )
-from anymail.message import attach_inline_image_file
+from anymail.message import attach_inline_image
 
 from .mock_requests_backend import RequestsBackendMockAPITestCase
-from .utils import (
-    SAMPLE_IMAGE_FILENAME,
-    decode_att,
-    sample_image_content,
-    sample_image_path,
-)
+from .utils import create_text_attachment, decode_att, sample_image_content
 
 
 @tag("mailersend")
@@ -248,93 +241,40 @@ class MailerSendBackendStandardEmailTests(MailerSendBackendMockAPITestCase):
         self.assertEqual(data["headers"], [{"name": "X-Extra", "value": "Další"}])
 
     def test_attachments(self):
-        text_content = "* Item one\n* Item two\n* Item three"
+        # Mailersend has no way to include a charset for text attachments.
+        # It guesses content type from the filename. It allows non-ASCII
+        # filenames, and correctly rfc2231 encodes the Content-Disposition
+        # filename param (but incorrectly applies rfc2047 to the obsolete
+        # Content-Type name param).
+        text_content = "pièce jointe\n"
         self.message.attach(
-            filename="test.txt", content=text_content, mimetype="text/plain"
+            create_text_attachment("pièce jointe\n", charset="iso-8859-1")
         )
-
-        # Should guess mimetype if not provided...
-        png_content = b"PNG\xb4 pretend this is the contents of a png file"
-        self.message.attach(filename="test.png", content=png_content)
-
-        # Should work with a MIMEBase object (also tests no filename)...
-        pdf_content = b"PDF\xb4 pretend this is valid pdf params"
-        mimeattachment = MIMEBase("application", "pdf")
-        mimeattachment.set_payload(pdf_content)
-        self.message.attach(mimeattachment)
+        self.message.attach("émoticône.img", b";-)", "image/x-emoticon")
+        image_data = sample_image_content()
+        cid = attach_inline_image(self.message, image_data, "test.png")
 
         self.message.send()
         data = self.get_api_call_json()
         attachments = data["attachments"]
         self.assertEqual(len(attachments), 3)
+
+        # Missing filename is generated. Text is sent as utf-8, despite charset.
         self.assertEqual(attachments[0]["disposition"], "attachment")
-        self.assertEqual(attachments[0]["filename"], "test.txt")
+        self.assertEqual(attachments[0]["filename"], "attachment.txt")
         self.assertEqual(
-            decode_att(attachments[0]["content"]).decode("ascii"), text_content
+            decode_att(attachments[0]["content"]).decode("utf-8"), text_content
         )
+
+        # (Filename with ".img" extension would cause a Brevo API error.)
         self.assertEqual(attachments[1]["disposition"], "attachment")
-        self.assertEqual(attachments[1]["filename"], "test.png")
-        self.assertEqual(decode_att(attachments[1]["content"]), png_content)
-        self.assertEqual(attachments[2]["disposition"], "attachment")
-        self.assertEqual(attachments[2]["filename"], "attachment.pdf")  # generated
-        self.assertEqual(decode_att(attachments[2]["content"]), pdf_content)
+        self.assertEqual(attachments[1]["filename"], "émoticône.img")
+        self.assertEqual(decode_att(attachments[1]["content"]), b";-)")
 
-    def test_unicode_attachment_correctly_decoded(self):
-        # Slight modification from the Django unicode docs:
-        # http://django.readthedocs.org/en/latest/ref/unicode.html#email
-        self.message.attach(
-            "Une pièce jointe.html", "<p>\u2019</p>", mimetype="text/html"
-        )
-        self.message.send()
-        data = self.get_api_call_json()
-        attachments = data["attachments"]
-        self.assertEqual(len(attachments), 1)
-
-    def test_embedded_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        cid = attach_inline_image_file(self.message, image_path)
-        html_content = (
-            '<p>This has an <img src="cid:%s" alt="inline" /> image.</p>' % cid
-        )
-        self.message.attach_alternative(html_content, "text/html")
-
-        self.message.send()
-        data = self.get_api_call_json()
-        self.assertEqual(data["html"], html_content)
-
-        self.assertEqual(len(data["attachments"]), 1)
-        self.assertEqual(data["attachments"][0]["disposition"], "inline")
-        self.assertEqual(data["attachments"][0]["filename"], image_filename)
-        self.assertEqual(data["attachments"][0]["id"], cid)
-        self.assertEqual(decode_att(data["attachments"][0]["content"]), image_data)
-
-    def test_attached_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        # option 1: attach as a file
-        self.message.attach_file(image_path)
-
-        # option 2: construct the MIMEImage and attach it directly
-        image = MIMEImage(image_data)
-        self.message.attach(image)
-
-        self.message.send()
-        data = self.get_api_call_json()
-        attachments = data["attachments"]
-        self.assertEqual(len(attachments), 2)
-        self.assertEqual(attachments[0]["disposition"], "attachment")
-        self.assertEqual(attachments[0]["filename"], image_filename)
-        self.assertEqual(decode_att(attachments[0]["content"]), image_data)
-        self.assertNotIn("id", attachments[0])  # not inline
-        self.assertEqual(attachments[1]["disposition"], "attachment")
-        self.assertEqual(attachments[1]["filename"], "attachment.png")  # generated
-        self.assertEqual(decode_att(attachments[1]["content"]), image_data)
-        self.assertNotIn("id", attachments[0])  # not inline
+        self.assertEqual(attachments[2]["disposition"], "inline")
+        self.assertEqual(attachments[2]["filename"], "test.png")
+        self.assertEqual(attachments[2]["id"], cid)
+        self.assertEqual(decode_att(attachments[2]["content"]), image_data)
 
     def test_multiple_html_alternatives(self):
         # Multiple text/html alternatives not allowed

--- a/tests/test_mailgun_backend.py
+++ b/tests/test_mailgun_backend.py
@@ -1,8 +1,5 @@
 from datetime import date, datetime
-from email import message_from_bytes
-from email.mime.base import MIMEBase
 from email.mime.image import MIMEImage
-from textwrap import dedent
 
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
@@ -19,19 +16,13 @@ from anymail.exceptions import (
     AnymailRequestsAPIError,
     AnymailUnsupportedFeature,
 )
-from anymail.message import attach_inline_image_file
+from anymail.message import attach_inline_image
 
 from .mock_requests_backend import (
     RequestsBackendMockAPITestCase,
     SessionSharingTestCases,
 )
-from .utils import (
-    SAMPLE_IMAGE_FILENAME,
-    AnymailTestMixin,
-    sample_email_content,
-    sample_image_content,
-    sample_image_path,
-)
+from .utils import AnymailTestMixin, create_text_attachment, sample_image_content
 
 
 @tag("mailgun")
@@ -209,166 +200,49 @@ class MailgunBackendStandardEmailTests(MailgunBackendMockAPITestCase):
             self.message.send()
 
     def test_attachments(self):
-        text_content = "* Item one\n* Item two\n* Item three"
+        # Mailgun supports non-utf-8 content with charset in the form data
+        # headers. It requires attachment filenames. It supports non-ASCII
+        # filenames which *must* be sent to the API using 8-bit utf-8 per
+        # RFC 7578 (and which Mailgun incorrectly changes to rfc2047 when
+        # sending).
+        text_content = "pièce jointe\n"
         self.message.attach(
-            filename="test.txt", content=text_content, mimetype="text/plain"
+            create_text_attachment("pièce jointe\n", charset="iso-8859-1")
         )
-
-        # Should guess mimetype if not provided...
-        png_content = b"PNG\xb4 pretend this is the contents of a png file"
-        self.message.attach(filename="test.png", content=png_content)
-
-        # Should work with a MIMEBase object...
-        pdf_content = b"PDF\xb4 pretend this is valid pdf data"
-        mimeattachment = MIMEBase("application", "pdf")
-        mimeattachment.set_payload(pdf_content)
-        # Mailgun requires filename:
-        mimeattachment["Content-Disposition"] = 'attachment; filename="custom filename"'
-        self.message.attach(mimeattachment)
-
-        # And also with an message/rfc822 attachment
-        forwarded_email_content = sample_email_content()
-        forwarded_email = message_from_bytes(forwarded_email_content)
-        rfcmessage = MIMEBase("message", "rfc822")
-        # Mailgun requires filename:
-        rfcmessage.add_header(
-            "Content-Disposition", "attachment", filename="forwarded message"
-        )
-        rfcmessage.attach(forwarded_email)
-        self.message.attach(rfcmessage)
+        self.message.attach("émoticône.img", b";-)", "image/x-emoticon")
+        image_data = sample_image_content()
+        cid = attach_inline_image(self.message, image_data, "test.png")
 
         self.message.send()
         files = self.get_api_call_files()
         attachments = [value for (field, value) in files if field == "attachment"]
-        self.assertEqual(len(attachments), 4)
-        self.assertEqual(attachments[0], ("test.txt", text_content, "text/plain"))
-        self.assertEqual(
-            # (type inferred from filename)
-            attachments[1],
-            ("test.png", png_content, "image/png"),
-        )
-        self.assertEqual(
-            attachments[2], ("custom filename", pdf_content, "application/pdf")
-        )
-        # Email messages can get a bit changed with respect to whitespace characters
-        # in headers, without breaking the message, so we tolerate that:
-        self.assertEqual(attachments[3][0], "forwarded message")
-        self.assertEqualIgnoringHeaderFolding(
-            attachments[3][1],
-            b"Content-Type: message/rfc822\nMIME-Version: 1.0\n"
-            + b'Content-Disposition: attachment; filename="forwarded message"\n'
-            + b"\n"
-            + forwarded_email_content,
-        )
-        self.assertEqual(attachments[3][2], "message/rfc822")
+        self.assertEqual(len(attachments), 2)
 
-        # Make sure the image attachment is not treated as embedded:
+        # Missing filename defaults to "attachment".
+        self.assertEqual(
+            attachments[0],
+            (
+                "attachment",
+                text_content.encode("iso-8859-1"),
+                'text/plain; charset="iso-8859-1"',
+            ),
+        )
+        self.assertEqual(attachments[1], ("émoticône.img", b";-)", "image/x-emoticon"))
+
         inlines = [value for (field, value) in files if field == "inline"]
-        self.assertEqual(len(inlines), 0)
+        self.assertEqual(len(inlines), 1)
+        self.assertEqual(inlines[0], (cid, image_data, "image/png"))
 
-    def test_unicode_attachment_correctly_decoded(self):
-        self.message.attach(
-            "Une pièce jointe.html", "<p>\u2019</p>", mimetype="text/html"
-        )
-        self.message.send()
+        request_body = self.get_api_prepared_request().body
+        # Verify charset was included for the text attachment
+        self.assertIn(b'Content-Type: text/plain; charset="iso-8859-1"', request_body)
+        self.assertIn(text_content.encode("iso-8859-1"), request_body)
+        # Verify RFC 7578 was used for the non-ASCII filename
+        self.assertNotIn(b"filename*=", request_body)  # no RFC 2231 encoding
+        self.assertIn('filename="émoticône.img"'.encode("utf-8"), request_body)
 
-        # Verify the RFC 7578 compliance workaround has kicked in:
-        data = self.get_api_call_data()
-        if isinstance(data, dict):
-            # workaround not needed or used (but let's double check actual request)
-            workaround = False
-            prepared = self.get_api_prepared_request()
-            data = prepared.body
-        else:
-            workaround = True
-        data = data.decode("utf-8").replace("\r\n", "\n")
-        self.assertNotIn("filename*=", data)  # No RFC 2231 encoding
-        self.assertIn(
-            'Content-Disposition: form-data; name="attachment";'
-            ' filename="Une pièce jointe.html"',
-            data,
-        )
-
-        if workaround:
-            files = self.get_api_call_files(required=False)
-            self.assertFalse(files)  # files should have been moved to formdata body
-
-    def test_rfc_7578_compliance(self):
-        # Check some corner cases in the workaround
-        # that undoes RFC 2231 multipart/form-data encoding...
-        self.message.subject = "Testing for filename*=utf-8''problems"
-        self.message.body = (
-            "The attached message should have an attachment named 'vedhæftet fil.txt'"
-        )
-        # A forwarded message with its own attachment:
-        forwarded_message = dedent(
-            """\
-            MIME-Version: 1.0
-            From: sender@example.com
-            Subject: This is a test message
-            Content-Type: multipart/mixed; boundary="boundary"
-
-            --boundary
-            Content-Type: text/plain
-
-            This message has an attached file with a non-ASCII filename.
-            --boundary
-            Content-Type: text/plain; name*=utf-8''vedh%C3%A6ftet%20fil.txt
-            Content-Disposition: attachment; filename*=utf-8''vedh%C3%A6ftet%20fil.txt
-
-            This is an attachment.
-            --boundary--
-            """
-        )
-        self.message.attach(
-            "besked med vedhæftede filer", forwarded_message, "message/rfc822"
-        )
-        self.message.send()
-
-        data = self.get_api_call_data()
-        if isinstance(data, dict):
-            # workaround not needed or used (but let's double check actual request)
-            prepared = self.get_api_prepared_request()
-            data = prepared.body
-        data = data.decode("utf-8").replace("\r\n", "\n")
-
-        # Top-level attachment (in form-data)
-        # should have RFC 7578 filename (raw Unicode):
-        self.assertIn(
-            'Content-Disposition: form-data; name="attachment";'
-            ' filename="besked med vedhæftede filer"',
-            data,
-        )
-        # Embedded message/rfc822 attachment should retain its RFC 2231 encoded
-        # filename:
-        self.assertIn(
-            "Content-Type: text/plain; name*=utf-8''vedh%C3%A6ftet%20fil.txt", data
-        )
-        self.assertIn(
-            "Content-Disposition: attachment;"
-            " filename*=utf-8''vedh%C3%A6ftet%20fil.txt",
-            data,
-        )
-        # References to RFC 2231 in message text should remain intact:
-        self.assertIn("Testing for filename*=utf-8''problems", data)
-        self.assertIn(
-            "The attached message should have an attachment named 'vedhæftet fil.txt'",
-            data,
-        )
-
-    def test_attachment_missing_filename(self):
-        """Mailgun silently drops attachments without filenames, so warn the caller"""
-        mimeattachment = MIMEBase("application", "pdf")
-        mimeattachment.set_payload(b"PDF\xb4 pretend this is valid pdf data")
-        mimeattachment["Content-Disposition"] = "attachment"
-        self.message.attach(mimeattachment)
-
-        with self.assertRaisesMessage(
-            AnymailUnsupportedFeature, "attachments without filenames"
-        ):
-            self.message.send()
-
-    def test_inline_missing_contnet_id(self):
+    def test_inline_missing_content_id(self):
+        # Mailgun silently drops inline images without Content-Id
         mimeattachment = MIMEImage(b"imagedata", "x-fakeimage")
         mimeattachment["Content-Disposition"] = 'inline; filename="fakeimage.txt"'
         self.message.attach(mimeattachment)
@@ -376,54 +250,6 @@ class MailgunBackendStandardEmailTests(MailgunBackendMockAPITestCase):
             AnymailUnsupportedFeature, "inline attachments without Content-ID"
         ):
             self.message.send()
-
-    def test_embedded_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        cid = attach_inline_image_file(self.message, image_path)
-        html_content = (
-            '<p>This has an <img src="cid:%s" alt="inline" /> image.</p>' % cid
-        )
-        self.message.attach_alternative(html_content, "text/html")
-
-        self.message.send()
-        data = self.get_api_call_data()
-        self.assertEqual(data["html"], html_content)
-
-        files = self.get_api_call_files()
-        inlines = [value for (field, value) in files if field == "inline"]
-        self.assertEqual(len(inlines), 1)
-        # filename is cid; type is guessed:
-        self.assertEqual(inlines[0], (cid, image_data, "image/png"))
-        # Make sure neither the html nor the inline image is treated as an attachment:
-        attachments = [value for (field, value) in files if field == "attachment"]
-        self.assertEqual(len(attachments), 0)
-
-    def test_attached_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        # option 1: attach as a file:
-        self.message.attach_file(image_path)
-
-        # option 2: construct the MIMEImage and attach it directly:
-        image = MIMEImage(image_data)
-        # Mailgun requires filenames:
-        image.set_param("filename", "custom-filename", "Content-Disposition")
-        self.message.attach(image)
-
-        self.message.send()
-        files = self.get_api_call_files()
-        attachments = [value for (field, value) in files if field == "attachment"]
-        self.assertEqual(len(attachments), 2)
-        self.assertEqual(attachments[0], (image_filename, image_data, "image/png"))
-        self.assertEqual(attachments[1], ("custom-filename", image_data, "image/png"))
-        # Make sure the image attachments are not treated as inline:
-        inlines = [value for (field, value) in files if field == "inline"]
-        self.assertEqual(len(inlines), 0)
 
     def test_multiple_html_alternatives(self):
         # Multiple alternatives not allowed

--- a/tests/test_mailjet_backend.py
+++ b/tests/test_mailjet_backend.py
@@ -1,8 +1,5 @@
 import json
-from base64 import b64encode
 from decimal import Decimal
-from email.mime.base import MIMEBase
-from email.mime.image import MIMEImage
 
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
@@ -14,18 +11,17 @@ from anymail.exceptions import (
     AnymailSerializationError,
     AnymailUnsupportedFeature,
 )
-from anymail.message import attach_inline_image, attach_inline_image_file
+from anymail.message import attach_inline_image
 
 from .mock_requests_backend import (
     RequestsBackendMockAPITestCase,
     SessionSharingTestCases,
 )
 from .utils import (
-    SAMPLE_IMAGE_FILENAME,
     AnymailTestMixin,
+    create_text_attachment,
     decode_att,
     sample_image_content,
-    sample_image_path,
 )
 
 
@@ -273,126 +269,43 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
         self.assertEqual(data["Globals"]["Headers"], {"X-Extra": "Další"})
 
     def test_attachments(self):
-        text_content = "* Item one\n* Item two\n* Item three"
+        # Mailjet adds `charset=utf-8` to all text Content-Type fields, even
+        # if another charset is already present in the ContentType API param.
+        # (To avoid this, send text as utf-8 and omit the charset.)
+        # Mailjet allows and correctly encodes a non-ASCII Filename.
+        # It requires a non-empty Filename, but places no other restrictions on it.
+        text_content = "pièce jointe\n"
         self.message.attach(
-            filename="test.txt", content=text_content, mimetype="text/plain"
+            create_text_attachment("pièce jointe\n", charset="iso-8859-1")
         )
-
-        # Should guess mimetype if not provided...
-        png_content = b"PNG\xb4 pretend this is the contents of a png file"
-        self.message.attach(filename="test.png", content=png_content)
-
-        # Should work with a MIMEBase object (also tests no filename)...
-        pdf_content = b"PDF\xb4 pretend this is valid pdf data"
-        mimeattachment = MIMEBase("application", "pdf")
-        mimeattachment.set_payload(pdf_content)
-        self.message.attach(mimeattachment)
+        self.message.attach("émoticône.img", b";-)", "image/x-emoticon")
+        image_data = sample_image_content()
+        cid = attach_inline_image(self.message, image_data, "test.png")
 
         self.message.send()
         data = self.get_api_call_json()
         attachments = data["Globals"]["Attachments"]
-        self.assertEqual(len(attachments), 3)
-        self.assertEqual(attachments[0]["Filename"], "test.txt")
-        self.assertEqual(attachments[0]["ContentType"], "text/plain")
+        self.assertEqual(len(attachments), 2)
+        self.assertEqual(attachments[0]["Filename"], "attachment")  # generated
+        self.assertEqual(attachments[0]["ContentType"], "text/plain")  # no charset
         self.assertEqual(
-            decode_att(attachments[0]["Base64Content"]).decode("ascii"), text_content
+            # utf-8, despite original charset
+            decode_att(attachments[0]["Base64Content"]).decode("utf-8"),
+            text_content,
         )
         self.assertNotIn("ContentID", attachments[0])
 
-        # inferred from filename:
-        self.assertEqual(attachments[1]["ContentType"], "image/png")
-        self.assertEqual(attachments[1]["Filename"], "test.png")
-        self.assertEqual(decode_att(attachments[1]["Base64Content"]), png_content)
-        # make sure image not treated as inline:
+        self.assertEqual(attachments[1]["ContentType"], "image/x-emoticon")
+        self.assertEqual(attachments[1]["Filename"], "émoticône.img")
+        self.assertEqual(decode_att(attachments[1]["Base64Content"]), b";-)")
         self.assertNotIn("ContentID", attachments[1])
 
-        self.assertEqual(attachments[2]["ContentType"], "application/pdf")
-        self.assertEqual(attachments[2]["Filename"], "attachment")
-        self.assertEqual(decode_att(attachments[2]["Base64Content"]), pdf_content)
-        self.assertNotIn("ContentID", attachments[2])
-
-        self.assertNotIn("InlinedAttachments", data["Globals"])
-
-    def test_unicode_attachment_correctly_decoded(self):
-        self.message.attach(
-            "Une pièce jointe.html", "<p>\u2019</p>", mimetype="text/html"
-        )
-        self.message.send()
-        data = self.get_api_call_json()
-        self.assertEqual(
-            data["Globals"]["Attachments"],
-            [
-                {
-                    "Filename": "Une pièce jointe.html",
-                    "ContentType": "text/html",
-                    "Base64Content": b64encode("<p>\u2019</p>".encode("utf-8")).decode(
-                        "ascii"
-                    ),
-                }
-            ],
-        )
-
-    def test_embedded_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        cid = attach_inline_image_file(self.message, image_path)  # Read from a png file
-        cid2 = attach_inline_image(self.message, image_data)
-        html_content = (
-            '<p>This has an <img src="cid:%s" alt="inline" /> image.</p>' % cid
-        )
-        self.message.attach_alternative(html_content, "text/html")
-
-        self.message.send()
-        data = self.get_api_call_json()
-        self.assertEqual(data["Globals"]["HTMLPart"], html_content)
-
-        attachments = data["Globals"]["InlinedAttachments"]
-        self.assertEqual(len(attachments), 2)
-        self.assertEqual(attachments[0]["Filename"], image_filename)
-        self.assertEqual(attachments[0]["ContentID"], cid)
-        self.assertEqual(attachments[0]["ContentType"], "image/png")
-        self.assertEqual(decode_att(attachments[0]["Base64Content"]), image_data)
-        # Mailjet requires a filename for all attachments, so make sure it's not empty:
-        self.assertEqual(attachments[1]["Filename"], "attachment")
-        self.assertEqual(attachments[1]["ContentID"], cid2)
-        self.assertEqual(attachments[1]["ContentType"], "image/png")
-        self.assertEqual(decode_att(attachments[1]["Base64Content"]), image_data)
-
-        self.assertNotIn("Attachments", data["Globals"])
-
-    def test_attached_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        # option 1: attach as a file:
-        self.message.attach_file(image_path)
-
-        # option 2: construct the MIMEImage and attach it directly:
-        image = MIMEImage(image_data)
-        self.message.attach(image)
-
-        image_data_b64 = b64encode(image_data).decode("ascii")
-
-        self.message.send()
-        data = self.get_api_call_json()
-        self.assertEqual(
-            data["Globals"]["Attachments"],
-            [
-                {
-                    "Filename": image_filename,  # the named one
-                    "ContentType": "image/png",
-                    "Base64Content": image_data_b64,
-                },
-                {
-                    "Filename": "attachment",  # the unnamed one
-                    "ContentType": "image/png",
-                    "Base64Content": image_data_b64,
-                },
-            ],
-        )
+        inlines = data["Globals"]["InlinedAttachments"]
+        self.assertEqual(len(inlines), 1)
+        self.assertEqual(inlines[0]["Filename"], "test.png")
+        self.assertEqual(inlines[0]["ContentID"], cid)
+        self.assertEqual(inlines[0]["ContentType"], "image/png")
+        self.assertEqual(decode_att(inlines[0]["Base64Content"]), image_data)
 
     def test_multiple_html_alternatives(self):
         # Multiple alternatives not allowed

--- a/tests/test_mandrill_backend.py
+++ b/tests/test_mandrill_backend.py
@@ -1,7 +1,5 @@
 from datetime import date, datetime
 from decimal import Decimal
-from email.mime.base import MIMEBase
-from email.mime.image import MIMEImage
 
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
@@ -24,11 +22,10 @@ from .mock_requests_backend import (
     SessionSharingTestCases,
 )
 from .utils import (
-    SAMPLE_IMAGE_FILENAME,
     AnymailTestMixin,
+    create_text_attachment,
     decode_att,
     sample_image_content,
-    sample_image_path,
 )
 
 
@@ -232,92 +229,37 @@ class MandrillBackendStandardEmailTests(MandrillBackendMockAPITestCase):
         self.assertEqual(data["message"]["headers"]["X-Other"], "Keep")
 
     def test_attachments(self):
-        text_content = "* Item one\n* Item two\n* Item three"
+        # Mandrill supports non-utf-8 content with charset in the `type` field.
+        # Mandrill does not require attachment filenames. It accepts non-ASCII
+        # filenames but sends them incorrectly as raw 8-bit utf-8.
+        text_content = "pièce jointe\n"
         self.message.attach(
-            filename="test.txt", content=text_content, mimetype="text/plain"
+            create_text_attachment("pièce jointe\n", charset="iso-8859-1")
         )
-
-        # Should guess mimetype if not provided...
-        png_content = b"PNG\xb4 pretend this is the contents of a png file"
-        self.message.attach(filename="test.png", content=png_content)
-
-        # Should work with a MIMEBase object (also tests no filename)...
-        pdf_content = b"PDF\xb4 pretend this is valid pdf data"
-        mimeattachment = MIMEBase("application", "pdf")
-        mimeattachment.set_payload(pdf_content)
-        self.message.attach(mimeattachment)
+        self.message.attach("émoticône.img", b";-)", "image/x-emoticon")
+        image_data = sample_image_content()
+        cid = attach_inline_image(self.message, image_data, "test.png")
 
         self.message.send()
         data = self.get_api_call_json()
-        attachments = data["message"]["attachments"]
-        self.assertEqual(len(attachments), 3)
-        self.assertEqual(attachments[0]["type"], "text/plain")
-        self.assertEqual(attachments[0]["name"], "test.txt")
-        self.assertEqual(
-            decode_att(attachments[0]["content"]).decode("ascii"), text_content
-        )
-        self.assertEqual(attachments[1]["type"], "image/png")  # inferred from filename
-        self.assertEqual(attachments[1]["name"], "test.png")
-        self.assertEqual(decode_att(attachments[1]["content"]), png_content)
-        self.assertEqual(attachments[2]["type"], "application/pdf")
-        self.assertEqual(attachments[2]["name"], "")  # none
-        self.assertEqual(decode_att(attachments[2]["content"]), pdf_content)
-        # Make sure the image attachment is not treated as embedded:
-        self.assertFalse("images" in data["message"])
 
-    def test_unicode_attachment_correctly_decoded(self):
-        self.message.attach(
-            "Une pièce jointe.html", "<p>\u2019</p>", mimetype="text/html"
-        )
-        self.message.send()
-        data = self.get_api_call_json()
-        attachments = data["message"]["attachments"]
-        self.assertEqual(len(attachments), 1)
-
-    def test_embedded_images(self):
-        image_data = sample_image_content()  # Read from a png file
-
-        cid = attach_inline_image(self.message, image_data)
-        html_content = (
-            '<p>This has an <img src="cid:%s" alt="inline" /> image.</p>' % cid
-        )
-        self.message.attach_alternative(html_content, "text/html")
-
-        self.message.send()
-        data = self.get_api_call_json()
-        self.assertEqual(len(data["message"]["images"]), 1)
-        self.assertEqual(data["message"]["images"][0]["type"], "image/png")
-        self.assertEqual(data["message"]["images"][0]["name"], cid)
-        self.assertEqual(
-            decode_att(data["message"]["images"][0]["content"]), image_data
-        )
-        # Make sure neither the html nor the inline image is treated as an attachment:
-        self.assertFalse("attachments" in data["message"])
-
-    def test_attached_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        # option 1: attach as a file:
-        self.message.attach_file(image_path)
-
-        # option 2: construct the MIMEImage and attach it directly:
-        image = MIMEImage(image_data)
-        self.message.attach(image)
-
-        self.message.send()
-        data = self.get_api_call_json()
         attachments = data["message"]["attachments"]
         self.assertEqual(len(attachments), 2)
-        self.assertEqual(attachments[0]["type"], "image/png")
-        self.assertEqual(attachments[0]["name"], image_filename)
-        self.assertEqual(decode_att(attachments[0]["content"]), image_data)
-        self.assertEqual(attachments[1]["type"], "image/png")
-        self.assertEqual(attachments[1]["name"], "")  # unknown -- not attached as file
-        self.assertEqual(decode_att(attachments[1]["content"]), image_data)
-        # Make sure the image attachments are not treated as embedded:
-        self.assertFalse("images" in data["message"])
+        self.assertEqual(attachments[0]["type"], 'text/plain; charset="iso-8859-1"')
+        self.assertEqual(attachments[0]["name"], "")  # no filename
+        self.assertEqual(
+            decode_att(attachments[0]["content"]).decode("iso-8859-1"), text_content
+        )
+        self.assertEqual(attachments[1]["type"], "image/x-emoticon")
+        self.assertEqual(attachments[1]["name"], "émoticône.img")
+        self.assertEqual(decode_att(attachments[1]["content"]), b";-)")
+
+        inlines = data["message"]["images"]
+        self.assertEqual(len(data["message"]["images"]), 1)
+        self.assertEqual(len(inlines), 1)
+        self.assertEqual(inlines[0]["type"], "image/png")  # from filename
+        self.assertEqual(inlines[0]["name"], cid)
+        self.assertEqual(decode_att(inlines[0]["content"]), image_data)
 
     def test_multiple_html_alternatives(self):
         # Multiple alternatives not allowed

--- a/tests/test_resend_backend.py
+++ b/tests/test_resend_backend.py
@@ -1,9 +1,6 @@
 import json
-from base64 import b64encode
 from datetime import date, datetime
 from decimal import Decimal
-from email.mime.base import MIMEBase
-from email.mime.image import MIMEImage
 
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
@@ -18,18 +15,17 @@ from anymail.exceptions import (
     AnymailSerializationError,
     AnymailUnsupportedFeature,
 )
-from anymail.message import AnymailMessage, attach_inline_image_file
+from anymail.message import AnymailMessage, attach_inline_image
 
 from .mock_requests_backend import (
     RequestsBackendMockAPITestCase,
     SessionSharingTestCases,
 )
 from .utils import (
-    SAMPLE_IMAGE_FILENAME,
     AnymailTestMixin,
+    create_text_attachment,
     decode_att,
     sample_image_content,
-    sample_image_path,
 )
 
 
@@ -205,116 +201,44 @@ class ResendBackendStandardEmailTests(ResendBackendMockAPITestCase):
         self.assertEqual(data["headers"], {"X-Extra": "Další"})
 
     def test_attachments(self):
-        text_content = "* Item one\n* Item two\n* Item three"
+        # Resend supports non-utf-8 content with charset in the `content_type` field.
+        # Resend requires attachment filenames whose extensions are consistent with
+        # the content_type (and silently drops messages where they aren't).
+        # It allows non-ASCII filenames and sends them correctly using rfc2231
+        # in the Content-Disposition filename param (but incorrectly applies
+        # rfc2047 in the obsolete Content-Type name param).
+        text_content = "pièce jointe\n"
         self.message.attach(
-            filename="test.txt", content=text_content, mimetype="text/plain"
+            create_text_attachment("pièce jointe\n", charset="iso-8859-1")
         )
-
-        # Should guess mimetype if not provided...
-        png_content = b"PNG\xb4 pretend this is the contents of a png file"
-        self.message.attach(filename="test.png", content=png_content)
-
-        # Should work with a MIMEBase object (also tests no filename)...
-        pdf_content = b"PDF\xb4 pretend this is valid pdf data"
-        mimeattachment = MIMEBase("application", "pdf")
-        mimeattachment.set_payload(pdf_content)
-        self.message.attach(mimeattachment)
+        self.message.attach("émoticône.img", b";-)", "image/x-emoticon")
+        image_data = sample_image_content()
+        cid = attach_inline_image(self.message, image_data, "test.png")
 
         self.message.send()
         data = self.get_api_call_json()
+
         attachments = data["attachments"]
         self.assertEqual(len(attachments), 3)
-        self.assertEqual(attachments[0]["filename"], "test.txt")
-        self.assertEqual(attachments[0]["content_type"], "text/plain")
+
         self.assertEqual(
-            decode_att(attachments[0]["content"]).decode("ascii"), text_content
+            attachments[0]["content_type"], 'text/plain; charset="iso-8859-1"'
+        )
+        self.assertEqual(attachments[0]["filename"], "attachment.txt")  # generated
+        self.assertEqual(
+            decode_att(attachments[0]["content"]).decode("iso-8859-1"), text_content
         )
         self.assertNotIn("content_id", attachments[0])
 
-        self.assertEqual(attachments[1]["filename"], "test.png")
-        self.assertEqual(attachments[1]["content_type"], "image/png")
-        self.assertEqual(decode_att(attachments[1]["content"]), png_content)
+        self.assertEqual(attachments[1]["content_type"], "image/x-emoticon")
+        self.assertEqual(attachments[1]["filename"], "émoticône.img")
+        self.assertEqual(decode_att(attachments[1]["content"]), b";-)")
         self.assertNotIn("content_id", attachments[1])
 
-        # unnamed attachment given default name with correct extension for content type
-        self.assertEqual(attachments[2]["filename"], "attachment.pdf")
-        self.assertEqual(attachments[2]["content_type"], "application/pdf")
-        self.assertEqual(decode_att(attachments[2]["content"]), pdf_content)
-        self.assertNotIn("content_id", attachments[2])
-
-    def test_unicode_attachment_correctly_decoded(self):
-        self.message.attach(
-            "Une pièce jointe.html", "<p>\u2019</p>", mimetype="text/html"
-        )
-        self.message.send()
-        data = self.get_api_call_json()
-        self.assertEqual(
-            data["attachments"],
-            [
-                {
-                    "filename": "Une pièce jointe.html",
-                    "content_type": "text/html",
-                    "content": b64encode("<p>\u2019</p>".encode("utf-8")).decode(
-                        "ascii"
-                    ),
-                }
-            ],
-        )
-
-    def test_embedded_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        cid = attach_inline_image_file(self.message, image_path)  # Read from a png file
-        html_content = (
-            '<p>This has an <img src="cid:%s" alt="inline" /> image.</p>' % cid
-        )
-        self.message.attach_alternative(html_content, "text/html")
-
-        self.message.send()
-        data = self.get_api_call_json()
-        self.assertEqual(data["html"], html_content)
-
-        self.assertEqual(len(data["attachments"]), 1)
-        self.assertEqual(data["attachments"][0]["content_type"], "image/png")
-        self.assertEqual(data["attachments"][0]["filename"], image_filename)
-        self.assertEqual(data["attachments"][0]["content_id"], cid)
-        self.assertEqual(decode_att(data["attachments"][0]["content"]), image_data)
-
-    def test_attached_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        # option 1: attach as a file
-        self.message.attach_file(image_path)
-
-        # option 2: construct the MIMEImage and attach it directly
-        image = MIMEImage(image_data)
-        self.message.attach(image)
-
-        image_data_b64 = b64encode(image_data).decode("ascii")
-
-        self.message.send()
-        data = self.get_api_call_json()
-        self.assertEqual(
-            data["attachments"],
-            [
-                {
-                    "filename": image_filename,  # the named one
-                    "content_type": "image/png",
-                    "content": image_data_b64,
-                },
-                {
-                    # For unnamed attachments, Anymail constructs a default name
-                    # based on the content_type:
-                    "filename": "attachment.png",
-                    "content_type": "image/png",
-                    "content": image_data_b64,
-                },
-            ],
-        )
+        self.assertEqual(attachments[2]["content_type"], "image/png")
+        self.assertEqual(attachments[2]["filename"], "test.png")
+        self.assertEqual(decode_att(attachments[2]["content"]), image_data)
+        self.assertEqual(attachments[2]["content_id"], cid)
 
     def test_mismatched_attachment_extension(self):
         # See note above about silently dropping messages.
@@ -333,11 +257,11 @@ class ResendBackendStandardEmailTests(ResendBackendMockAPITestCase):
         data = self.get_api_call_json()
         attachments = data["attachments"]
         self.assertEqual(len(attachments), 1)
-        self.assertEqual(attachments[0]["content_type"], "text/csv")
+        self.assertEqual(attachments[0]["content_type"], 'text/csv; charset="utf-8"')
         self.assertEqual(attachments[0]["filename"], "data.txt")
 
     def test_missing_attachment_filename_unknown_type(self):
-        # Earlier tests cover generating a missing filename (attachment.txt).
+        # test_attachments() covers generating a missing filename (attachment.txt).
         # Verify an error when the extension can't be determined.
         self.message.attach(None, "data", "text/x-unknown-type")
         with self.assertRaisesMessage(

--- a/tests/test_sparkpost_backend.py
+++ b/tests/test_sparkpost_backend.py
@@ -1,9 +1,6 @@
 import json
 from datetime import date, datetime, timezone
 from decimal import Decimal
-from email.mime.base import MIMEBase
-from email.mime.image import MIMEImage
-from email.mime.text import MIMEText
 
 from django.core import mail
 from django.test import override_settings, tag
@@ -19,15 +16,10 @@ from anymail.exceptions import (
     AnymailSerializationError,
     AnymailUnsupportedFeature,
 )
-from anymail.message import AnymailMessage, attach_inline_image_file
+from anymail.message import AnymailMessage, attach_inline_image
 
 from .mock_requests_backend import RequestsBackendMockAPITestCase
-from .utils import (
-    SAMPLE_IMAGE_FILENAME,
-    decode_att,
-    sample_image_content,
-    sample_image_path,
-)
+from .utils import create_text_attachment, decode_att, sample_image_content
 
 
 @tag("sparkpost")
@@ -287,109 +279,36 @@ class SparkPostBackendStandardEmailTests(SparkPostBackendMockAPITestCase):
         )
 
     def test_attachments(self):
-        text_content = "* Item one\n* Item two\n* Item three"
+        # Sparkpost supports non-utf-8 content with charset in the `type` field.
+        # Sparkpost does not require attachment filenames. It allows non-ASCII
+        # filenames (though incorrectly applies rfc2047 when sending).
+        text_content = "pièce jointe\n"
         self.message.attach(
-            filename="test.txt", content=text_content, mimetype="text/plain"
+            create_text_attachment("pièce jointe\n", charset="iso-8859-1")
         )
-
-        # Should guess mimetype if not provided...
-        png_content = b"PNG\xb4 pretend this is the contents of a png file"
-        self.message.attach(filename="test.png", content=png_content)
-
-        # Should work with a MIMEBase object (also tests no filename)...
-        pdf_content = b"PDF\xb4 pretend this is valid pdf params"
-        mimeattachment = MIMEBase("application", "pdf")
-        mimeattachment.set_payload(pdf_content)
-        self.message.attach(mimeattachment)
+        self.message.attach("émoticône.img", b";-)", "image/x-emoticon")
+        image_data = sample_image_content()
+        cid = attach_inline_image(self.message, image_data, "test.png")
 
         self.message.send()
         data = self.get_api_call_json()
-        attachments = data["content"]["attachments"]
-        self.assertEqual(len(attachments), 3)
-        self.assertEqual(attachments[0]["type"], "text/plain")
-        self.assertEqual(attachments[0]["name"], "test.txt")
-        self.assertEqual(
-            decode_att(attachments[0]["data"]).decode("ascii"), text_content
-        )
-        self.assertEqual(attachments[1]["type"], "image/png")  # inferred from filename
-        self.assertEqual(attachments[1]["name"], "test.png")
-        self.assertEqual(decode_att(attachments[1]["data"]), png_content)
-        self.assertEqual(attachments[2]["type"], "application/pdf")
-        self.assertEqual(attachments[2]["name"], "")  # none
-        self.assertEqual(decode_att(attachments[2]["data"]), pdf_content)
-        # Make sure the image attachment is not treated as embedded:
-        self.assertNotIn("inline_images", data["content"])
 
-    def test_unicode_attachment_correctly_decoded(self):
-        # Slight modification from the Django unicode docs:
-        # http://django.readthedocs.org/en/latest/ref/unicode.html#email
-        self.message.attach(
-            "Une pièce jointe.html", "<p>\u2019</p>", mimetype="text/html"
-        )
-        self.message.send()
-        data = self.get_api_call_json()
-        attachments = data["content"]["attachments"]
-        self.assertEqual(len(attachments), 1)
-
-    def test_attachment_charset(self):
-        # SparkPost allows charset param in attachment type
-        self.message.attach(MIMEText("Une pièce jointe", "plain", "iso8859-1"))
-        self.message.send()
-        data = self.get_api_call_json()
-        attachment = data["content"]["attachments"][0]
-        self.assertEqual(attachment["type"], 'text/plain; charset="iso8859-1"')
-        self.assertEqual(
-            decode_att(attachment["data"]), "Une pièce jointe".encode("iso8859-1")
-        )
-
-    def test_embedded_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        cid = attach_inline_image_file(self.message, image_path)
-        html_content = (
-            '<p>This has an <img src="cid:%s" alt="inline" /> image.</p>' % cid
-        )
-        self.message.attach_alternative(html_content, "text/html")
-
-        self.message.send()
-        data = self.get_api_call_json()
-        self.assertEqual(data["content"]["html"], html_content)
-
-        self.assertEqual(len(data["content"]["inline_images"]), 1)
-        self.assertEqual(data["content"]["inline_images"][0]["type"], "image/png")
-        self.assertEqual(data["content"]["inline_images"][0]["name"], cid)
-        self.assertEqual(
-            decode_att(data["content"]["inline_images"][0]["data"]), image_data
-        )
-        # Make sure neither the html nor the inline image is treated as an attachment:
-        self.assertNotIn("attachments", data["content"])
-
-    def test_attached_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        # option 1: attach as a file
-        self.message.attach_file(image_path)
-
-        # option 2: construct the MIMEImage and attach it directly
-        image = MIMEImage(image_data)
-        self.message.attach(image)
-
-        self.message.send()
-        data = self.get_api_call_json()
         attachments = data["content"]["attachments"]
         self.assertEqual(len(attachments), 2)
-        self.assertEqual(attachments[0]["type"], "image/png")
-        self.assertEqual(attachments[0]["name"], image_filename)
-        self.assertEqual(decode_att(attachments[0]["data"]), image_data)
-        self.assertEqual(attachments[1]["type"], "image/png")
-        self.assertEqual(attachments[1]["name"], "")  # unknown -- not attached as file
-        self.assertEqual(decode_att(attachments[1]["data"]), image_data)
-        # Make sure the image attachments are not treated as embedded:
-        self.assertNotIn("inline_images", data["content"])
+        self.assertEqual(attachments[0]["type"], 'text/plain; charset="iso-8859-1"')
+        self.assertEqual(attachments[0]["name"], "")  # no filename
+        self.assertEqual(
+            decode_att(attachments[0]["data"]).decode("iso-8859-1"), text_content
+        )
+        self.assertEqual(attachments[1]["type"], "image/x-emoticon")
+        self.assertEqual(attachments[1]["name"], "émoticône.img")
+        self.assertEqual(decode_att(attachments[1]["data"]), b";-)")
+
+        inlines = data["content"]["inline_images"]
+        self.assertEqual(len(inlines), 1)
+        self.assertEqual(inlines[0]["type"], "image/png")  # from filename
+        self.assertEqual(inlines[0]["name"], cid)
+        self.assertEqual(decode_att(inlines[0]["data"]), image_data)
 
     def test_multiple_html_alternatives(self):
         # Multiple text/html alternatives not allowed

--- a/tests/test_unisender_go_backend.py
+++ b/tests/test_unisender_go_backend.py
@@ -1,9 +1,6 @@
 import json
-from base64 import b64encode
 from datetime import date, datetime
 from decimal import Decimal
-from email.mime.base import MIMEBase
-from email.mime.image import MIMEImage
 from unittest.mock import patch
 
 from django.core import mail
@@ -20,17 +17,17 @@ from anymail.exceptions import (
     AnymailSerializationError,
     AnymailUnsupportedFeature,
 )
-from anymail.message import AnymailMessage, attach_inline_image_file
+from anymail.message import AnymailMessage, attach_inline_image
 
 from .mock_requests_backend import (
     RequestsBackendMockAPITestCase,
     SessionSharingTestCases,
 )
 from .utils import (
-    SAMPLE_IMAGE_FILENAME,
     AnymailTestMixin,
+    create_text_attachment,
+    decode_att,
     sample_image_content,
-    sample_image_path,
 )
 
 
@@ -324,108 +321,37 @@ class UnisenderGoBackendStandardEmailTests(UnisenderGoBackendMockAPITestCase):
         )
 
     def test_attachments(self):
-        text_content = "* Item one\n* Item two\n* Item three"
+        # Unisender Go supports non-utf-8 content with charset in the `type` field.
+        # Unisender Go requires the `name` field, which may be an empty string.
+        # It allows non-ASCII filenames (though incorrectly applies rfc2047 when
+        # sending).
+        text_content = "pièce jointe\n"
         self.message.attach(
-            filename="test.txt", content=text_content, mimetype="text/plain"
+            create_text_attachment("pièce jointe\n", charset="iso-8859-1")
         )
-
-        # Should guess mimetype if not provided...
-        png_content = b"PNG\xb4 pretend this is the contents of a png file"
-        self.message.attach(filename="test.png", content=png_content)
-
-        # Should work with a MIMEBase object (also tests no filename)...
-        pdf_content = b"PDF\xb4 pretend this is valid pdf data"
-        mimeattachment = MIMEBase("application", "pdf")
-        mimeattachment.set_payload(pdf_content)
-        self.message.attach(mimeattachment)
+        self.message.attach("émoticône.img", b";-)", "image/x-emoticon")
+        image_data = sample_image_content()
+        cid = attach_inline_image(self.message, image_data, "test.png")
 
         self.message.send()
         data = self.get_api_call_json()
+
         attachments = data["message"]["attachments"]
-        self.assertEqual(len(attachments), 3)
-
+        self.assertEqual(len(attachments), 2)
+        self.assertEqual(attachments[0]["type"], 'text/plain; charset="iso-8859-1"')
+        self.assertEqual(attachments[0]["name"], "")  # no filename
         self.assertEqual(
-            attachments[0],
-            {
-                "name": "test.txt",
-                "content": b64encode(text_content.encode("utf-8")).decode("ascii"),
-                "type": "text/plain",
-            },
+            decode_att(attachments[0]["content"]).decode("iso-8859-1"), text_content
         )
-        self.assertEqual(
-            attachments[1],
-            {
-                "name": "test.png",
-                "content": b64encode(png_content).decode("ascii"),
-                "type": "image/png",  # (type inferred from filename)
-            },
-        )
-        self.assertEqual(
-            attachments[2],
-            {
-                "name": "",  # no filename -- but param is required
-                "content": b64encode(pdf_content).decode("ascii"),
-                "type": "application/pdf",
-            },
-        )
+        self.assertEqual(attachments[1]["type"], "image/x-emoticon")
+        self.assertEqual(attachments[1]["name"], "émoticône.img")
+        self.assertEqual(decode_att(attachments[1]["content"]), b";-)")
 
-    def test_embedded_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        cid = attach_inline_image_file(self.message, image_path)  # Read from a png file
-        html_content = (
-            '<p>This has an <img src="cid:%s" alt="inline" /> image.</p>' % cid
-        )
-        self.message.attach_alternative(html_content, "text/html")
-
-        self.message.send()
-        data = self.get_api_call_json()
-
-        self.assertEqual(
-            data["message"]["inline_attachments"],
-            [
-                {
-                    "name": cid,
-                    "content": b64encode(image_data).decode("ascii"),
-                    "type": "image/png",  # (type inferred from filename)
-                }
-            ],
-        )
-
-    def test_attached_images(self):
-        image_filename = SAMPLE_IMAGE_FILENAME
-        image_path = sample_image_path(image_filename)
-        image_data = sample_image_content(image_filename)
-
-        # option 1: attach as a file
-        self.message.attach_file(image_path)
-
-        # option 2: construct the MIMEImage and attach it directly
-        image = MIMEImage(image_data)
-        self.message.attach(image)
-
-        self.message.send()
-
-        image_data_b64 = b64encode(image_data).decode("ascii")
-        data = self.get_api_call_json()
-        self.assertEqual(
-            data["message"]["attachments"][0],
-            {
-                "name": image_filename,  # the named one
-                "content": image_data_b64,
-                "type": "image/png",
-            },
-        )
-        self.assertEqual(
-            data["message"]["attachments"][1],
-            {
-                "name": "",  # the unnamed one
-                "content": image_data_b64,
-                "type": "image/png",
-            },
-        )
+        inlines = data["message"]["inline_attachments"]
+        self.assertEqual(len(inlines), 1)
+        self.assertEqual(inlines[0]["type"], "image/png")  # from filename
+        self.assertEqual(inlines[0]["name"], cid)
+        self.assertEqual(decode_att(inlines[0]["content"]), image_data)
 
     def test_multiple_html_alternatives(self):
         # Multiple alternatives not allowed

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,8 @@ import uuid
 import warnings
 from base64 import b64decode
 from contextlib import contextmanager
+from email.message import MIMEPart
+from email.mime.text import MIMEText
 from io import BytesIO, StringIO
 from pathlib import Path
 from unittest import TestCase
@@ -65,6 +67,29 @@ def sample_email_content(filename=SAMPLE_EMAIL_FILENAME):
     Returns bytes contents of an email file (e.g., for forwarding as an attachment)
     """
     return test_file_content(filename)
+
+
+#
+# Text attachment with charset
+#
+
+
+def create_text_attachment(content, *, subtype="plain", charset="utf-8", filename=None):
+    """
+    Return a MIME text attachment object compatible with current Django version,
+    using specified charset.
+    """
+    if django.VERSION < (6, 0):
+        # MIMEBase deprecated in Django 6.0, removed in Django 7.0
+        mime_text = MIMEText(content, subtype, charset)
+    else:
+        # MIMEPart added in Django 6.0
+        mime_text = MIMEPart()
+        mime_text.set_content(content, subtype=subtype, charset=charset)
+
+    cd_params = {} if filename is None else {"filename": filename}
+    mime_text.add_header("Content-Disposition", "attachment", **cd_params)
+    return mime_text
 
 
 #


### PR DESCRIPTION
Improve handling of non-ASCII characters in attachments

Update ESP backends and tests to provide the best available handling
of non-ASCII characters in attachments, and document limitations.

Improve Anymail's normalized Attachment object:
- Rework content-type properties: add maintype, subtype and charset;
  ensure content_type includes charset param if appropriate
- Add content accessors that force utf-8 or use original charset
  for text/* types (and str content)
- Add support for modern MIMEPart attachments (prep for Django 6.0)
- Stop using (undocumented) Django EmailMessage.encoding for text
  attachment charset (but continue using settings.DEFAULT_CHARSET,
  which is EmailMessage.encoding's default)
- Handle Python Message and EmailMessage and Django EmailMessage
  objects as attachment content, consistent with Django's own
  behavior in EmailMessage.message().
- Add several missing normalized Attachment tests

Based on testing individual ESP behavior:
- Ensure charset is included in attachment content type for ESPs
  that support it properly
- Ensure attachment text content is encoded as utf-8 for ESPs
  that assume utf-8 and/or force charset=utf-8 in headers
- Document likely mojibake content for ESPs that refuse to send
  charset on a text attachment
- Document likely mojibake filenames for ESPs that send them as
  raw 8-bit utf-8, rather than RFC 2231. (But don't bother documenting
  the large number of ESPs that incorrectly use RFC 2047 for
  attachment filenames. Many email clients seem to accept that, and the
  encoded-word identifies the charset so is unlikely to cause mojibake.)

Also:
- Simplify ESP-specific attachment tests (now that different ways
  to attach things are covered in normalized Attachment utility test)
- Mailgun: default missing attachment filename to "attachment"
  for consistency with other ESPs
- Mailgun: remove defunct tests for old workaround when requests
  didn't use RFC 7578 filename encoding

Closes #449