### PR TITLE
Exempt webhooks from Django's LoginRequiredMiddleware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -91,6 +91,9 @@ Fixes
 * Handle sending attached messages (e.g., forwarded emails) consistently with
   Django's SMTP EmailBackend.
 
+* Exempt webhooks from Django's LoginRequiredMiddleware.
+  (Thanks to `@Zerotask`_ for reporting the issue.)
+
 * **Brevo, Mailgun, Mandrill, Postal, Postmark, Scaleway TEM, Unisender Go:**
   Fix Anymail bugs that could cause text attachments with non-ASCII content
   to display incorrectly in some email clients.
@@ -1982,3 +1985,4 @@ Features
 .. _@vgrebenschikov: https://github.com/vgrebenschikov
 .. _@vitaliyf: https://github.com/vitaliyf
 .. _@yourcelf: https://github.com/yourcelf
+.. _@Zerotask: https://github.com/Zerotask

--- a/anymail/webhooks/base.py
+++ b/anymail/webhooks/base.py
@@ -9,6 +9,13 @@ from django.views.generic import View
 from ..exceptions import AnymailInsecureWebhookWarning, AnymailWebhookValidationFailure
 from ..utils import collect_all_methods, get_anymail_setting, get_request_basic_auth
 
+try:
+    from django.contrib.auth.decorators import login_not_required
+except ImportError:
+    # LoginRequiredMiddleware added in Django 5.1
+    def login_not_required(view_func):
+        return view_func
+
 
 # Mixin note: Django's View.__init__ doesn't cooperate with chaining,
 # so all mixins that need __init__ must appear before View in MRO.
@@ -63,6 +70,7 @@ class AnymailCoreWebhookView(View):
     http_method_names = ["post", "head", "options"]
 
     @method_decorator(csrf_exempt)
+    @method_decorator(login_not_required)
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
Webhooks provide their own auth mechanism and are not capable
of using Django's login forms. Mark them `login_not_required`.

Fixes #443