### PR TITLE
Resend: Support inline images; identify attachment content-type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,8 +65,18 @@ Breaking changes
   local part). This avoids a Mailgun API bug that generates undeliverable
   messages.
 
+* **Resend:** Raise an error if an attachment's filename has an extension that
+  doesn't match its content type. This tries to help you avoid a Resend API bug
+  that can silently drop sent messages.
+
 * **Scaleway TEM:** Raise an error if any address field uses EAI (has a non-ASCII
   local part). This avoids a Scaleway API bug that generates undeliverable messages.
+
+Features
+~~~~~~~~
+
+* **Resend:** Add support for inline images. Identify attachment content type
+  using new API parameter. (See related Resend breaking change above.)
 
 Fixes
 ~~~~~

--- a/anymail/backends/resend.py
+++ b/anymail/backends/resend.py
@@ -31,6 +31,15 @@ class EmailBackend(AnymailRequestsBackend):
         )
         if not api_url.endswith("/"):
             api_url += "/"
+
+        # Undocumented setting to control checking attachment filename extensions.
+        # (See ResendPayload.make_attachment().)
+        self.verify_attachment_extensions = get_anymail_setting(
+            "verify_attachment_extensions",
+            esp_name=esp_name,
+            kwargs=kwargs,
+            default=True,
+        )
         super().__init__(api_url, **kwargs)
 
     def build_message_payload(self, message, defaults):
@@ -172,25 +181,43 @@ class ResendPayload(RequestsPayload):
             self.unsupported_feature("multiple html parts")
         self.data["html"] = body
 
-    @staticmethod
-    def make_attachment(attachment):
+    def make_attachment(self, attachment):
         """Returns Resend attachment dict for attachment"""
+        # Resend silently drops messages with attachments that don't have
+        # a filename, or whose filename extensions don't match the content_type.
+        # (But it *will* send attachments with unknown extensions and types.)
+        # Try to detect and prevent attachments that might silently fail.
+        # If Resend fixes their API, you can disable this check in settings.py:
+        #    ANYMAIL = { ..., "RESEND_VERIFY_ATTACHMENT_EXTENSIONS": False }
         filename = attachment.name or ""
+        if filename and self.backend.verify_attachment_extensions:
+            mimetype, _ = mimetypes.guess_type(filename)
+            if mimetype and mimetype != attachment.mimetype:
+                self.unsupported_feature(
+                    f"attachments of type {attachment.mimetype} with name {filename!r}"
+                )
         if not filename:
-            # Provide default name with reasonable extension.
-            # (Resend guesses content type from the filename extension;
-            # there doesn't seem to be any other way to specify it.)
-            ext = mimetypes.guess_extension(attachment.content_type)
-            if ext is not None:
+            # No name provided. Generate default name with reasonable extension.
+            ext = mimetypes.guess_extension(attachment.mimetype)
+            if ext:
                 filename = f"attachment{ext}"
-        att = {"content": attachment.b64content, "filename": filename}
-        # attachment.inline / attachment.cid not supported
+            else:
+                self.unsupported_feature(
+                    f"unnamed attachments of type {attachment.mimetype}"
+                )
+        att = {
+            "content": attachment.b64content,
+            "filename": filename,
+            "content_type": attachment.content_type,
+        }
+        if attachment.inline:
+            if not attachment.cid:
+                self.unsupported_feature("inline attachments without Content-ID")
+            att["content_id"] = attachment.cid
         return att
 
     def set_attachments(self, attachments):
         if attachments:
-            if any(att.content_id for att in attachments):
-                self.unsupported_feature("inline content-id")
             self.data["attachments"] = [
                 self.make_attachment(attachment) for attachment in attachments
             ]

--- a/docs/esps/resend.rst
+++ b/docs/esps/resend.rst
@@ -117,20 +117,27 @@ error when you try to send a message using features that Resend doesn't support.
 You can tell Anymail to suppress these errors and send the messages
 anyway---see :ref:`unsupported-features`.
 
-**Attachment filename determines content type**
-  Resend determines the content type of an attachment from its filename extension.
+**Attachment filename extension must match content type**
+  Resend silently drops messages with attachments whose filename extensions
+  are inconsistent with their content types (mimetype). E.g., sending
+  a *text/csv* attachment with the filename "data.txt" rather than "data.csv"
+  will not generate an API error or bounce, but the message will never be
+  delivered.
 
-  If you try to send an attachment without a filename, Anymail will substitute
-  "attachment\ *.ext*" using an appropriate *.ext* for the content type.
+  To avoid this, Anymail attempts to verify attachment filenames before sending,
+  and raises an :exc:`~anymail.exceptions.AnymailUnsupportedFeature` error for
+  likely mismatches. (This is a best guess using Python's :mod:`mimetypes`
+  package. There's no way for Anymail to know exactly which extensions and
+  content types will cause Resend to drop a message.)
 
-  If you try to send an attachment whose content type doesn't match its filename
-  extension, Resend will change the content type to match the extension.
-  (E.g., the filename "data.txt" will always be sent as "text/plain",
-  even if you specified a "text/csv" content type.)
+  If you try to send an attachment without a filename, Anymail will generate
+  a filename for you using "attachment\ *.ext*" with an appropriate extension
+  for the content type.
 
-**No inline images**
-  Resend's API does not provide a mechanism to send inline content
-  or to specify :mailheader:`Content-ID` for an attachment.
+  .. versionchanged:: vNext
+
+      Resend's API did not previously support specifying the content type,
+      and instead based attachment content type on the filename.
 
 **Anymail tags and metadata are exposed to recipient**
   Anymail implements its normalized :attr:`~anymail.message.AnymailMessage.tags`
@@ -181,6 +188,13 @@ anyway---see :ref:`unsupported-features`.
 **No non-ASCII mailboxes (EAI)**
   Resend does not support sending from or to Unicode mailboxes (the *user* part of
   *user\@domain*---see :ref:`EAI <eai>`). Trying to use one will cause an API error.
+
+**Earlier limitations**
+
+    .. versionchanged:: vNext
+
+    Resend's API did not previously support inline images. Earlier Anymail
+    releases raised an error on attempts to send them through Resend.
 
 
 .. _resend-api-rate-limits:


### PR DESCRIPTION
Use Resend's new `content_id` param for inline images.

Use Resend's new(-ish?) `content_type` param to supply attachment content-type.

Try to avoid a Resend API bug that silently fails to send messages where an attachment's filename extension doesn't match its content type (by raising an unsupported feature error).

Closes #440.