### PR TITLE
Postmark: Avoid KeyError in tracking webhook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -105,6 +105,10 @@ Fixes
   than raising an error) for consistency with Anymail's handling of missing
   attachment filenames in other ESPs.
 
+* **Postmark:** Prevent a KeyError in the tracking webhook when handling
+  an unsubscribe request due to a bounce. (Thanks to `@dshunfen`_ for reporting
+  the issue.)
+
 Other
 ~~~~~
 
@@ -1938,6 +1942,7 @@ Features
 .. _@dgilmanAIDENTIFIED: https://github.com/dgilmanAIDENTIFIED
 .. _@dimitrisor: https://github.com/dimitrisor
 .. _@dominik-lekse: https://github.com/dominik-lekse
+.. _@dshunfen: https://github.com/dshunfen
 .. _@Ecno92: https://github.com/Ecno92
 .. _@erikdrums: https://github.com/erikdrums
 .. _@ewingrj: https://github.com/ewingrj

--- a/anymail/webhooks/postmark.py
+++ b/anymail/webhooks/postmark.py
@@ -103,7 +103,7 @@ class PostmarkTrackingWebhookView(PostmarkBaseWebhookView):
             except KeyError:
                 pass
         if event_type == EventType.UNSUBSCRIBED:
-            if esp_event["SuppressSending"]:
+            if esp_event.get("SuppressSending", True):
                 # Postmark doesn't provide a way to distinguish between
                 # explicit unsubscribes and bounces
                 try:


### PR DESCRIPTION
Avoid KeyError for bounce/unsubscribe payload.

Fixes #447