### PR TITLE
Django 6.1 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,18 @@ Other
 
 * Test against prerelease versions of Django 6.1.
 
+Deprecations
+~~~~~~~~~~~~
+
+* Support for ``fail_silently`` in Anymail's email backends is being phased out,
+  matching Django's deprecation of the feature. Anymail will issue a deprecation
+  warning when ``fail_silently`` is used. Support for it will be dropped in a
+  future release when Django 6.2 support is discontinued.
+
+  See `Replacing fail_silently
+  <https://docs.djangoproject.com/en/6.1/howto/mailers-migration/#migrating-to-mailers-fail-silently>`_
+  in Django's documentation for recommendations.
+
 
 v15.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,17 @@ Release history
 ^^^^^^^^^^^^^^^
     ..  This extra heading level keeps the ToC from becoming unmanageably long
 
+vNext
+-----
+
+*Unreleased changes*
+
+Other
+~~~~~
+
+* Test against prerelease versions of Django 6.1.
+
+
 v15.0
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,12 @@ vNext
 
 *Unreleased changes*
 
+Fixes
+~~~~~
+
+* **Amazon SES, Brevo:** Fix ``InvalidMailer`` error about "Unknown options"
+  when used with Django 6.1 ``MAILERS`` setting.
+
 Other
 ~~~~~
 

--- a/anymail/backends/amazon_ses.py
+++ b/anymail/backends/amazon_ses.py
@@ -33,7 +33,6 @@ class EmailBackend(AnymailBaseBackend):
 
     def __init__(self, **kwargs):
         """Init options from Django settings"""
-        super().__init__(**kwargs)
         # AMAZON_SES_CLIENT_PARAMS is optional
         # (boto3 can find credentials several other ways)
         self.session_params, self.client_params = _get_anymail_boto3_params(
@@ -53,7 +52,7 @@ class EmailBackend(AnymailBaseBackend):
             allow_bare=False,
             default=None,
         )
-
+        super().__init__(**kwargs)
         self.client = None
 
     def open(self):

--- a/anymail/backends/base.py
+++ b/anymail/backends/base.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from datetime import date, datetime, timezone
 
 from django.core.mail.backends.base import BaseEmailBackend
@@ -89,6 +90,11 @@ class AnymailBaseBackend(BaseEmailBackend):
                     raise AnymailConfigurationError(msg) from error
 
         super().__init__(**kwargs)
+        if fail_silently:
+            warnings.warn(
+                "Anymail will drop support for fail_silently after Django 6.2.",
+                DeprecationWarning,
+            )
         self.fail_silently = fail_silently
 
     def open(self):

--- a/anymail/backends/base.py
+++ b/anymail/backends/base.py
@@ -11,6 +11,7 @@ from ..exceptions import (
     AnymailConfigurationError,
     AnymailError,
     AnymailInvalidAddress,
+    AnymailInvalidMailer,
     AnymailRecipientsRefused,
     AnymailSerializationError,
     AnymailUnsupportedFeature,
@@ -42,9 +43,7 @@ class AnymailBaseBackend(BaseEmailBackend):
     Base Anymail email backend
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
+    def __init__(self, fail_silently=False, **kwargs):
         self.ignore_unsupported_features = get_anymail_setting(
             "ignore_unsupported_features", kwargs=kwargs, default=False
         )
@@ -83,9 +82,14 @@ class AnymailBaseBackend(BaseEmailBackend):
                 )
                 self._idna_encoder = import_string(dotted_path)
             except (ImportError, TypeError) as error:
-                raise AnymailConfigurationError(
-                    f"cannot resolve IDNA_ENCODER={self.idna_encoder!r}"
-                ) from error
+                msg = f"Cannot resolve IDNA_ENCODER={self.idna_encoder!r}"
+                if "alias" in kwargs:
+                    raise AnymailInvalidMailer(msg, alias=kwargs["alias"]) from error
+                else:
+                    raise AnymailConfigurationError(msg) from error
+
+        super().__init__(**kwargs)
+        self.fail_silently = fail_silently
 
     def open(self):
         """

--- a/anymail/backends/base_requests.py
+++ b/anymail/backends/base_requests.py
@@ -17,8 +17,9 @@ class AnymailRequestsBackend(AnymailBaseBackend):
     def __init__(self, api_url, **kwargs):
         """Init options from Django settings"""
         self.api_url = api_url
-        self.timeout = get_anymail_setting(
-            "requests_timeout", kwargs=kwargs, default=30
+        self.timeout = kwargs.pop(
+            "timeout",
+            get_anymail_setting("requests_timeout", kwargs=kwargs, default=30),
         )
         super().__init__(**kwargs)
         self.session = None

--- a/anymail/backends/brevo.py
+++ b/anymail/backends/brevo.py
@@ -30,7 +30,6 @@ class EmailBackend(AnymailRequestsBackend):
         )
         if not api_url.endswith("/"):
             api_url += "/"
-        super().__init__(api_url, **kwargs)
 
         # Undocumented setting to control workaround for Brevo display-name bug.
         # If/when Brevo improves their API, you can disable Anymail's workaround
@@ -55,6 +54,8 @@ class EmailBackend(AnymailRequestsBackend):
             kwargs=kwargs,
             default=True,
         )
+
+        super().__init__(api_url, **kwargs)
 
     def build_message_payload(self, message, defaults):
         return BrevoPayload(message, defaults, self)

--- a/anymail/checks.py
+++ b/anymail/checks.py
@@ -1,7 +1,34 @@
+import warnings
+
 from django.conf import settings
 from django.core import checks
 
 from anymail.utils import get_anymail_setting
+
+
+def get_configured_email_backends():
+    try:
+        mailers = settings.MAILERS
+    except AttributeError:
+        # Django < 6.1, or < 7.0 and using deprecated email settings.
+        pass
+    else:
+        return {
+            config.get("BACKEND", "django.core.mail.backends.smtp.EmailBackend")
+            for config in mailers.values()
+        }
+
+    try:
+        from django.utils.deprecation import RemovedInDjango70Warning
+    except ImportError:
+        # Django < 6.1
+        return {settings.EMAIL_BACKEND}
+    else:
+        # Django 6.1 -- 6.2: ignore warning on deprecated setting access
+        with warnings.catch_warnings(
+            action="ignore", category=RemovedInDjango70Warning
+        ):
+            return {settings.EMAIL_BACKEND}
 
 
 def check_deprecated_settings(app_configs, **kwargs):
@@ -31,9 +58,9 @@ def check_deprecated_settings(app_configs, **kwargs):
             )
         )
 
-    if (
-        getattr(settings, "EMAIL_BACKEND", "")
-        == "anymail.backends.sendgrid.EmailBackend"
+    if any(
+        backend == "anymail.backends.sendgrid.EmailBackend"
+        for backend in get_configured_email_backends()
     ):
         errors.append(
             checks.Warning(

--- a/anymail/exceptions.py
+++ b/anymail/exceptions.py
@@ -4,6 +4,14 @@ from traceback import format_exception_only
 from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from requests import HTTPError
 
+try:
+    from django.core.mail import InvalidMailer
+except ImportError:
+    # Django < 6.1
+    class InvalidMailer(ImproperlyConfigured):
+        def __init__(self, *args, alias=None):
+            super().__init__(*args)
+
 
 class AnymailError(Exception):
     """Base class for exceptions raised by Anymail
@@ -166,6 +174,10 @@ class AnymailConfigurationError(ImproperlyConfigured):
 
     # This deliberately doesn't inherit from AnymailError,
     # because we don't want it to be swallowed by backend fail_silently
+
+
+class AnymailInvalidMailer(AnymailConfigurationError, InvalidMailer):
+    """Exception for invalid MAILERS configuration"""
 
 
 class AnymailImproperlyInstalled(AnymailConfigurationError, ImportError):

--- a/anymail/utils.py
+++ b/anymail/utils.py
@@ -26,7 +26,11 @@ except ImportError:
     # Django >= 7.0
     MIMEMixin = None
 
-from .exceptions import AnymailConfigurationError, AnymailInvalidAddress
+from .exceptions import (
+    AnymailConfigurationError,
+    AnymailInvalidAddress,
+    AnymailInvalidMailer,
+)
 
 BASIC_NUMERIC_TYPES = (int, float)
 
@@ -639,13 +643,18 @@ def get_anymail_setting(
                 except AttributeError:
                     pass
             if default is UNSET:
-                message = (
-                    f"You must set {anymail_setting} or ANYMAIL = {{'{setting}': ...}}"
-                )
+                if "alias" in kwargs:
+                    # When initializing from MAILERS, don't bother listing
+                    # other settings options.
+                    raise AnymailInvalidMailer(
+                        f"OPTIONS must define '{name}'", alias=kwargs["alias"]
+                    ) from None
 
-                if allow_bare:
-                    message += f" or {setting}"
-                message += " in your Django settings"
+                or_bare_setting = f" or {setting}" if allow_bare else ""
+                message = (
+                    f"You must set ANYMAIL = {{'{setting}': ...}} or {anymail_setting}"
+                    f"{or_bare_setting} in your Django settings"
+                )
                 raise AnymailConfigurationError(message) from None
             else:
                 return default

--- a/anymail/webhooks/mandrill.py
+++ b/anymail/webhooks/mandrill.py
@@ -54,7 +54,9 @@ class MandrillSignatureMixin(AnymailCoreWebhookView):
         if self.webhook_key is None:
             # issue deferred "missing setting" error
             # (re-call get-setting without a default)
-            get_anymail_setting("webhook_key", esp_name=self.esp_name, allow_bare=True)
+            get_anymail_setting(
+                "webhook_key", esp_name=self.esp_name, allow_bare=True, kwargs={}
+            )
 
         try:
             signature = request.META["HTTP_X_MANDRILL_SIGNATURE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ path = "anymail/_version.py"
 
 [tool.black]
 force-exclude = '^/tests/test_settings/settings_.*\.py'
-target-version = ["py38"]
+target-version = ["py310"]
 
 [tool.doc8]
 # for now, Anymail allows longer lines in docs source:
@@ -147,4 +147,4 @@ max-line-length = 120
 combine_as_imports = true
 known_first_party = "anymail"
 profile = "black"
-py_version = "38"
+py_version = "310"

--- a/runtests.py
+++ b/runtests.py
@@ -11,6 +11,10 @@ from pathlib import Path
 import django
 from django.conf import settings
 from django.test.utils import get_runner
+from django.utils.deprecation import (
+    RemovedAfterNextVersionWarning,
+    RemovedInNextVersionWarning,
+)
 
 
 def find_test_settings():
@@ -66,8 +70,12 @@ def setup_and_run_tests(test_labels=None):
     if exclude_tags:
         print("Excluding tests tagged: %r" % exclude_tags)
 
-    # show DeprecationWarning and other default-ignored warnings:
-    warnings.simplefilter("default")
+    if not sys.warnoptions:
+        # Print all warnings
+        warnings.simplefilter("default")
+        # Error on Django deprecations
+        warnings.simplefilter("error", RemovedInNextVersionWarning)
+        warnings.simplefilter("error", RemovedAfterNextVersionWarning)
 
     settings_module = find_test_settings()
     print(f"Using settings module {settings_module!r}.")

--- a/tests/mock_requests_backend.py
+++ b/tests/mock_requests_backend.py
@@ -4,11 +4,12 @@ from unittest.mock import patch
 
 import requests
 from django.core import mail
+from django.core.mail import EmailMessage
 from django.test import SimpleTestCase
 
 from anymail.exceptions import AnymailAPIError
 
-from .utils import AnymailTestMixin
+from .utils import AnymailTestMixin, get_default_mailer, ignore_fail_silently_warning
 
 UNSET = object()
 
@@ -232,25 +233,31 @@ class SessionSharingTestCases(RequestsBackendMockAPITestCase):
         self.assertEqual(self.mock_close.call_count, 1)
 
     def test_caller_managed_connections(self):
-        """Calling code can created long-lived connection that it opens and closes"""
-        connection = mail.get_connection()
+        """Calling code can create long-lived connection that it opens and closes"""
+        connection = get_default_mailer()
         connection.open()
-        mail.send_mail(
-            "Subject 1",
-            "body",
-            "from@example.com",
-            ["to@example.com"],
-            connection=connection,
+        connection.send_messages(
+            [
+                EmailMessage(
+                    "Subject 1",
+                    "body",
+                    "from@example.com",
+                    ["to@example.com"],
+                )
+            ]
         )
         session1 = self.mock_request.call_args[0]
         self.assertEqual(self.mock_close.call_count, 0)  # shouldn't be closed yet
 
-        mail.send_mail(
-            "Subject 2",
-            "body",
-            "from@example.com",
-            ["to@example.com"],
-            connection=connection,
+        connection.send_messages(
+            [
+                EmailMessage(
+                    "Subject 2",
+                    "body",
+                    "from@example.com",
+                    ["to@example.com"],
+                )
+            ]
         )
         self.assertEqual(self.mock_close.call_count, 0)  # still shouldn't be closed
         session2 = self.mock_request.call_args[0]
@@ -265,6 +272,7 @@ class SessionSharingTestCases(RequestsBackendMockAPITestCase):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
         self.assertEqual(self.mock_close.call_count, 1)
 
+    @ignore_fail_silently_warning()
     def test_session_closed_after_fail_silently_exception(self):
         self.set_mock_response(status_code=500)
         sent = mail.send_mail(
@@ -278,16 +286,19 @@ class SessionSharingTestCases(RequestsBackendMockAPITestCase):
         self.assertEqual(self.mock_close.call_count, 1)
 
     def test_caller_managed_session_closed_after_exception(self):
-        connection = mail.get_connection()
+        connection = get_default_mailer()
         connection.open()
         self.set_mock_response(status_code=500)
         with self.assertRaises(AnymailAPIError):
-            mail.send_mail(
-                "Subject",
-                "Message",
-                "from@example.com",
-                ["to@example.com"],
-                connection=connection,
+            connection.send_messages(
+                [
+                    EmailMessage(
+                        "Subject",
+                        "Message",
+                        "from@example.com",
+                        ["to@example.com"],
+                    )
+                ]
             )
         self.assertEqual(self.mock_close.call_count, 0)  # wait for us to close it
 

--- a/tests/test_amazon_ses_backend.py
+++ b/tests/test_amazon_ses_backend.py
@@ -7,18 +7,27 @@ from unittest.mock import ANY, patch
 
 import django
 from django.core import mail
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail import __version__ as ANYMAIL_VERSION
 from anymail.exceptions import AnymailAPIError, AnymailUnsupportedFeature
 from anymail.inbound import AnymailInboundMessage
 from anymail.message import AnymailMessage, attach_inline_image
 
-from .utils import AnymailTestMixin, create_text_attachment, sample_image_content
+from .utils import (
+    AnymailTestMixin,
+    create_text_attachment,
+    ignore_connection_warnings,
+    ignore_fail_silently_warning,
+    override_settings,
+    sample_image_content,
+)
 
 
 @tag("amazon_ses")
-@override_settings(EMAIL_BACKEND="anymail.backends.amazon_ses.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.amazon_ses.EmailBackend"}}
+)
 class AmazonSESBackendMockAPITestCase(AnymailTestMixin, SimpleTestCase):
     """TestCase that uses the Amazon SES EmailBackend with a mocked boto3 client"""
 
@@ -137,7 +146,6 @@ class AmazonSESBackendStandardEmailTests(AmazonSESBackendMockAPITestCase):
             "Here is the message.",
             "from@example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         params = self.get_send_params()
         # send_email takes a fully-formatted MIME message.
@@ -403,6 +411,7 @@ class AmazonSESBackendStandardEmailTests(AmazonSESBackendMockAPITestCase):
         # Raw AWS response is available on the exception:
         self.assertEqual(err.response, error_response)
 
+    @ignore_fail_silently_warning()
     def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
         self.set_mock_failure(
@@ -417,6 +426,7 @@ class AmazonSESBackendStandardEmailTests(AmazonSESBackendMockAPITestCase):
         sent = self.message.send(fail_silently=True)
         self.assertEqual(sent, 0)
 
+    @ignore_fail_silently_warning()
     def test_session_failure_fail_silently(self):
         # Make sure fail_silently is respected if boto3.Session creation fails
         # (e.g., due to invalid or missing credentials)
@@ -525,7 +535,14 @@ class AmazonSESBackendAnymailFeatureTests(AmazonSESBackendMockAPITestCase):
         params = self.get_send_params()
         self.assertNotIn("Tags", params)
 
-    @override_settings(ANYMAIL_AMAZON_SES_MESSAGE_TAG_NAME="Campaign")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.amazon_ses.EmailBackend",
+                "OPTIONS": {"message_tag_name": "Campaign"},
+            }
+        }
+    )
     def test_amazon_message_tags(self):
         """
         The Anymail AMAZON_SES_MESSAGE_TAG_NAME setting enables a single Message Tag
@@ -785,8 +802,13 @@ class AmazonSESBackendAnymailFeatureTests(AmazonSESBackendMockAPITestCase):
         self.assertIn("ReplacementHeaders", params["BulkEmailEntries"][1])
 
     @override_settings(
-        # This will pass DefaultEmailTags: Name "Campaign"
-        ANYMAIL_AMAZON_SES_MESSAGE_TAG_NAME="Campaign"
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.amazon_ses.EmailBackend",
+                # This will pass DefaultEmailTags: Name "Campaign"
+                "OPTIONS": {"message_tag_name": "Campaign"},
+            }
+        }
     )
     def test_template_default_email_tag(self):
         raw_response = {
@@ -986,25 +1008,29 @@ class AmazonSESBackendConfigurationTests(AmazonSESBackendMockAPITestCase):
         )
 
     @override_settings(
-        ANYMAIL={
-            "AMAZON_SES_CLIENT_PARAMS": {
-                # Example for testing; it's not a good idea to hardcode credentials in
-                # your code. Safer: `os.getenv("MY_SPECIAL_AWS_KEY_ID")` etc.
-                "aws_access_key_id": "test-access-key-id",
-                "aws_secret_access_key": "test-secret-access-key",
-                "region_name": "ap-northeast-1",
-                # config can be given as dict of botocore.config.Config params
-                "config": {
-                    "read_timeout": 30,
-                    "retries": {"max_attempts": 2},
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.amazon_ses.EmailBackend",
+                "OPTIONS": {
+                    "client_params": {
+                        # Example for testing; it's not a good idea to hardcode credentials in
+                        # your code. Safer: `os.getenv("MY_SPECIAL_AWS_KEY_ID")` etc.
+                        "aws_access_key_id": "test-access-key-id",
+                        "aws_secret_access_key": "test-secret-access-key",
+                        "region_name": "ap-northeast-1",
+                        # config can be given as dict of botocore.config.Config params
+                        "config": {
+                            "read_timeout": 30,
+                            "retries": {"max_attempts": 2},
+                        },
+                    }
                 },
             }
         }
     )
     def test_client_params_in_setting(self):
         """
-        The Anymail AMAZON_SES_CLIENT_PARAMS setting specifies
-        boto3 session.client() params for Anymail
+        The client_params option specifies boto3 session.client() params
         """
         self.message.send()
         client_params = self.get_client_params()
@@ -1021,6 +1047,8 @@ class AmazonSESBackendConfigurationTests(AmazonSESBackendMockAPITestCase):
         self.assertEqual(config.read_timeout, 30)
         self.assertEqual(config.retries, {"max_attempts": 2})
 
+    # This case can be removed once the minimum version is Django 7.0.
+    @ignore_connection_warnings()
     def test_client_params_in_connection_init(self):
         """
         You can also supply credentials specifically
@@ -1030,7 +1058,6 @@ class AmazonSESBackendConfigurationTests(AmazonSESBackendMockAPITestCase):
 
         boto_config = Config(connect_timeout=30)
         conn = mail.get_connection(
-            "anymail.backends.amazon_ses.EmailBackend",
             client_params={
                 "aws_session_token": "test-session-token",
                 "config": boto_config,
@@ -1045,12 +1072,16 @@ class AmazonSESBackendConfigurationTests(AmazonSESBackendMockAPITestCase):
         self.assertEqual(config.connect_timeout, 30)
 
     @override_settings(
-        ANYMAIL={"AMAZON_SES_SESSION_PARAMS": {"profile_name": "anymail-testing"}}
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.amazon_ses.EmailBackend",
+                "OPTIONS": {"session_params": {"profile_name": "anymail-testing"}},
+            }
+        }
     )
     def test_session_params_in_setting(self):
         """
-        The Anymail AMAZON_SES_SESSION_PARAMS setting
-        specifies boto3.session.Session() params for Anymail
+        The session_params option specifies boto3 session.Session() params
         """
         self.message.send()
 
@@ -1064,7 +1095,12 @@ class AmazonSESBackendConfigurationTests(AmazonSESBackendMockAPITestCase):
         self.assertEqual(client_params, {})
 
     @override_settings(
-        ANYMAIL={"AMAZON_SES_CONFIGURATION_SET_NAME": "MyConfigurationSet"}
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.amazon_ses.EmailBackend",
+                "OPTIONS": {"configuration_set_name": "MyConfigurationSet"},
+            }
+        }
     )
     def test_config_set_setting(self):
         """You can supply a default ConfigurationSetName"""

--- a/tests/test_amazon_ses_integration.py
+++ b/tests/test_amazon_ses_integration.py
@@ -2,12 +2,12 @@ import os
 import unittest
 from email.utils import formataddr
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin, sample_image_path
+from .utils import AnymailTestMixin, override_settings, sample_image_path
 
 ANYMAIL_TEST_AMAZON_SES_ACCESS_KEY_ID = os.getenv(
     "ANYMAIL_TEST_AMAZON_SES_ACCESS_KEY_ID"
@@ -30,21 +30,25 @@ ANYMAIL_TEST_AMAZON_SES_DOMAIN = os.getenv("ANYMAIL_TEST_AMAZON_SES_DOMAIN")
     " environment variables to run Amazon SES integration tests",
 )
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.amazon_ses.EmailBackend",
-    ANYMAIL={
-        "AMAZON_SES_CLIENT_PARAMS": {
-            # This setting provides Anymail-specific AWS credentials to boto3.client(),
-            # overriding any credentials in the environment or boto config. It's often
-            # *not* the best approach. See the Anymail and boto3 docs for other options.
-            "aws_access_key_id": ANYMAIL_TEST_AMAZON_SES_ACCESS_KEY_ID,
-            "aws_secret_access_key": ANYMAIL_TEST_AMAZON_SES_SECRET_ACCESS_KEY,
-            "region_name": ANYMAIL_TEST_AMAZON_SES_REGION_NAME,
-            # Can supply any other boto3.client params,
-            # including botocore.config.Config as dict
-            "config": {"retries": {"max_attempts": 2}},
-        },
-        # actual config set in Anymail test account:
-        "AMAZON_SES_CONFIGURATION_SET_NAME": "TestConfigurationSet",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.amazon_ses.EmailBackend",
+            "OPTIONS": {
+                "client_params": {
+                    # This option provides Anymail-specific AWS credentials to boto3.client(),
+                    # overriding any credentials in the environment or boto config. It's often
+                    # *not* the best approach. See the Anymail and boto3 docs for other options.
+                    "aws_access_key_id": ANYMAIL_TEST_AMAZON_SES_ACCESS_KEY_ID,
+                    "aws_secret_access_key": ANYMAIL_TEST_AMAZON_SES_SECRET_ACCESS_KEY,
+                    "region_name": ANYMAIL_TEST_AMAZON_SES_REGION_NAME,
+                    # Can supply any other boto3.client params,
+                    # including botocore.config.Config as dict
+                    "config": {"retries": {"max_attempts": 2}},
+                },
+                # actual config set in Anymail test account:
+                "configuration_set_name": "TestConfigurationSet",
+            },
+        }
     },
 )
 @tag("amazon_ses", "live")
@@ -197,11 +201,16 @@ class AmazonSESBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         )
 
     @override_settings(
-        ANYMAIL={
-            "AMAZON_SES_CLIENT_PARAMS": {
-                "aws_access_key_id": "test-invalid-access-key-id",
-                "aws_secret_access_key": "test-invalid-secret-access-key",
-                "region_name": ANYMAIL_TEST_AMAZON_SES_REGION_NAME,
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.amazon_ses.EmailBackend",
+                "OPTIONS": {
+                    "client_params": {
+                        "aws_access_key_id": "test-invalid-access-key-id",
+                        "aws_secret_access_key": "test-invalid-secret-access-key",
+                        "region_name": ANYMAIL_TEST_AMAZON_SES_REGION_NAME,
+                    }
+                },
             }
         }
     )

--- a/tests/test_base_backends.py
+++ b/tests/test_base_backends.py
@@ -1,12 +1,13 @@
-from unittest import mock
+from unittest import mock, skipIf
 
-from django.test import SimpleTestCase, override_settings, tag
+import django.core.mail
+from django.test import SimpleTestCase, tag
 
 from anymail.backends.base_requests import AnymailRequestsBackend, RequestsPayload
 from anymail.message import AnymailMessage, AnymailRecipientStatus
-from tests.utils import AnymailTestMixin
 
 from .mock_requests_backend import RequestsBackendMockAPITestCase
+from .utils import AnymailTestMixin, ignore_fail_silently_warning, override_settings
 
 
 class MinimalRequestsBackend(AnymailRequestsBackend):
@@ -43,7 +44,9 @@ class MinimalRequestsPayload(RequestsPayload):
     add_attachment = _noop
 
 
-@override_settings(EMAIL_BACKEND="tests.test_base_backends.MinimalRequestsBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "tests.test_base_backends.MinimalRequestsBackend"}}
+)
 class RequestsBackendBaseTestCase(RequestsBackendMockAPITestCase):
     """Test common functionality in AnymailRequestsBackend"""
 
@@ -71,6 +74,22 @@ class RequestsBackendBaseTestCase(RequestsBackendMockAPITestCase):
         timeout = self.get_api_call_arg("timeout")
         self.assertEqual(timeout, 5)
 
+    @skipIf(not hasattr(django.core.mail, "mailers"), "timeout is MAILERS OPTIONS only")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "tests.test_base_backends.MinimalRequestsBackend",
+                "OPTIONS": {"timeout": 5},
+            }
+        }
+    )
+    def test_timeout_option(self):
+        """You can use the timeout option to override the default"""
+        self.message.send()
+        timeout = self.get_api_call_arg("timeout")
+        self.assertEqual(timeout, 5)
+
+    @ignore_fail_silently_warning()
     @mock.patch(f"{__name__}.MinimalRequestsBackend.create_session")
     def test_create_session_error_fail_silently(self, mock_create_session):
         # If create_session fails and fail_silently is True,
@@ -81,7 +100,9 @@ class RequestsBackendBaseTestCase(RequestsBackendMockAPITestCase):
 
 
 @tag("live")
-@override_settings(EMAIL_BACKEND="tests.test_base_backends.MinimalRequestsBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "tests.test_base_backends.MinimalRequestsBackend"}},
+)
 class RequestsBackendLiveTestCase(AnymailTestMixin, SimpleTestCase):
     @override_settings(ANYMAIL_DEBUG_API_REQUESTS=True)
     def test_debug_logging(self):

--- a/tests/test_base_backends.py
+++ b/tests/test_base_backends.py
@@ -95,7 +95,11 @@ class RequestsBackendBaseTestCase(RequestsBackendMockAPITestCase):
         # If create_session fails and fail_silently is True,
         # make sure _send doesn't raise a misleading error.
         mock_create_session.side_effect = ValueError("couldn't create session")
-        sent = self.message.send(fail_silently=True)
+        with self.assertWarnsMessage(
+            DeprecationWarning,
+            "Anymail will drop support for fail_silently after Django 6.2.",
+        ):
+            sent = self.message.send(fail_silently=True)
         self.assertEqual(sent, 0)
 
 

--- a/tests/test_brevo_backend.py
+++ b/tests/test_brevo_backend.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timezone
 from decimal import Decimal
 
 from django.core import mail
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 from django.utils.timezone import (
     get_fixed_timezone,
     override as override_current_timezone,
@@ -25,14 +25,20 @@ from .utils import (
     AnymailTestMixin,
     create_text_attachment,
     decode_att,
+    ignore_fail_silently_warning,
+    override_settings,
     sample_image_content,
 )
 
 
 @tag("brevo")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.brevo.EmailBackend",
-    ANYMAIL={"BREVO_API_KEY": "test_api_key"},
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.brevo.EmailBackend",
+            "OPTIONS": {"api_key": "test_api_key"},
+        }
+    }
 )
 class BrevoBackendMockAPITestCase(RequestsBackendMockAPITestCase):
     DEFAULT_RAW_RESPONSE = (
@@ -59,7 +65,6 @@ class BrevoBackendStandardEmailTests(BrevoBackendMockAPITestCase):
             "Here is the message.",
             "from@sender.example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         self.assert_esp_called("https://api.brevo.com/v3/smtp/email")
         http_headers = self.get_api_call_headers()
@@ -360,6 +365,8 @@ class BrevoBackendStandardEmailTests(BrevoBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailAPIError, "Brevo API response 400"):
             mail.send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
 
+    @ignore_fail_silently_warning()
+    def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
         self.set_mock_response(status_code=400)
         sent = mail.send_mail(
@@ -721,6 +728,7 @@ class BrevoBackendAnymailFeatureTests(BrevoBackendMockAPITestCase):
         )
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=500)
@@ -765,10 +773,15 @@ class BrevoBackendSessionSharingTestCase(
 
 
 @tag("brevo")
-@override_settings(EMAIL_BACKEND="anymail.backends.brevo.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.brevo.EmailBackend"}}
+)
 class BrevoBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
     """Test ESP backend without required settings in place"""
 
     def test_missing_auth(self):
-        with self.assertRaisesRegex(AnymailConfigurationError, r"\bBREVO_API_KEY\b"):
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'api_key'|\bBREVO_API_KEY.*ANYMAIL_BREVO_API_KEY",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])

--- a/tests/test_brevo_integration.py
+++ b/tests/test_brevo_integration.py
@@ -3,12 +3,12 @@ import unittest
 from datetime import datetime, timedelta
 from email.utils import formataddr
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin
+from .utils import AnymailTestMixin, override_settings
 
 ANYMAIL_TEST_BREVO_API_KEY = os.getenv("ANYMAIL_TEST_BREVO_API_KEY")
 ANYMAIL_TEST_BREVO_DOMAIN = os.getenv("ANYMAIL_TEST_BREVO_DOMAIN")
@@ -21,9 +21,14 @@ ANYMAIL_TEST_BREVO_DOMAIN = os.getenv("ANYMAIL_TEST_BREVO_DOMAIN")
     "environment variables to run Brevo integration tests",
 )
 @override_settings(
-    ANYMAIL_BREVO_API_KEY=ANYMAIL_TEST_BREVO_API_KEY,
-    ANYMAIL_BREVO_SEND_DEFAULTS=dict(),
-    EMAIL_BACKEND="anymail.backends.brevo.EmailBackend",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.brevo.EmailBackend",
+            "OPTIONS": {
+                "api_key": ANYMAIL_TEST_BREVO_API_KEY,
+            },
+        },
+    },
 )
 class BrevoBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """Brevo v3 API integration tests
@@ -147,7 +152,16 @@ class BrevoBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             recipient_status["test+to2@anymail.dev"].message_id,
         )
 
-    @override_settings(ANYMAIL_BREVO_API_KEY="Hey, that's not an API key!")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.brevo.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "Hey, that's not an API key!",
+                },
+            },
+        },
+    )
     def test_invalid_api_key(self):
         with self.assertRaises(AnymailAPIError) as cm:
             self.message.send()

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,10 +1,9 @@
 from django.core import checks
 from django.test import SimpleTestCase
-from django.test.utils import override_settings
 
 from anymail.checks import check_deprecated_settings, check_insecure_settings
 
-from .utils import AnymailTestMixin
+from .utils import AnymailTestMixin, override_settings
 
 
 class DeprecatedSettingsTests(AnymailTestMixin, SimpleTestCase):
@@ -38,7 +37,9 @@ class DeprecatedSettingsTests(AnymailTestMixin, SimpleTestCase):
             ],
         )
 
-    @override_settings(EMAIL_BACKEND="anymail.backends.sendgrid.EmailBackend")
+    @override_settings(
+        MAILERS={"default": {"BACKEND": "anymail.backends.sendgrid.EmailBackend"}}
+    )
     def test_sendgrid_unsupported(self):
         errors = check_deprecated_settings(None)
         self.assertEqual(

--- a/tests/test_general_backend.py
+++ b/tests/test_general_backend.py
@@ -2,10 +2,7 @@ import unittest
 from datetime import datetime, timezone
 
 from django.core import mail
-from django.core.exceptions import ImproperlyConfigured
-from django.core.mail import get_connection, send_mail
 from django.test import SimpleTestCase
-from django.test.utils import override_settings
 from django.utils.functional import Promise
 from django.utils.translation import gettext_lazy
 
@@ -14,12 +11,18 @@ from anymail.exceptions import (
     AnymailConfigurationError,
     AnymailError,
     AnymailInvalidAddress,
+    AnymailInvalidMailer,
     AnymailUnsupportedFeature,
 )
 from anymail.message import AnymailMessage
 from anymail.utils import EmailAddress, get_anymail_setting
 
-from .utils import AnymailTestMixin
+from .utils import (
+    AnymailTestMixin,
+    get_default_mailer,
+    ignore_connection_warnings,
+    override_settings,
+)
 
 
 def uts46_installed():
@@ -48,7 +51,9 @@ class SettingsTestBackend(TestBackend):
         super().__init__(*args, **kwargs)
 
 
-@override_settings(EMAIL_BACKEND="anymail.backends.test.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.test.EmailBackend"}}
+)
 class TestBackendTestCase(AnymailTestMixin, SimpleTestCase):
     """Base TestCase using Anymail's Test EmailBackend"""
 
@@ -85,40 +90,69 @@ class TestBackendTestCase(AnymailTestMixin, SimpleTestCase):
             )
 
 
-@override_settings(EMAIL_BACKEND="tests.test_general_backend.SettingsTestBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "tests.test_general_backend.SettingsTestBackend"}}
+)
 class BackendSettingsTests(TestBackendTestCase):
     """Test settings initializations for Anymail EmailBackends"""
+
+    @unittest.skipUnless(
+        hasattr(mail, "mailers"), "MAILERS not supported in Django < 6.1"
+    )
+    def test_mailers_options(self):
+        # Note that self.settings() does not convert MAILERS to EMAIL_BACKEND
+        # on older Django versions (like our custom override_settings() does).
+        with self.settings(
+            ANYMAIL={"TEST_SAMPLE_SETTING": "setting_from_anymail_settings"},
+            MAILERS={
+                "default": {
+                    "BACKEND": "tests.test_general_backend.SettingsTestBackend",
+                    "OPTIONS": {"sample_setting": "setting_from_mailers_options"},
+                }
+            },
+        ):
+            backend = get_default_mailer()
+            self.assertEqual(backend.sample_setting, "setting_from_mailers_options")
+
+    @unittest.skipUnless(
+        hasattr(mail, "mailers"), "MAILERS not supported in Django < 6.1"
+    )
+    def test_missing_mailers_options(self):
+        with self.assertRaisesMessage(
+            AnymailInvalidMailer,
+            "MAILERS['default']: OPTIONS must define 'sample_setting'",
+        ):
+            get_default_mailer()
 
     @override_settings(ANYMAIL={"TEST_SAMPLE_SETTING": "setting_from_anymail_settings"})
     def test_anymail_setting(self):
         """ESP settings usually come from ANYMAIL settings dict"""
-        backend = get_connection()
+        backend = get_default_mailer()
         self.assertEqual(backend.sample_setting, "setting_from_anymail_settings")
 
     @override_settings(TEST_SAMPLE_SETTING="setting_from_bare_settings")
     def test_bare_setting(self):
         """ESP settings are also usually allowed at root of settings file"""
-        backend = get_connection()
+        backend = get_default_mailer()
         self.assertEqual(backend.sample_setting, "setting_from_bare_settings")
 
+    # This case can be removed once the minimum supported version is Django 7.0.
     @override_settings(ANYMAIL={"TEST_SAMPLE_SETTING": "setting_from_settings"})
+    @ignore_connection_warnings()
     def test_connection_kwargs_overrides_settings(self):
         """Can override settings file in get_connection"""
-        backend = get_connection()
-        self.assertEqual(backend.sample_setting, "setting_from_settings")
-
-        backend = get_connection(sample_setting="setting_from_kwargs")
+        backend = mail.get_connection(sample_setting="setting_from_kwargs")
         self.assertEqual(backend.sample_setting, "setting_from_kwargs")
 
     def test_missing_setting(self):
         """Settings without defaults must be provided"""
-        with self.assertRaises(AnymailConfigurationError) as cm:
-            get_connection()
-        self.assertIsInstance(cm.exception, ImproperlyConfigured)  # Django consistency
-        errmsg = str(cm.exception)
-        self.assertRegex(errmsg, r"\bTEST_SAMPLE_SETTING\b")
-        self.assertRegex(errmsg, r"\bANYMAIL_TEST_SAMPLE_SETTING\b")
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'sample_setting'|\bTEST_SAMPLE_SETTING.*ANYMAIL_TEST_SAMPLE_SETTING",
+        ):
+            get_default_mailer()
 
+    # This case can be removed once the minimum version is Django 7.0.
     @override_settings(
         ANYMAIL={
             "TEST_USERNAME": "username_from_settings",
@@ -126,14 +160,15 @@ class BackendSettingsTests(TestBackendTestCase):
             "TEST_SAMPLE_SETTING": "required",
         }
     )
+    @ignore_connection_warnings()
     def test_username_password_kwargs_overrides(self):
         """Overrides for 'username' and 'password' should work like other overrides"""
-        # These are special-cased because of default args in Django core mail functions.
-        backend = get_connection()
+        # These are special-cased because of default args in mail.get_connection().
+        backend = mail.get_connection()
         self.assertEqual(backend.username, "username_from_settings")
         self.assertEqual(backend.password, "password_from_settings")
 
-        backend = get_connection(
+        backend = mail.get_connection(
             username="username_from_kwargs", password="password_from_kwargs"
         )
         self.assertEqual(backend.username, "username_from_kwargs")
@@ -190,6 +225,30 @@ class SendDefaultsTests(TestBackendTestCase):
         self.assertEqual(params["globalextra"], "globalsetting")
 
     @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.test.EmailBackend",
+                "OPTIONS": {
+                    "send_defaults": {
+                        "metadata": {"global": "espvalue"},
+                        "tags": ["esptag"],
+                        "track_opens": False,
+                        "esp_extra": {"globalextra": "espsetting"},
+                    }
+                },
+            }
+        }
+    )
+    def test_esp_send_defaults(self):
+        self.message.send()
+        params = self.get_send_params()
+        self.assertEqual(params["metadata"], {"global": "espvalue"})
+        self.assertEqual(params["tags"], ["esptag"])
+        self.assertEqual(params["track_opens"], False)
+        # Test EmailBackend merges esp_extra into params:
+        self.assertEqual(params["globalextra"], "espsetting")
+
+    @override_settings(
         ANYMAIL={
             # SEND_DEFAULTS for the Test EmailBackend, because
             # "TEST" is the name of the Test EmailBackend's ESP
@@ -201,7 +260,7 @@ class SendDefaultsTests(TestBackendTestCase):
             }
         }
     )
-    def test_esp_send_defaults(self):
+    def test_esp_send_defaults_anymail_setting(self):
         """Test that esp-specific send defaults are applied"""
         self.message.send()
         params = self.get_send_params()
@@ -258,7 +317,7 @@ class SendDefaultsTests(TestBackendTestCase):
         )
 
         # Send another message to make sure original SEND_DEFAULTS unchanged
-        send_mail("subject", "body", "from@example.com", ["to@example.com"])
+        mail.send_mail("subject", "body", "from@example.com", ["to@example.com"])
         params = self.get_send_params()
         self.assertEqual(
             params["metadata"], {"global": "globalvalue", "other": "othervalue"}
@@ -671,10 +730,7 @@ class BatchSendDetectionTestCase(TestBackendTestCase):
                     self.unsupported_feature("cc with batch send")
                 super().set_cc(emails)
 
-        connection = mail.get_connection(
-            "anymail.backends.test.EmailBackend",
-            payload_class=ImproperlyImplementedPayload,
-        )
+        connection = TestBackend(payload_class=ImproperlyImplementedPayload)
         with self.assertRaisesMessage(
             AssertionError, "Cannot call is_batch before all attributes processed"
         ):
@@ -695,7 +751,7 @@ class IDNAEncoderTests(TestBackendTestCase):
 
     def test_default_encode(self):
         """Default encoder is idna2008."""
-        connection = mail.get_connection()
+        connection = get_default_mailer()
         self.assertEqual(connection.idna_encode("faß.example"), "xn--fa-hia.example")
         self.assertEqual(
             connection.idna_encode("idna2008.މިސާލު.example"),
@@ -710,7 +766,7 @@ class IDNAEncoderTests(TestBackendTestCase):
     @override_settings(ANYMAIL={"IDNA_ENCODER": "idna2003"})
     def test_idna2003_encode(self):
         """idna2003 provides strict compatibility with Django and earlier releases."""
-        connection = mail.get_connection()
+        connection = get_default_mailer()
         self.assertEqual(connection.idna_encode("faß.example"), "fass.example")
         self.assertEqual(connection.idna_encode("✉.example"), "xn--4bi.example")
         self.assertEqual(connection.idna_encode("✉ß.example"), "xn--ss-ufy.example")
@@ -724,7 +780,7 @@ class IDNAEncoderTests(TestBackendTestCase):
     @override_settings(ANYMAIL={"IDNA_ENCODER": "uts46"})
     def test_uts46_encode(self):
         """uts46 handles some domains rejected by idna2008."""
-        connection = mail.get_connection()
+        connection = get_default_mailer()
         self.assertEqual(connection.idna_encode("faß.example"), "xn--fa-hia.example")
         self.assertEqual(
             connection.idna_encode("idna2008.މިސާލު.example"),
@@ -736,7 +792,7 @@ class IDNAEncoderTests(TestBackendTestCase):
     @override_settings(ANYMAIL={"IDNA_ENCODER": "none"})
     def test_none_encode(self):
         """No encoding, for ESPs that can handle IDNA themselves."""
-        connection = mail.get_connection()
+        connection = get_default_mailer()
         self.assertEqual(
             connection.idna_encode("idna2008.މިސާލު.example"), "idna2008.މިސާލު.example"
         )
@@ -744,15 +800,17 @@ class IDNAEncoderTests(TestBackendTestCase):
     @override_settings(ANYMAIL={"IDNA_ENCODER": f"{__name__}.custom_encoder"})
     def test_custom_idna_dotted_path(self):
         """IDNA_ENCODER can be set to a dotted import path to a custom function."""
-        connection = mail.get_connection()
+        connection = get_default_mailer()
         self.assertEqual(connection.idna_encode("example.com"), "CUSTOM:example.com")
 
     @override_settings(ANYMAIL={"IDNA_ENCODER": custom_encoder})
     def test_custom_idna_callable(self):
         """IDNA_ENCODER can be set directly to a callable."""
-        connection = mail.get_connection()
+        connection = get_default_mailer()
         self.assertEqual(connection.idna_encode("example.com"), "CUSTOM:example.com")
 
+    # This case can be removed once the minimum supported version is Django 7.0.
+    @ignore_connection_warnings()
     def test_custom_idna_param(self):
         """IDNA_ENCODER can be overridden in backend initialization params."""
         connection = mail.get_connection(idna_encoder=custom_encoder)
@@ -766,5 +824,20 @@ class IDNAEncoderTests(TestBackendTestCase):
     )
     def test_esp_specific_encoder(self):
         """<ESP_NAME>_IDNA_ENCODER takes precedence over IDNA_ENCODER."""
-        connection = mail.get_connection()
+        connection = get_default_mailer()
+        self.assertEqual(connection.idna_encode("✉.example"), "xn--4bi.example")
+
+    @unittest.skipIf(not hasattr(mail, "mailers"), "MAILERS not supported")
+    @override_settings(
+        ANYMAIL={"IDNA_ENCODER": "raw"},
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.test.EmailBackend",
+                "OPTIONS": {"idna_encoder": "idna2003"},
+            }
+        },
+    )
+    def test_mailers_options_override(self):
+        """Specific mailer OPTIONS takes precedence over IDNA_ENCODER setting."""
+        connection = mail.mailers.default
         self.assertEqual(connection.idna_encode("✉.example"), "xn--4bi.example")

--- a/tests/test_mailersend_backend.py
+++ b/tests/test_mailersend_backend.py
@@ -3,7 +3,7 @@ from datetime import date, datetime
 from decimal import Decimal
 
 from django.core import mail
-from django.test import override_settings, tag
+from django.test import tag
 from django.utils.timezone import (
     get_fixed_timezone,
     override as override_current_timezone,
@@ -19,13 +19,24 @@ from anymail.exceptions import (
 from anymail.message import attach_inline_image
 
 from .mock_requests_backend import RequestsBackendMockAPITestCase
-from .utils import create_text_attachment, decode_att, sample_image_content
+from .utils import (
+    create_text_attachment,
+    decode_att,
+    ignore_connection_warnings,
+    ignore_fail_silently_warning,
+    override_settings,
+    sample_image_content,
+)
 
 
 @tag("mailersend")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.mailersend.EmailBackend",
-    ANYMAIL={"MAILERSEND_API_TOKEN": "test_api_token"},
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailersend.EmailBackend",
+            "OPTIONS": {"api_token": "test_api_token"},
+        },
+    },
 )
 class MailerSendBackendMockAPITestCase(RequestsBackendMockAPITestCase):
     """TestCase that uses MailerSend EmailBackend with a mocked API"""
@@ -82,7 +93,6 @@ class MailerSendBackendStandardEmailTests(MailerSendBackendMockAPITestCase):
             "Here is the message.",
             "from@example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
 
         self.assert_esp_called("/v1/email")
@@ -289,6 +299,7 @@ class MailerSendBackendStandardEmailTests(MailerSendBackendMockAPITestCase):
         with self.assertRaises(AnymailUnsupportedFeature):
             self.message.send()
 
+    @ignore_fail_silently_warning()
     def test_alternatives_fail_silently(self):
         # Make sure fail_silently is respected
         self.message.attach_alternative("{'not': 'allowed'}", "application/json")
@@ -323,6 +334,7 @@ class MailerSendBackendStandardEmailTests(MailerSendBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailAPIError, "Helpful ESP explanation"):
             self.message.send()
 
+    @ignore_fail_silently_warning()
     def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
         self.set_mock_response(status_code=422)
@@ -420,7 +432,17 @@ class MailerSendBackendAnymailFeatureTests(MailerSendBackendMockAPITestCase):
         # For "tags", MailerSend uses the param value if provided, otherwise
         # the template default if any. (It does not attempt to combine them.)
 
-    @override_settings(ANYMAIL_MAILERSEND_BATCH_SEND_MODE="expose-to-list")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailersend.EmailBackend",
+                "OPTIONS": {
+                    "api_token": "test_api_token",
+                    "batch_send_mode": "expose-to-list",
+                },
+            },
+        },
+    )
     def test_merge_data_expose_to_list(self):
         self.message.to = ["alice@example.com", "Bob <bob@example.com>"]
         self.message.cc = ["cc@example.com"]
@@ -457,7 +479,17 @@ class MailerSendBackendAnymailFeatureTests(MailerSendBackendMockAPITestCase):
             ],
         )
 
-    @override_settings(ANYMAIL_MAILERSEND_BATCH_SEND_MODE="use-bulk-email")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailersend.EmailBackend",
+                "OPTIONS": {
+                    "api_token": "test_api_token",
+                    "batch_send_mode": "use-bulk-email",
+                },
+            },
+        },
+    )
     def test_merge_data_use_bulk_email(self):
         self.set_mock_response(
             json_data={
@@ -700,7 +732,17 @@ class MailerSendBackendAnymailFeatureTests(MailerSendBackendMockAPITestCase):
         self.assertEqual(recipients["to2@example.com"].message_id, "12345abcde")
 
     # noinspection PyUnresolvedReferences
-    @override_settings(ANYMAIL_MAILERSEND_BATCH_SEND_MODE="use-bulk-email")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailersend.EmailBackend",
+                "OPTIONS": {
+                    "api_token": "test_api_token",
+                    "batch_send_mode": "use-bulk-email",
+                },
+            },
+        },
+    )
     def test_bulk_send_response(self):
         self.set_mock_response(
             json_data={
@@ -716,6 +758,7 @@ class MailerSendBackendAnymailFeatureTests(MailerSendBackendMockAPITestCase):
         self.assertEqual(self.message.anymail_status.message_id, "bulk:12345abcde")
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=400)
@@ -776,6 +819,7 @@ class MailerSendBackendRecipientsRefusedTests(MailerSendBackendMockAPITestCase):
         with self.assertRaises(AnymailRecipientsRefused):
             msg.send()
 
+    @ignore_fail_silently_warning()
     def test_fail_silently(self):
         self.set_mock_rejected(
             {
@@ -844,28 +888,34 @@ class MailerSendBackendConfigurationTests(MailerSendBackendMockAPITestCase):
     """Test various MailerSend client options"""
 
     @override_settings(
-        # clear MAILERSEND_API_TOKEN from MailerSendBackendMockAPITestCase:
-        ANYMAIL={}
+        MAILERS={
+            "default": {"BACKEND": "anymail.backends.mailersend.EmailBackend"},
+        },
     )
     def test_missing_api_token(self):
-        with self.assertRaises(AnymailConfigurationError) as cm:
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'api_token'|\bMAILERSEND_API_TOKEN.*ANYMAIL_MAILERSEND_API_TOKEN",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
-        errmsg = str(cm.exception)
-        # Make sure the error mentions the different places to set the key
-        self.assertRegex(errmsg, r"\bMAILERSEND_API_TOKEN\b")
-        self.assertRegex(errmsg, r"\bANYMAIL_MAILERSEND_API_TOKEN\b")
 
     @override_settings(
-        ANYMAIL={
-            "MAILERSEND_API_URL": "https://api.dev.mailersend.com/v2",
-            "MAILERSEND_API_TOKEN": "test_api_key",
-        }
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailersend.EmailBackend",
+                "OPTIONS": {
+                    "api_url": "https://api.dev.mailersend.com/v2",
+                    "api_token": "test_api_key",
+                },
+            }
+        },
     )
     def test_mailersend_api_url(self):
         mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
         self.assert_esp_called("https://api.dev.mailersend.com/v2/email")
 
-        # can also override on individual connection
+    @ignore_connection_warnings()
+    def test_mailersend_api_url_get_connection_override(self):
         connection = mail.get_connection(api_url="https://api.mailersend.com/vNext")
         mail.send_mail(
             "Subject",
@@ -876,7 +926,14 @@ class MailerSendBackendConfigurationTests(MailerSendBackendMockAPITestCase):
         )
         self.assert_esp_called("https://api.mailersend.com/vNext/email")
 
-    @override_settings(ANYMAIL={"MAILERSEND_API_TOKEN": "bad_token"})
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailersend.EmailBackend",
+                "OPTIONS": {"api_token": "bad_token"},
+            },
+        },
+    )
     def test_invalid_api_key(self):
         self.set_mock_response(
             status_code=401,

--- a/tests/test_mailersend_integration.py
+++ b/tests/test_mailersend_integration.py
@@ -3,12 +3,12 @@ import unittest
 from datetime import datetime, timedelta
 from email.utils import formataddr
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin, sample_image_path
+from .utils import AnymailTestMixin, override_settings, sample_image_path
 
 ANYMAIL_TEST_MAILERSEND_API_TOKEN = os.getenv("ANYMAIL_TEST_MAILERSEND_API_TOKEN")
 ANYMAIL_TEST_MAILERSEND_DOMAIN = os.getenv("ANYMAIL_TEST_MAILERSEND_DOMAIN")
@@ -21,10 +21,14 @@ ANYMAIL_TEST_MAILERSEND_DOMAIN = os.getenv("ANYMAIL_TEST_MAILERSEND_DOMAIN")
     " environment variables to run MailerSend integration tests",
 )
 @override_settings(
-    ANYMAIL={
-        "MAILERSEND_API_TOKEN": ANYMAIL_TEST_MAILERSEND_API_TOKEN,
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailersend.EmailBackend",
+            "OPTIONS": {
+                "api_token": ANYMAIL_TEST_MAILERSEND_API_TOKEN,
+            },
+        },
     },
-    EMAIL_BACKEND="anymail.backends.mailersend.EmailBackend",
 )
 class MailerSendBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """MailerSend API integration tests
@@ -180,9 +184,12 @@ class MailerSendBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         )
 
     @override_settings(
-        ANYMAIL={
-            "MAILERSEND_API_TOKEN": "Hey, that's not an API token",
-        }
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailersend.EmailBackend",
+                "OPTIONS": {"api_token": "Hey, that's not an API token"},
+            },
+        },
     )
     def test_invalid_api_key(self):
         with self.assertRaisesMessage(AnymailAPIError, "Unauthenticated"):

--- a/tests/test_mailgun_backend.py
+++ b/tests/test_mailgun_backend.py
@@ -4,15 +4,16 @@ from email.mime.image import MIMEImage
 
 import django
 from django.core import mail
-from django.core.exceptions import ImproperlyConfigured
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 from django.utils.timezone import (
     get_fixed_timezone,
     override as override_current_timezone,
 )
+from requests.exceptions import SSLError
 
 from anymail.exceptions import (
     AnymailAPIError,
+    AnymailConfigurationError,
     AnymailError,
     AnymailInvalidAddress,
     AnymailRequestsAPIError,
@@ -24,13 +25,23 @@ from .mock_requests_backend import (
     RequestsBackendMockAPITestCase,
     SessionSharingTestCases,
 )
-from .utils import AnymailTestMixin, create_text_attachment, sample_image_content
+from .utils import (
+    AnymailTestMixin,
+    create_text_attachment,
+    ignore_fail_silently_warning,
+    override_settings,
+    sample_image_content,
+)
 
 
 @tag("mailgun")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.mailgun.EmailBackend",
-    ANYMAIL={"MAILGUN_API_KEY": "test_api_key"},
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailgun.EmailBackend",
+            "OPTIONS": {"api_key": "test_api_key"},
+        },
+    },
 )
 class MailgunBackendMockAPITestCase(RequestsBackendMockAPITestCase):
     DEFAULT_RAW_RESPONSE = b"""{
@@ -57,7 +68,6 @@ class MailgunBackendStandardEmailTests(MailgunBackendMockAPITestCase):
             "Here is the message.",
             "from@example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         self.assert_esp_called("/example.com/messages")
         auth = self.get_api_call_auth()
@@ -286,6 +296,7 @@ class MailgunBackendStandardEmailTests(MailgunBackendMockAPITestCase):
         self.assertEqual(data["html"], "<p>HTML</p>")
         self.assertEqual(data["amp-html"], "<p>And AMP HTML</p>")
 
+    @ignore_fail_silently_warning()
     def test_alternatives_fail_silently(self):
         # Make sure fail_silently is respected
         self.message.attach_alternative("{'not': 'allowed'}", "application/json")
@@ -328,6 +339,8 @@ class MailgunBackendStandardEmailTests(MailgunBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailAPIError, "Mailgun API response 400"):
             mail.send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
 
+    @ignore_fail_silently_warning()
+    def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
         self.set_mock_response(status_code=400)
         sent = mail.send_mail(
@@ -362,7 +375,6 @@ class MailgunBackendStandardEmailTests(MailgunBackendMockAPITestCase):
     def test_requests_exception(self):
         """Exception during API call should be AnymailAPIError"""
         # (The post itself raises an error--different from returning a failure response)
-        from requests.exceptions import SSLError  # a low-level requests exception
 
         self.mock_request.side_effect = SSLError("Something bad")
         with self.assertRaisesMessage(AnymailRequestsAPIError, "Something bad") as cm:
@@ -370,6 +382,8 @@ class MailgunBackendStandardEmailTests(MailgunBackendMockAPITestCase):
         # also retains specific requests exception class:
         self.assertIsInstance(cm.exception, SSLError)
 
+    @ignore_fail_silently_warning()
+    def test_requests_exception_fail_silently(self):
         # Make sure fail_silently is respected
         self.mock_request.side_effect = SSLError("Something bad")
         sent = mail.send_mail(
@@ -766,7 +780,17 @@ class MailgunBackendAnymailFeatureTests(MailgunBackendMockAPITestCase):
         self.message.send()
         self.assert_esp_called("/esp-extra.example.com/messages")
 
-    @override_settings(ANYMAIL_MAILGUN_SENDER_DOMAIN="mg.example.com")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailgun.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "test_api_key",
+                    "sender_domain": "mg.example.com",
+                },
+            },
+        },
+    )
     def test_sender_domain_setting(self):
         # setting overrides from_email
         self.message.send()
@@ -782,7 +806,17 @@ class MailgunBackendAnymailFeatureTests(MailgunBackendMockAPITestCase):
         ):
             self.message.send()
 
-    @override_settings(ANYMAIL_MAILGUN_SENDER_DOMAIN="example.com%2Finvalid")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailgun.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "test_api_key",
+                    "sender_domain": "example.com%2Finvalid",
+                },
+            },
+        },
+    )
     def test_invalid_sender_domain_setting(self):
         # See previous test. Also, note that Mailgun unquotes % encoding *before*
         # extracting the sender domain (so %2f is just as bad as '/')
@@ -791,7 +825,17 @@ class MailgunBackendAnymailFeatureTests(MailgunBackendMockAPITestCase):
         ):
             self.message.send()
 
-    @override_settings(ANYMAIL_MAILGUN_SENDER_DOMAIN="example.com # oops")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailgun.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "test_api_key",
+                    "sender_domain": "example.com # oops",
+                },
+            },
+        },
+    )
     def test_encode_sender_domain(self):
         # See previous tests. For anything other than slashes, we let Mailgun detect
         # the problem (but must properly encode the domain in the API URL)
@@ -815,8 +859,16 @@ class MailgunBackendAnymailFeatureTests(MailgunBackendMockAPITestCase):
             self.message.send()
 
     @override_settings(
-        # This is *not* a valid MAILGUN_API_URL setting (it should end at "...v3/"):
-        ANYMAIL_MAILGUN_API_URL="https://api.mailgun.net/v3/example.com/messages"
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailgun.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "test_api_key",
+                    # This is *not* a valid api_url (it should end at "...v3/"):
+                    "api_url": "https://api.mailgun.net/v3/example.com/messages",
+                },
+            },
+        },
     )
     def test_magnificent_api(self):
         # (Wouldn't a truly "magnificent API" just provide a helpful error message?)
@@ -874,6 +926,7 @@ class MailgunBackendAnymailFeatureTests(MailgunBackendMockAPITestCase):
         self.assertEqual(msg.anymail_status.esp_response.content, response_content)
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=500)
@@ -932,6 +985,7 @@ class MailgunBackendRecipientsRefusedTests(MailgunBackendMockAPITestCase):
         with self.assertRaises(AnymailAPIError):
             msg.send()
 
+    @ignore_fail_silently_warning()
     def test_fail_silently(self):
         self.set_mock_response(status_code=400, raw=self.INVALID_TO_RESPONSE)
         sent = mail.send_mail(
@@ -954,14 +1008,15 @@ class MailgunBackendSessionSharingTestCase(
 
 
 @tag("mailgun")
-@override_settings(EMAIL_BACKEND="anymail.backends.mailgun.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.mailgun.EmailBackend"}}
+)
 class MailgunBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
     """Test ESP backend without required settings in place"""
 
     def test_missing_api_key(self):
-        with self.assertRaises(ImproperlyConfigured) as cm:
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'api_key'|\bMAILGUN_API_KEY.*ANYMAIL_MAILGUN_API_KEY",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
-        errmsg = str(cm.exception)
-        # Make sure the error mentions MAILGUN_API_KEY and ANYMAIL_MAILGUN_API_KEY
-        self.assertRegex(errmsg, r"\bMAILGUN_API_KEY\b")
-        self.assertRegex(errmsg, r"\bANYMAIL_MAILGUN_API_KEY\b")

--- a/tests/test_mailgun_integration.py
+++ b/tests/test_mailgun_integration.py
@@ -6,12 +6,12 @@ from email.utils import formataddr
 from time import sleep
 
 import requests
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin, sample_image_path
+from .utils import AnymailTestMixin, override_settings, sample_image_path
 
 ANYMAIL_TEST_MAILGUN_API_KEY = os.getenv("ANYMAIL_TEST_MAILGUN_API_KEY")
 ANYMAIL_TEST_MAILGUN_DOMAIN = os.getenv("ANYMAIL_TEST_MAILGUN_DOMAIN")
@@ -24,12 +24,16 @@ ANYMAIL_TEST_MAILGUN_DOMAIN = os.getenv("ANYMAIL_TEST_MAILGUN_DOMAIN")
     " variables to run Mailgun integration tests",
 )
 @override_settings(
-    ANYMAIL={
-        "MAILGUN_API_KEY": ANYMAIL_TEST_MAILGUN_API_KEY,
-        "MAILGUN_SENDER_DOMAIN": ANYMAIL_TEST_MAILGUN_DOMAIN,
-        "MAILGUN_SEND_DEFAULTS": {"esp_extra": {"o:testmode": "yes"}},
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailgun.EmailBackend",
+            "OPTIONS": {
+                "api_key": ANYMAIL_TEST_MAILGUN_API_KEY,
+                "sender_domain": ANYMAIL_TEST_MAILGUN_DOMAIN,
+                "send_defaults": {"esp_extra": {"o:testmode": "yes"}},
+            },
+        },
     },
-    EMAIL_BACKEND="anymail.backends.mailgun.EmailBackend",
 )
 class MailgunBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """Mailgun API integration tests
@@ -267,11 +271,16 @@ class MailgunBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     #     self.assertIn("'from' parameter is not a valid address", str(err))
 
     @override_settings(
-        ANYMAIL={
-            "MAILGUN_API_KEY": "Hey, that's not an API key",
-            "MAILGUN_SENDER_DOMAIN": ANYMAIL_TEST_MAILGUN_DOMAIN,
-            "MAILGUN_SEND_DEFAULTS": {"esp_extra": {"o:testmode": "yes"}},
-        }
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailgun.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "Hey, that's not an API key",
+                    "sender_domain": ANYMAIL_TEST_MAILGUN_DOMAIN,
+                    "send_defaults": {"esp_extra": {"o:testmode": "yes"}},
+                },
+            },
+        },
     )
     def test_invalid_api_key(self):
         with self.assertRaises(AnymailAPIError) as cm:

--- a/tests/test_mailjet_backend.py
+++ b/tests/test_mailjet_backend.py
@@ -3,10 +3,11 @@ from decimal import Decimal
 
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import (
     AnymailAPIError,
+    AnymailConfigurationError,
     AnymailRequestsAPIError,
     AnymailSerializationError,
     AnymailUnsupportedFeature,
@@ -21,16 +22,22 @@ from .utils import (
     AnymailTestMixin,
     create_text_attachment,
     decode_att,
+    ignore_fail_silently_warning,
+    override_settings,
     sample_image_content,
 )
 
 
 @tag("mailjet")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.mailjet.EmailBackend",
-    ANYMAIL={
-        "MAILJET_API_KEY": "API KEY HERE",
-        "MAILJET_SECRET_KEY": "SECRET KEY HERE",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailjet.EmailBackend",
+            "OPTIONS": {
+                "api_key": "API KEY HERE",
+                "secret_key": "SECRET KEY HERE",
+            },
+        },
     },
 )
 class MailjetBackendMockAPITestCase(RequestsBackendMockAPITestCase):
@@ -65,7 +72,6 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
             "Here is the message.",
             "from@sender.example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         self.assert_esp_called("/v3.1/send")
 
@@ -320,6 +326,7 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
         with self.assertRaises(AnymailUnsupportedFeature):
             self.message.send()
 
+    @ignore_fail_silently_warning()
     def test_alternatives_fail_silently(self):
         # Make sure fail_silently is respected
         self.message.attach_alternative("{'not': 'allowed'}", "application/json")
@@ -349,6 +356,8 @@ class MailjetBackendStandardEmailTests(MailjetBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailAPIError, "Mailjet API response 500"):
             mail.send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
 
+    @ignore_fail_silently_warning()
+    def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
         self.set_mock_response(status_code=500)
         sent = mail.send_mail(
@@ -706,6 +715,7 @@ class MailjetBackendAnymailFeatureTests(MailjetBackendMockAPITestCase):
         self.assertEqual(msg.anymail_status.esp_response.json(), response_data)
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=500)
@@ -779,19 +789,30 @@ class MailjetBackendSessionSharingTestCase(
 
 
 @tag("mailjet")
-@override_settings(EMAIL_BACKEND="anymail.backends.mailjet.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.mailjet.EmailBackend"}},
+)
 class MailjetBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
     """Test ESP backend without required settings in place"""
 
     def test_missing_api_key(self):
-        with self.assertRaises(ImproperlyConfigured) as cm:
+        with self.assertRaisesRegex(
+            ImproperlyConfigured,
+            r"'api_key'|\bMAILJET_API_KEY.*ANYMAIL_MAILJET_API_KEY",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
-        errmsg = str(cm.exception)
-        self.assertRegex(errmsg, r"\bMAILJET_API_KEY\b")
 
-    @override_settings(ANYMAIL={"MAILJET_API_KEY": "dummy"})
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailjet.EmailBackend",
+                "OPTIONS": {"api_key": "test-api-key"},
+            }
+        },
+    )
     def test_missing_secret_key(self):
-        with self.assertRaises(ImproperlyConfigured) as cm:
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'secret_key'|\bMAILJET_SECRET_KEY.*ANYMAIL_MAILJET_SECRET_KEY",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
-        errmsg = str(cm.exception)
-        self.assertRegex(errmsg, r"\bMAILJET_SECRET_KEY\b")

--- a/tests/test_mailjet_integration.py
+++ b/tests/test_mailjet_integration.py
@@ -2,12 +2,12 @@ import os
 import unittest
 from email.utils import formataddr
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin, sample_image_content
+from .utils import AnymailTestMixin, override_settings, sample_image_content
 
 ANYMAIL_TEST_MAILJET_API_KEY = os.getenv("ANYMAIL_TEST_MAILJET_API_KEY")
 ANYMAIL_TEST_MAILJET_SECRET_KEY = os.getenv("ANYMAIL_TEST_MAILJET_SECRET_KEY")
@@ -25,14 +25,17 @@ ANYMAIL_TEST_MAILJET_TEMPLATE_ID = os.getenv("ANYMAIL_TEST_MAILJET_TEMPLATE_ID")
     " integration tests",
 )
 @override_settings(
-    ANYMAIL={
-        "MAILJET_API_KEY": ANYMAIL_TEST_MAILJET_API_KEY,
-        "MAILJET_SECRET_KEY": ANYMAIL_TEST_MAILJET_SECRET_KEY,
-        "MAILJET_SEND_DEFAULTS": {
-            "esp_extra": {"SandboxMode": True}  # don't actually send mail
-        },
-    },
-    EMAIL_BACKEND="anymail.backends.mailjet.EmailBackend",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailjet.EmailBackend",
+            "OPTIONS": {
+                "api_key": ANYMAIL_TEST_MAILJET_API_KEY,
+                "secret_key": ANYMAIL_TEST_MAILJET_SECRET_KEY,
+                # don't actually send mail
+                "send_defaults": {"esp_extra": {"SandboxMode": True}},
+            },
+        }
+    }
 )
 class MailjetBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """
@@ -162,10 +165,15 @@ class MailjetBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         self.assertEqual(recipient_status["test+to1@anymail.dev"].status, "sent")
 
     @override_settings(
-        ANYMAIL={
-            "MAILJET_API_KEY": "Hey, that's not an API key!",
-            "MAILJET_SECRET_KEY": "and this isn't the secret for it",
-        }
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailjet.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "Hey, that's not an API key!",
+                    "secret_key": "and this isn't the secret for it",
+                },
+            },
+        },
     )
     def test_invalid_api_key(self):
         with self.assertRaises(AnymailAPIError) as cm:

--- a/tests/test_mailtrap_backend.py
+++ b/tests/test_mailtrap_backend.py
@@ -4,12 +4,12 @@ from datetime import datetime
 from decimal import Decimal
 
 from django.core import mail
-from django.core.exceptions import ImproperlyConfigured
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 from django.utils.timezone import timezone
 
 from anymail.exceptions import (
     AnymailAPIError,
+    AnymailConfigurationError,
     AnymailSerializationError,
     AnymailUnsupportedFeature,
 )
@@ -23,14 +23,22 @@ from .utils import (
     AnymailTestMixin,
     create_text_attachment,
     decode_att,
+    ignore_fail_silently_warning,
+    override_settings,
     sample_image_content,
 )
 
 
 @tag("mailtrap")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.mailtrap.EmailBackend",
-    ANYMAIL={"MAILTRAP_API_TOKEN": "test_api_token"},
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+            "OPTIONS": {
+                "api_token": "test_api_token",
+            },
+        },
+    },
 )
 class MailtrapBackendMockAPITestCase(RequestsBackendMockAPITestCase):
     DEFAULT_RAW_RESPONSE = b"""{
@@ -68,7 +76,6 @@ class MailtrapBackendStandardEmailTests(MailtrapBackendMockAPITestCase):
             "Here is the message.",
             "from@sender.example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         # Uses transactional API
         self.assert_esp_called("https://send.api.mailtrap.io/api/send")
@@ -296,6 +303,7 @@ class MailtrapBackendStandardEmailTests(MailtrapBackendMockAPITestCase):
         ):
             self.message.send()
 
+    @ignore_fail_silently_warning()
     def test_alternatives_fail_silently(self):
         # Make sure fail_silently is respected
         self.message.attach_alternative("{'not': 'allowed'}", "application/json")
@@ -322,6 +330,7 @@ class MailtrapBackendStandardEmailTests(MailtrapBackendMockAPITestCase):
         # Error message includes response details:
         self.assertIn("helpful error message", str(cm.exception))
 
+    @ignore_fail_silently_warning()
     def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
         self.set_mock_response(status_code=500)
@@ -801,7 +810,15 @@ class MailtrapBackendAnymailFeatureTests(MailtrapBackendMockAPITestCase):
 
     # noinspection PyUnresolvedReferences
     @override_settings(
-        ANYMAIL={"MAILTRAP_API_TOKEN": "test-token", "MAILTRAP_SANDBOX_ID": 12345}
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+                "OPTIONS": {
+                    "api_token": "test-token",
+                    "sandbox_id": 12345,
+                },
+            },
+        },
     )
     def test_sandbox_send(self):
         self.set_mock_response_message_ids(["sandbox-single-id"])
@@ -824,7 +841,15 @@ class MailtrapBackendAnymailFeatureTests(MailtrapBackendMockAPITestCase):
         )
 
     @override_settings(
-        ANYMAIL={"MAILTRAP_API_TOKEN": "test-token", "MAILTRAP_SANDBOX_ID": ""}
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+                "OPTIONS": {
+                    "api_token": "test-token",
+                    "sandbox_id": "",
+                },
+            },
+        },
     )
     def test_sandbox_id_empty_string(self):
         """Use transactional API when MAILTRAP_SANDBOX_ID is an empty string."""
@@ -832,7 +857,15 @@ class MailtrapBackendAnymailFeatureTests(MailtrapBackendMockAPITestCase):
         self.assert_esp_called("https://send.api.mailtrap.io/api/send")
 
     @override_settings(
-        ANYMAIL={"MAILTRAP_API_TOKEN": "test-token", "MAILTRAP_SANDBOX_ID": 12345}
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+                "OPTIONS": {
+                    "api_token": "test-token",
+                    "sandbox_id": 12345,
+                },
+            },
+        },
     )
     def test_sandbox_batch_send(self):
         self.set_mock_response(
@@ -876,7 +909,15 @@ class MailtrapBackendAnymailFeatureTests(MailtrapBackendMockAPITestCase):
         )
 
     @override_settings(
-        ANYMAIL={"MAILTRAP_API_TOKEN": "test-token", "MAILTRAP_SANDBOX_ID": 12345}
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+                "OPTIONS": {
+                    "api_token": "test-token",
+                    "sandbox_id": 12345,
+                },
+            },
+        },
     )
     def test_wrong_message_id_count_sandbox(self):
         self.set_mock_response_message_ids(2)
@@ -885,6 +926,7 @@ class MailtrapBackendAnymailFeatureTests(MailtrapBackendMockAPITestCase):
             self.message.send()
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=500)
@@ -949,10 +991,15 @@ class MailtrapBackendAnymailFeatureTests(MailtrapBackendMockAPITestCase):
             self.message.send()
 
     @override_settings(
-        ANYMAIL={
-            "MAILTRAP_API_TOKEN": "test-token",
-            "MAILTRAP_API_URL": "https://bulk.api.mailtrap.io/api",
-        }
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+                "OPTIONS": {
+                    "api_token": "test-token",
+                    "api_url": "https://bulk.api.mailtrap.io/api",
+                },
+            },
+        },
     )
     def test_override_api_url(self):
         self.message.send()
@@ -969,13 +1016,15 @@ class MailtrapBackendSessionSharingTestCase(
 
 
 @tag("mailtrap")
-@override_settings(EMAIL_BACKEND="anymail.backends.mailtrap.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.mailtrap.EmailBackend"}}
+)
 class MailtrapBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
     """Test ESP backend without required settings in place"""
 
     def test_missing_api_token(self):
-        with self.assertRaises(ImproperlyConfigured) as cm:
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'api_token'|\bMAILTRAP_API_TOKEN.*ANYMAIL_MAILTRAP_API_TOKEN",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
-        errmsg = str(cm.exception)
-        self.assertRegex(errmsg, r"\bMAILTRAP_API_TOKEN\b")
-        self.assertRegex(errmsg, r"\bANYMAIL_MAILTRAP_API_TOKEN\b")

--- a/tests/test_mailtrap_integration.py
+++ b/tests/test_mailtrap_integration.py
@@ -2,12 +2,12 @@ import os
 import unittest
 from email.utils import formataddr
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin, sample_image_path
+from .utils import AnymailTestMixin, override_settings, sample_image_path
 
 # Environment variables to run these live integration tests...
 # API token for both sets of tests:
@@ -27,10 +27,12 @@ ANYMAIL_TEST_MAILTRAP_TEMPLATE_UUID = os.getenv("ANYMAIL_TEST_MAILTRAP_TEMPLATE_
     " environment variables to run Mailtrap transactional integration tests",
 )
 @override_settings(
-    ANYMAIL={
-        "MAILTRAP_API_TOKEN": ANYMAIL_TEST_MAILTRAP_API_TOKEN,
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+            "OPTIONS": {"api_token": ANYMAIL_TEST_MAILTRAP_API_TOKEN},
+        },
     },
-    EMAIL_BACKEND="anymail.backends.mailtrap.EmailBackend",
 )
 class MailtrapBackendTransactionalIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """
@@ -148,7 +150,14 @@ class MailtrapBackendTransactionalIntegrationTests(AnymailTestMixin, SimpleTestC
         message.send()
         self.assertEqual(message.anymail_status.status, {"queued"})
 
-    @override_settings(ANYMAIL={"MAILTRAP_API_TOKEN": "Hey, that's not an API token!"})
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+                "OPTIONS": {"api_token": "Hey, that's not an API token!"},
+            },
+        },
+    )
     def test_invalid_api_token(self):
         # Invalid API key generates same error as unvalidated from address
         with self.assertRaisesMessage(AnymailAPIError, "Unauthorized"):
@@ -162,11 +171,15 @@ class MailtrapBackendTransactionalIntegrationTests(AnymailTestMixin, SimpleTestC
     " environment variables to run Mailtrap sandbox integration tests",
 )
 @override_settings(
-    ANYMAIL={
-        "MAILTRAP_API_TOKEN": ANYMAIL_TEST_MAILTRAP_API_TOKEN,
-        "MAILTRAP_SANDBOX_ID": ANYMAIL_TEST_MAILTRAP_SANDBOX_ID,
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+            "OPTIONS": {
+                "api_token": ANYMAIL_TEST_MAILTRAP_API_TOKEN,
+                "sandbox_id": ANYMAIL_TEST_MAILTRAP_SANDBOX_ID,
+            },
+        },
     },
-    EMAIL_BACKEND="anymail.backends.mailtrap.EmailBackend",
 )
 class MailtrapBackendSandboxIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """
@@ -277,10 +290,15 @@ class MailtrapBackendSandboxIntegrationTests(AnymailTestMixin, SimpleTestCase):
         self.assertEqual(message.anymail_status.status, {"queued"})
 
     @override_settings(
-        ANYMAIL={
-            "MAILTRAP_API_TOKEN": "Hey, that's not an API token!",
-            "MAILTRAP_SANDBOX_ID": ANYMAIL_TEST_MAILTRAP_SANDBOX_ID,
-        }
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mailtrap.EmailBackend",
+                "OPTIONS": {
+                    "api_token": "Hey, that's not an API token!",
+                    "sandbox_id": ANYMAIL_TEST_MAILTRAP_SANDBOX_ID,
+                },
+            },
+        },
     )
     def test_invalid_api_token(self):
         with self.assertRaises(AnymailAPIError) as cm:

--- a/tests/test_mandrill_backend.py
+++ b/tests/test_mandrill_backend.py
@@ -2,8 +2,7 @@ from datetime import date, datetime
 from decimal import Decimal
 
 from django.core import mail
-from django.core.exceptions import ImproperlyConfigured
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 from django.utils.timezone import (
     get_fixed_timezone,
     override as override_current_timezone,
@@ -11,6 +10,7 @@ from django.utils.timezone import (
 
 from anymail.exceptions import (
     AnymailAPIError,
+    AnymailConfigurationError,
     AnymailRecipientsRefused,
     AnymailSerializationError,
     AnymailUnsupportedFeature,
@@ -25,14 +25,20 @@ from .utils import (
     AnymailTestMixin,
     create_text_attachment,
     decode_att,
+    ignore_fail_silently_warning,
+    override_settings,
     sample_image_content,
 )
 
 
 @tag("mandrill")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.mandrill.EmailBackend",
-    ANYMAIL={"MANDRILL_API_KEY": "test_api_key"},
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mandrill.EmailBackend",
+            "OPTIONS": {"api_key": "test_api_key"},
+        },
+    },
 )
 class MandrillBackendMockAPITestCase(RequestsBackendMockAPITestCase):
     DEFAULT_RAW_RESPONSE = b"""[{
@@ -60,7 +66,6 @@ class MandrillBackendStandardEmailTests(MandrillBackendMockAPITestCase):
             "Here is the message.",
             "from@example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         self.assert_esp_called("/messages/send.json")
         data = self.get_api_call_json()
@@ -274,6 +279,7 @@ class MandrillBackendStandardEmailTests(MandrillBackendMockAPITestCase):
         with self.assertRaises(AnymailUnsupportedFeature):
             self.message.send()
 
+    @ignore_fail_silently_warning()
     def test_alternatives_fail_silently(self):
         # Make sure fail_silently is respected
         self.message.attach_alternative("{'not': 'allowed'}", "application/json")
@@ -286,6 +292,8 @@ class MandrillBackendStandardEmailTests(MandrillBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailAPIError, "Mandrill API response 400"):
             mail.send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
 
+    @ignore_fail_silently_warning()
+    def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
         self.set_mock_response(status_code=400)
         sent = mail.send_mail(
@@ -675,6 +683,7 @@ class MandrillBackendAnymailFeatureTests(MandrillBackendMockAPITestCase):
         self.assertEqual(msg.anymail_status.esp_response.content, response_content)
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=500)
@@ -752,6 +761,7 @@ class MandrillBackendRecipientsRefusedTests(MandrillBackendMockAPITestCase):
         with self.assertRaises(AnymailRecipientsRefused):
             msg.send()
 
+    @ignore_fail_silently_warning()
     def test_fail_silently(self):
         self.set_mock_response(raw=b"""[
             {"email": "invalid@localhost", "status": "invalid"},
@@ -822,13 +832,15 @@ class MandrillBackendSessionSharingTestCase(
 
 
 @tag("mandrill")
-@override_settings(EMAIL_BACKEND="anymail.backends.mandrill.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.mandrill.EmailBackend"}},
+)
 class MandrillBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
     """Test backend without required settings"""
 
     def test_missing_api_key(self):
-        with self.assertRaises(ImproperlyConfigured) as cm:
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'api_key'|\bMANDRILL_API_KEY.*ANYMAIL_MANDRILL_API_KEY",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
-        errmsg = str(cm.exception)
-        self.assertRegex(errmsg, r"\bMANDRILL_API_KEY\b")
-        self.assertRegex(errmsg, r"\bANYMAIL_MANDRILL_API_KEY\b")

--- a/tests/test_mandrill_integration.py
+++ b/tests/test_mandrill_integration.py
@@ -3,12 +3,12 @@ import unittest
 from email.utils import formataddr
 
 from django.core import mail
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError, AnymailRecipientsRefused
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin, sample_image_path
+from .utils import AnymailTestMixin, override_settings, sample_image_path
 
 ANYMAIL_TEST_MANDRILL_API_KEY = os.getenv("ANYMAIL_TEST_MANDRILL_API_KEY")
 ANYMAIL_TEST_MANDRILL_DOMAIN = os.getenv("ANYMAIL_TEST_MANDRILL_DOMAIN")
@@ -21,8 +21,12 @@ ANYMAIL_TEST_MANDRILL_DOMAIN = os.getenv("ANYMAIL_TEST_MANDRILL_DOMAIN")
     "environment variables to run integration tests",
 )
 @override_settings(
-    MANDRILL_API_KEY=ANYMAIL_TEST_MANDRILL_API_KEY,
-    EMAIL_BACKEND="anymail.backends.mandrill.EmailBackend",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mandrill.EmailBackend",
+            "OPTIONS": {"api_key": ANYMAIL_TEST_MANDRILL_API_KEY},
+        },
+    },
 )
 class MandrillBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """Mandrill API integration tests
@@ -165,7 +169,14 @@ class MandrillBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
                     " for blacklist recipient"
                 )
 
-    @override_settings(MANDRILL_API_KEY="Hey, that's not an API key!")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.mandrill.EmailBackend",
+                "OPTIONS": {"api_key": "Hey, that's not an API key!"},
+            },
+        },
+    )
     def test_invalid_api_key(self):
         # Example of trying to send with an invalid MANDRILL_API_KEY.
         # Mandrill responds either 401 or 500 status for this case (it varies),

--- a/tests/test_postal_backend.py
+++ b/tests/test_postal_backend.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
 
 from django.core import mail
-from django.core.exceptions import ImproperlyConfigured
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import (
     AnymailAPIError,
+    AnymailConfigurationError,
     AnymailSerializationError,
     AnymailUnsupportedFeature,
 )
@@ -19,16 +19,22 @@ from .utils import (
     AnymailTestMixin,
     create_text_attachment,
     decode_att,
+    ignore_fail_silently_warning,
+    override_settings,
     sample_image_content,
 )
 
 
 @tag("postal")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.postal.EmailBackend",
-    ANYMAIL={
-        "POSTAL_API_KEY": "test_server_token",
-        "POSTAL_API_URL": "https://postal.example.com",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.postal.EmailBackend",
+            "OPTIONS": {
+                "api_key": "test_server_token",
+                "api_url": "https://postal.example.com",
+            },
+        },
     },
 )
 class PostalBackendMockAPITestCase(RequestsBackendMockAPITestCase):
@@ -63,7 +69,6 @@ class PostalBackendStandardEmailTests(PostalBackendMockAPITestCase):
             "Here is the message.",
             "from@sender.example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         self.assert_esp_called("/message")
         headers = self.get_api_call_headers()
@@ -261,6 +266,7 @@ class PostalBackendStandardEmailTests(PostalBackendMockAPITestCase):
         with self.assertRaises(AnymailUnsupportedFeature):
             self.message.send()
 
+    @ignore_fail_silently_warning()
     def test_alternatives_fail_silently(self):
         # Make sure fail_silently is respected
         self.message.attach_alternative("{'not': 'allowed'}", "application/json")
@@ -296,7 +302,17 @@ class PostalBackendStandardEmailTests(PostalBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailAPIError, "Postal API response 200"):
             mail.send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
 
+    @ignore_fail_silently_warning()
+    def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
+        failure_response = b"""{
+            "status": "error",
+            "time": 0.0,
+            "flags": {},
+            "data": {
+                "code": "ValidationError"
+            }
+        }"""
         self.set_mock_response(status_code=200, raw=failure_response)
         sent = mail.send_mail(
             "Subject",
@@ -459,6 +475,7 @@ class PostalBackendAnymailFeatureTests(PostalBackendMockAPITestCase):
         self.assertEqual(msg.anymail_status.esp_response.content, response_content)
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=500)
@@ -516,13 +533,15 @@ class PostalBackendSessionSharingTestCase(
 
 
 @tag("postal")
-@override_settings(EMAIL_BACKEND="anymail.backends.postal.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.postal.EmailBackend"}},
+)
 class PostalBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
     """Test ESP backend without required settings in place"""
 
     def test_missing_api_key(self):
-        with self.assertRaises(ImproperlyConfigured) as cm:
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'api_key'|\bPOSTAL_API_KEY.*ANYMAIL_POSTAL_API_KEY",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
-        errmsg = str(cm.exception)
-        self.assertRegex(errmsg, r"\bPOSTAL_API_KEY\b")
-        self.assertRegex(errmsg, r"\bANYMAIL_POSTAL_API_KEY\b")

--- a/tests/test_postal_integration.py
+++ b/tests/test_postal_integration.py
@@ -2,12 +2,12 @@ import os
 import unittest
 from email.utils import formataddr
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin
+from .utils import AnymailTestMixin, override_settings
 
 ANYMAIL_TEST_POSTAL_API_KEY = os.getenv("ANYMAIL_TEST_POSTAL_API_KEY")
 ANYMAIL_TEST_POSTAL_API_URL = os.getenv("ANYMAIL_TEST_POSTAL_API_URL")
@@ -23,9 +23,15 @@ ANYMAIL_TEST_POSTAL_DOMAIN = os.getenv("ANYMAIL_TEST_POSTAL_DOMAIN")
     " ANYMAIL_TEST_POSTAL_DOMAIN environment variables to run Postal integration tests",
 )
 @override_settings(
-    ANYMAIL_POSTAL_API_KEY=ANYMAIL_TEST_POSTAL_API_KEY,
-    ANYMAIL_POSTAL_API_URL=ANYMAIL_TEST_POSTAL_API_URL,
-    EMAIL_BACKEND="anymail.backends.postal.EmailBackend",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.postal.EmailBackend",
+            "OPTIONS": {
+                "api_key": ANYMAIL_TEST_POSTAL_API_KEY,
+                "api_url": ANYMAIL_TEST_POSTAL_API_URL,
+            },
+        },
+    },
 )
 class PostalBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """Postal API integration tests
@@ -106,7 +112,17 @@ class PostalBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         )
         self.assertIn("UnauthenticatedFromAddress", response["data"]["code"])
 
-    @override_settings(ANYMAIL_POSTAL_API_KEY="Hey, that's not an API key!")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.postal.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "Hey, that's not an API key!",
+                    "api_url": ANYMAIL_TEST_POSTAL_API_URL,
+                },
+            },
+        },
+    )
     def test_invalid_server_token(self):
         with self.assertRaises(AnymailAPIError) as cm:
             self.message.send()

--- a/tests/test_postmark_backend.py
+++ b/tests/test_postmark_backend.py
@@ -2,11 +2,11 @@ import json
 from decimal import Decimal
 
 from django.core import mail
-from django.core.exceptions import ImproperlyConfigured
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import (
     AnymailAPIError,
+    AnymailConfigurationError,
     AnymailInvalidAddress,
     AnymailRecipientsRefused,
     AnymailSerializationError,
@@ -22,14 +22,20 @@ from .utils import (
     AnymailTestMixin,
     create_text_attachment,
     decode_att,
+    ignore_fail_silently_warning,
+    override_settings,
     sample_image_content,
 )
 
 
 @tag("postmark")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.postmark.EmailBackend",
-    ANYMAIL={"POSTMARK_SERVER_TOKEN": "test_server_token"},
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.postmark.EmailBackend",
+            "OPTIONS": {"server_token": "test_server_token"},
+        },
+    },
 )
 class PostmarkBackendMockAPITestCase(RequestsBackendMockAPITestCase):
     DEFAULT_RAW_RESPONSE = b"""{
@@ -59,7 +65,6 @@ class PostmarkBackendStandardEmailTests(PostmarkBackendMockAPITestCase):
             "Here is the message.",
             "from@sender.example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         self.assert_esp_called("/email")
         headers = self.get_api_call_headers()
@@ -274,6 +279,7 @@ class PostmarkBackendStandardEmailTests(PostmarkBackendMockAPITestCase):
         with self.assertRaises(AnymailUnsupportedFeature):
             self.message.send()
 
+    @ignore_fail_silently_warning()
     def test_alternatives_fail_silently(self):
         # Make sure fail_silently is respected
         self.message.attach_alternative("{'not': 'allowed'}", "application/json")
@@ -318,6 +324,8 @@ class PostmarkBackendStandardEmailTests(PostmarkBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailAPIError, "Postmark API response 500"):
             mail.send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
 
+    @ignore_fail_silently_warning()
+    def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
         self.set_mock_response(status_code=500)
         sent = mail.send_mail(
@@ -802,6 +810,7 @@ class PostmarkBackendAnymailFeatureTests(PostmarkBackendMockAPITestCase):
         self.assertEqual(msg.anymail_status.esp_response.content, response_content)
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=500)
@@ -951,6 +960,7 @@ class PostmarkBackendRecipientsRefusedTests(PostmarkBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailAPIError, "Invalid metadata content"):
             msg.send()
 
+    @ignore_fail_silently_warning()
     def test_fail_silently(self):
         self.set_mock_response(
             status_code=422,
@@ -1053,13 +1063,15 @@ class PostmarkBackendSessionSharingTestCase(
 
 
 @tag("postmark")
-@override_settings(EMAIL_BACKEND="anymail.backends.postmark.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.postmark.EmailBackend"}},
+)
 class PostmarkBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
     """Test ESP backend without required settings in place"""
 
     def test_missing_api_key(self):
-        with self.assertRaises(ImproperlyConfigured) as cm:
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'server_token'|\bPOSTMARK_SERVER_TOKEN.*ANYMAIL_POSTMARK_SERVER_TOKEN",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
-        errmsg = str(cm.exception)
-        self.assertRegex(errmsg, r"\bPOSTMARK_SERVER_TOKEN\b")
-        self.assertRegex(errmsg, r"\bANYMAIL_POSTMARK_SERVER_TOKEN\b")

--- a/tests/test_postmark_integration.py
+++ b/tests/test_postmark_integration.py
@@ -2,12 +2,12 @@ import os
 import unittest
 from email.utils import formataddr
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin, sample_image_path
+from .utils import AnymailTestMixin, override_settings, sample_image_path
 
 # For most integration tests, Postmark's sandboxed "POSTMARK_API_TEST" token is used.
 # But to test template sends, a real Postmark server token and template id are needed:
@@ -23,8 +23,12 @@ ANYMAIL_TEST_POSTMARK_DOMAIN = os.getenv("ANYMAIL_TEST_POSTMARK_DOMAIN")
     "to run Postmark template integration tests",
 )
 @override_settings(
-    ANYMAIL_POSTMARK_SERVER_TOKEN="POSTMARK_API_TEST",
-    EMAIL_BACKEND="anymail.backends.postmark.EmailBackend",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.postmark.EmailBackend",
+            "OPTIONS": {"server_token": "POSTMARK_API_TEST"},
+        },
+    },
 )
 class PostmarkBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """Postmark API integration tests
@@ -131,7 +135,14 @@ class PostmarkBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         "and ANYMAIL_TEST_POSTMARK_DOMAIN environment variables to run Postmark "
         "template integration tests",
     )
-    @override_settings(ANYMAIL_POSTMARK_SERVER_TOKEN=ANYMAIL_TEST_POSTMARK_SERVER_TOKEN)
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.postmark.EmailBackend",
+                "OPTIONS": {"server_token": ANYMAIL_TEST_POSTMARK_SERVER_TOKEN},
+            },
+        },
+    )
     def test_template(self):
         message = AnymailMessage(
             from_email=self.from_email,
@@ -146,7 +157,14 @@ class PostmarkBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         message.send()
         self.assertEqual(message.anymail_status.status, {"sent"})
 
-    @override_settings(ANYMAIL_POSTMARK_SERVER_TOKEN="Hey, that's not a server token!")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.postmark.EmailBackend",
+                "OPTIONS": {"server_token": "Hey, that's not a server token!"},
+            },
+        },
+    )
     def test_invalid_server_token(self):
         # Message will include something like
         # "Request does not contain a valid Server token"

--- a/tests/test_resend_backend.py
+++ b/tests/test_resend_backend.py
@@ -3,8 +3,7 @@ from datetime import date, datetime
 from decimal import Decimal
 
 from django.core import mail
-from django.core.exceptions import ImproperlyConfigured
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 from django.utils.timezone import (
     get_fixed_timezone,
     override as override_current_timezone,
@@ -12,6 +11,7 @@ from django.utils.timezone import (
 
 from anymail.exceptions import (
     AnymailAPIError,
+    AnymailConfigurationError,
     AnymailSerializationError,
     AnymailUnsupportedFeature,
 )
@@ -25,15 +25,19 @@ from .utils import (
     AnymailTestMixin,
     create_text_attachment,
     decode_att,
+    ignore_fail_silently_warning,
+    override_settings,
     sample_image_content,
 )
 
 
 @tag("resend")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.resend.EmailBackend",
-    ANYMAIL={
-        "RESEND_API_KEY": "test_api_key",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.resend.EmailBackend",
+            "OPTIONS": {"api_key": "test_api_key"},
+        },
     },
 )
 class ResendBackendMockAPITestCase(RequestsBackendMockAPITestCase):
@@ -58,7 +62,6 @@ class ResendBackendStandardEmailTests(ResendBackendMockAPITestCase):
             "Here is the message.",
             "from@sender.example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         self.assert_esp_called("/emails")
         headers = self.get_api_call_headers()
@@ -282,6 +285,7 @@ class ResendBackendStandardEmailTests(ResendBackendMockAPITestCase):
         with self.assertRaises(AnymailUnsupportedFeature):
             self.message.send()
 
+    @ignore_fail_silently_warning()
     def test_alternatives_fail_silently(self):
         # Make sure fail_silently is respected
         self.message.attach_alternative("{'not': 'allowed'}", "application/json")
@@ -317,7 +321,14 @@ class ResendBackendStandardEmailTests(ResendBackendMockAPITestCase):
             mail.send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
         self.assertIn("API key is invalid", str(cm.exception))
 
+    @ignore_fail_silently_warning()
+    def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
+        failure_response = {
+            "statusCode": 400,
+            "message": "API key is invalid",
+            "name": "validation_error",
+        }
         self.set_mock_response(status_code=422, json_data=failure_response)
         sent = mail.send_mail(
             "Subject",
@@ -598,6 +609,7 @@ class ResendBackendAnymailFeatureTests(ResendBackendMockAPITestCase):
         )
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=500)
@@ -655,13 +667,15 @@ class ResendBackendSessionSharingTestCase(
 
 
 @tag("resend")
-@override_settings(EMAIL_BACKEND="anymail.backends.resend.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.resend.EmailBackend"}},
+)
 class ResendBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
     """Test ESP backend without required settings in place"""
 
     def test_missing_api_key(self):
-        with self.assertRaises(ImproperlyConfigured) as cm:
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'api_key'|\bRESEND_API_KEY.*ANYMAIL_RESEND_API_KEY",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
-        errmsg = str(cm.exception)
-        self.assertRegex(errmsg, r"\bRESEND_API_KEY\b")
-        self.assertRegex(errmsg, r"\bANYMAIL_RESEND_API_KEY\b")

--- a/tests/test_resend_integration.py
+++ b/tests/test_resend_integration.py
@@ -2,12 +2,12 @@ import os
 import unittest
 from email.utils import formataddr
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin
+from .utils import AnymailTestMixin, override_settings
 
 ANYMAIL_TEST_RESEND_API_KEY = os.getenv("ANYMAIL_TEST_RESEND_API_KEY")
 ANYMAIL_TEST_RESEND_DOMAIN = os.getenv("ANYMAIL_TEST_RESEND_DOMAIN")
@@ -20,8 +20,12 @@ ANYMAIL_TEST_RESEND_DOMAIN = os.getenv("ANYMAIL_TEST_RESEND_DOMAIN")
     "environment variables to run Resend integration tests",
 )
 @override_settings(
-    ANYMAIL_RESEND_API_KEY=ANYMAIL_TEST_RESEND_API_KEY,
-    EMAIL_BACKEND="anymail.backends.resend.EmailBackend",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.resend.EmailBackend",
+            "OPTIONS": {"api_key": ANYMAIL_TEST_RESEND_API_KEY},
+        },
+    },
 )
 class ResendBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """Resend.com API integration tests
@@ -133,7 +137,14 @@ class ResendBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         )
 
     @unittest.skip("Resend has stopped responding to bad/missing API keys (12/2023)")
-    @override_settings(ANYMAIL_RESEND_API_KEY="Hey, that's not an API key!")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.resend.EmailBackend",
+                "OPTIONS": {"api_key": "Hey, that's not an API key!"},
+            },
+        },
+    )
     def test_invalid_api_key(self):
         with self.assertRaisesMessage(AnymailAPIError, "API key is invalid"):
             self.message.send()

--- a/tests/test_scaleway_backend.py
+++ b/tests/test_scaleway_backend.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.core import mail
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import (
     AnymailAPIError,
@@ -14,19 +14,29 @@ from .mock_requests_backend import (
     RequestsBackendMockAPITestCase,
     SessionSharingTestCases,
 )
-from .utils import create_text_attachment, decode_att, sample_image_content
+from .utils import (
+    create_text_attachment,
+    decode_att,
+    get_default_mailer,
+    override_settings,
+    sample_image_content,
+)
 
-# Minimal required ANYMAIL settings for Scaleway, used in multiple tests
-SCALEWAY_BASE_SETTINGS = {
-    "SCALEWAY_SECRET_KEY": "test_secret_key",
-    "SCALEWAY_PROJECT_ID": "test_project_id",
+# Minimal required MAILER OPTIONS for Scaleway, used in multiple tests
+SCALEWAY_BASE_OPTIONS = {
+    "secret_key": "test_secret_key",
+    "project_id": "test_project_id",
 }
 
 
 @tag("scaleway")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.scaleway.EmailBackend",
-    ANYMAIL=SCALEWAY_BASE_SETTINGS,
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.scaleway.EmailBackend",
+            "OPTIONS": SCALEWAY_BASE_OPTIONS,
+        },
+    },
 )
 class ScalewayBackendMockAPITestCase(RequestsBackendMockAPITestCase):
     DEFAULT_RAW_RESPONSE = b"""{
@@ -62,7 +72,6 @@ class ScalewayBackendStandardEmailTests(ScalewayBackendMockAPITestCase):
             "Here is the message.",
             "from@example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         self.assert_esp_called(
             "https://api.scaleway.com/transactional-email/v1alpha1/regions/fr-par/emails"
@@ -438,46 +447,84 @@ class ScalewayBackendSessionSharingTestCase(
 
 
 @tag("scaleway")
-@override_settings(EMAIL_BACKEND="anymail.backends.scaleway.EmailBackend")
 class ScalewayBackendConfigurationTests(SimpleTestCase):
-    @override_settings(ANYMAIL={"SCALEWAY_PROJECT_ID": "test_project_id"})
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.scaleway.EmailBackend",
+                "OPTIONS": {"project_id": "test_project_id"},
+            },
+        },
+    )
     def test_missing_secret_key(self):
         with self.assertRaisesRegex(
-            AnymailConfigurationError, r"You must set.*SCALEWAY_SECRET_KEY"
+            AnymailConfigurationError,
+            r"OPTIONS must define 'secret_key'|You must set.*SCALEWAY_SECRET_KEY",
         ):
-            mail.get_connection()
-
-    @override_settings(ANYMAIL={"SCALEWAY_SECRET_KEY": "test_secret_key"})
-    def test_missing_project_id(self):
-        with self.assertRaisesRegex(
-            AnymailConfigurationError, r"You must set.*SCALEWAY_PROJECT_ID"
-        ):
-            mail.get_connection()
+            get_default_mailer()
 
     @override_settings(
-        ANYMAIL={"SCALEWAY_PROJECT_ID": "test_project_id"},
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.scaleway.EmailBackend",
+                "OPTIONS": {"secret_key": "test_secret_key"},
+            },
+        },
+    )
+    def test_missing_project_id(self):
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"OPTIONS must define 'project_id'|You must set.*SCALEWAY_PROJECT_ID",
+        ):
+            get_default_mailer()
+
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.scaleway.EmailBackend",
+                "OPTIONS": {"project_id": "test_project_id"},
+            },
+        },
         SCALEWAY_SECRET_KEY="test_secret_key",
     )
     def test_bare_secret_key(self):
         # SCALEWAY_SECRET_KEY is allowed in settings file root
-        connection = mail.get_connection()
+        connection = get_default_mailer()
         self.assertEqual(connection.secret_key, "test_secret_key")
 
-    @override_settings(ANYMAIL=dict(SCALEWAY_BASE_SETTINGS, SCALEWAY_REGION="pl-waw"))
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.scaleway.EmailBackend",
+                "OPTIONS": {
+                    **SCALEWAY_BASE_OPTIONS,
+                    "region": "pl-waw",
+                },
+            },
+        },
+    )
     def test_region_setting(self):
-        backend = mail.get_connection()
+        backend = get_default_mailer()
         self.assertEqual(
             backend.api_url,
             "https://api.scaleway.com/transactional-email/v1alpha1/regions/pl-waw/",
         )
 
     @override_settings(
-        ANYMAIL=dict(SCALEWAY_BASE_SETTINGS, SCALEWAY_REGION="nl-ams # from /.env")
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.scaleway.EmailBackend",
+                "OPTIONS": {
+                    **SCALEWAY_BASE_OPTIONS,
+                    "region": "nl-ams # from /.env",
+                },
+            },
+        },
     )
     def test_bad_region_setting(self):
         # Make sure api_url is properly quoted
         # (e.g., misread from an env file that doesn't allow comments)
-        backend = mail.get_connection()
+        backend = get_default_mailer()
         self.assertEqual(
             backend.api_url,
             "https://api.scaleway.com/transactional-email/v1alpha1"
@@ -485,23 +532,33 @@ class ScalewayBackendConfigurationTests(SimpleTestCase):
         )
 
     @override_settings(
-        ANYMAIL=dict(
-            SCALEWAY_BASE_SETTINGS,
-            SCALEWAY_API_URL="https://scaleway.example.com/{region}/email",
-        )
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.scaleway.EmailBackend",
+                "OPTIONS": {
+                    **SCALEWAY_BASE_OPTIONS,
+                    "api_url": "https://scaleway.example.com/{region}/email",
+                },
+            },
+        },
     )
     def test_api_url_setting(self):
         # The {region} placeholder is replaced with the region setting
-        backend = mail.get_connection()
+        backend = get_default_mailer()
         self.assertEqual(backend.api_url, "https://scaleway.example.com/fr-par/email/")
 
     @override_settings(
-        ANYMAIL=dict(
-            SCALEWAY_BASE_SETTINGS,
-            SCALEWAY_API_URL="https://scaleway.example.com/email",
-        )
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.scaleway.EmailBackend",
+                "OPTIONS": {
+                    **SCALEWAY_BASE_OPTIONS,
+                    "api_url": "https://scaleway.example.com/email",
+                },
+            },
+        },
     )
     def test_api_url_setting_without_region(self):
         # The region placeholder is not required
-        backend = mail.get_connection()
+        backend = get_default_mailer()
         self.assertEqual(backend.api_url, "https://scaleway.example.com/email/")

--- a/tests/test_scaleway_integration.py
+++ b/tests/test_scaleway_integration.py
@@ -1,12 +1,12 @@
 import os
 import unittest
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin
+from .utils import AnymailTestMixin, override_settings
 
 ANYMAIL_TEST_SCALEWAY_SECRET_KEY = os.getenv("ANYMAIL_TEST_SCALEWAY_SECRET_KEY")
 ANYMAIL_TEST_SCALEWAY_PROJECT_ID = os.getenv("ANYMAIL_TEST_SCALEWAY_PROJECT_ID")
@@ -22,11 +22,15 @@ ANYMAIL_TEST_SCALEWAY_DOMAIN = os.getenv("ANYMAIL_TEST_SCALEWAY_DOMAIN")
     "ANYMAIL_TEST_SCALEWAY_DOMAIN environment variables to run Scaleway integration tests",
 )
 @override_settings(
-    ANYMAIL={
-        "SCALEWAY_SECRET_KEY": ANYMAIL_TEST_SCALEWAY_SECRET_KEY,
-        "SCALEWAY_PROJECT_ID": ANYMAIL_TEST_SCALEWAY_PROJECT_ID,
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.scaleway.EmailBackend",
+            "OPTIONS": {
+                "secret_key": ANYMAIL_TEST_SCALEWAY_SECRET_KEY,
+                "project_id": ANYMAIL_TEST_SCALEWAY_PROJECT_ID,
+            },
+        },
     },
-    EMAIL_BACKEND="anymail.backends.scaleway.EmailBackend",
 )
 class ScalewayIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """Scaleway API integration tests
@@ -87,10 +91,15 @@ class ScalewayIntegrationTests(AnymailTestMixin, SimpleTestCase):
         self.assertIn("Invalid email from address", str(err))
 
     @override_settings(
-        ANYMAIL={
-            "SCALEWAY_SECRET_KEY": "Hey, that's not a secret key",
-            "SCALEWAY_PROJECT_ID": "not-a-project-id",
-        }
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.scaleway.EmailBackend",
+                "OPTIONS": {
+                    "secret_key": "Hey, that's not a secret key",
+                    "project_id": "not-a-project-id",
+                },
+            },
+        },
     )
     def test_invalid_secret_key(self):
         with self.assertRaises(AnymailAPIError) as cm:

--- a/tests/test_sendgrid_backend.py
+++ b/tests/test_sendgrid_backend.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 from django.core import mail
-from django.test import SimpleTestCase, ignore_warnings, override_settings, tag
+from django.test import SimpleTestCase, ignore_warnings, tag
 from django.utils.timezone import (
     get_fixed_timezone,
     override as override_current_timezone,
@@ -28,14 +28,21 @@ from .utils import (
     AnymailTestMixin,
     create_text_attachment,
     decode_att,
+    get_default_mailer,
+    ignore_fail_silently_warning,
+    override_settings,
     sample_image_content,
 )
 
 
 @tag("sendgrid")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.sendgrid.EmailBackend",
-    ANYMAIL={"SENDGRID_API_KEY": "test_api_key"},
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.sendgrid.EmailBackend",
+            "OPTIONS": {"api_key": "test_api_key"},
+        },
+    },
 )
 @ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridBackendMockAPITestCase(RequestsBackendMockAPITestCase):
@@ -71,7 +78,7 @@ class SendGridBackendStandardEmailTests(SendGridBackendMockAPITestCase):
             AnymailNotSupportedWarning,
             msg="django-anymail has dropped official support for SendGrid.",
         ):
-            mail.get_connection()
+            get_default_mailer()
 
     def test_send_mail(self):
         """Test basic API for simple send"""
@@ -80,7 +87,6 @@ class SendGridBackendStandardEmailTests(SendGridBackendMockAPITestCase):
             "Here is the message.",
             "from@sender.example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         self.assert_esp_called("https://api.sendgrid.com/v3/mail/send")
         http_headers = self.get_api_call_headers()
@@ -391,6 +397,8 @@ class SendGridBackendStandardEmailTests(SendGridBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailAPIError, "SendGrid API response 400"):
             mail.send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
 
+    @ignore_fail_silently_warning()
+    def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
         self.set_mock_response(status_code=400)
         sent = mail.send_mail(
@@ -721,7 +729,15 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
         self.assertNotIn("sections", data)
 
     @override_settings(
-        ANYMAIL_SENDGRID_MERGE_FIELD_FORMAT=":{}"  # :field as shown in SG examples
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.sendgrid.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "test_api_key",
+                    "merge_field_format": ":{}",  # :field as shown in SG examples
+                },
+            },
+        },
     )
     def test_legacy_merge_field_format_setting(self):
         # Provide merge field delimiters in settings.py
@@ -1073,7 +1089,15 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
         )
 
     @override_settings(
-        ANYMAIL_SENDGRID_GENERATE_MESSAGE_ID=False  # else we force custom_args
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.sendgrid.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "test_api_key",
+                    "generate_message_id": False,  # else we force custom_args
+                },
+            },
+        },
     )
     def test_default_omits_options(self):
         """Make sure by default we don't send any ESP-specific options.
@@ -1230,7 +1254,17 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
             msg.anymail_status.recipients["cc@example.com"].message_id, "mocked-uuid-2"
         )
 
-    @override_settings(ANYMAIL_SENDGRID_GENERATE_MESSAGE_ID=False)
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.sendgrid.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "test_api_key",
+                    "generate_message_id": False,
+                },
+            },
+        },
+    )
     def test_disable_generate_message_id(self):
         msg = mail.EmailMessage(
             "Subject",
@@ -1243,6 +1277,7 @@ class SendGridBackendAnymailFeatureTests(SendGridBackendMockAPITestCase):
         self.assertIsNone(msg.anymail_status.recipients["to1@example.com"].message_id)
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=500)
@@ -1290,18 +1325,25 @@ class SendGridBackendSessionSharingTestCase(
 
 
 @tag("sendgrid")
-@override_settings(EMAIL_BACKEND="anymail.backends.sendgrid.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.sendgrid.EmailBackend"}},
+)
 @ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
     """Test ESP backend without required settings in place"""
 
     def test_missing_auth(self):
-        with self.assertRaisesRegex(AnymailConfigurationError, r"\bSENDGRID_API_KEY\b"):
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'api_key'|\bSENDGRID_API_KEY.*ANYMAIL_SENDGRID_API_KEY",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
 
 
 @tag("sendgrid")
-@override_settings(EMAIL_BACKEND="anymail.backends.sendgrid.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.sendgrid.EmailBackend"}},
+)
 @ignore_warnings(category=AnymailNotSupportedWarning)
 class SendGridBackendDisallowsV2Tests(AnymailTestMixin, SimpleTestCase):
     """Using v2-API-only features should cause errors with v3 backend"""

--- a/tests/test_sendgrid_integration.py
+++ b/tests/test_sendgrid_integration.py
@@ -3,12 +3,12 @@ import unittest
 from datetime import datetime, timedelta
 from email.utils import formataddr
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin, sample_image_path
+from .utils import AnymailTestMixin, override_settings, sample_image_path
 
 ANYMAIL_TEST_SENDGRID_API_KEY = os.getenv("ANYMAIL_TEST_SENDGRID_API_KEY")
 ANYMAIL_TEST_SENDGRID_TEMPLATE_ID = os.getenv("ANYMAIL_TEST_SENDGRID_TEMPLATE_ID")
@@ -22,13 +22,19 @@ ANYMAIL_TEST_SENDGRID_DOMAIN = os.getenv("ANYMAIL_TEST_SENDGRID_DOMAIN")
     "environment variables to run SendGrid integration tests",
 )
 @override_settings(
-    ANYMAIL_SENDGRID_API_KEY=ANYMAIL_TEST_SENDGRID_API_KEY,
-    ANYMAIL_SENDGRID_SEND_DEFAULTS={
-        "esp_extra": {
-            "mail_settings": {"sandbox_mode": {"enable": True}},
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.sendgrid.EmailBackend",
+            "OPTIONS": {
+                "api_key": ANYMAIL_TEST_SENDGRID_API_KEY,
+                "send_defaults": {
+                    "esp_extra": {
+                        "mail_settings": {"sandbox_mode": {"enable": True}},
+                    },
+                },
+            },
         }
     },
-    EMAIL_BACKEND="anymail.backends.sendgrid.EmailBackend",
 )
 class SendGridBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """
@@ -165,7 +171,14 @@ class SendGridBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         message.send()
         self.assertEqual(message.anymail_status.status, {"queued"})
 
-    @override_settings(ANYMAIL_SENDGRID_API_KEY="Hey, that's not an API key!")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.sendgrid.EmailBackend",
+                "OPTIONS": {"api_key": "Hey, that's not an API key!"},
+            },
+        },
+    )
     def test_invalid_api_key(self):
         with self.assertRaises(AnymailAPIError) as cm:
             self.message.send()

--- a/tests/test_sendinblue_deprecations.py
+++ b/tests/test_sendinblue_deprecations.py
@@ -1,7 +1,7 @@
 from unittest.mock import ANY
 
 from django.core.mail import EmailMessage, send_mail
-from django.test import ignore_warnings, override_settings, tag
+from django.test import ignore_warnings, tag
 
 from anymail.exceptions import AnymailConfigurationError, AnymailDeprecationWarning
 from anymail.webhooks.sendinblue import (
@@ -10,12 +10,13 @@ from anymail.webhooks.sendinblue import (
 )
 
 from .mock_requests_backend import RequestsBackendMockAPITestCase
+from .utils import override_settings
 from .webhook_cases import WebhookTestCase
 
 
 @tag("brevo", "sendinblue")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.sendinblue.EmailBackend",
+    MAILERS={"default": {"BACKEND": "anymail.backends.sendinblue.EmailBackend"}},
     ANYMAIL={"SENDINBLUE_API_KEY": "test_api_key"},
 )
 @ignore_warnings(category=AnymailDeprecationWarning)
@@ -40,7 +41,9 @@ class SendinBlueBackendDeprecationTests(RequestsBackendMockAPITestCase):
     @override_settings(ANYMAIL={"BREVO_API_KEY": "test_api_key"})
     def test_missing_api_key_error_uses_correct_setting_name(self):
         # The sendinblue.EmailBackend requires SENDINBLUE_ settings names
-        with self.assertRaisesMessage(AnymailConfigurationError, "SENDINBLUE_API_KEY"):
+        with self.assertRaisesRegex(
+            AnymailConfigurationError, "'api_key'|SENDINBLUE_API_KEY"
+        ):
             send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
 
 

--- a/tests/test_sparkpost_backend.py
+++ b/tests/test_sparkpost_backend.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timezone
 from decimal import Decimal
 
 from django.core import mail
-from django.test import override_settings, tag
+from django.test import tag
 from django.utils.timezone import (
     get_fixed_timezone,
     override as override_current_timezone,
@@ -19,13 +19,24 @@ from anymail.exceptions import (
 from anymail.message import AnymailMessage, attach_inline_image
 
 from .mock_requests_backend import RequestsBackendMockAPITestCase
-from .utils import create_text_attachment, decode_att, sample_image_content
+from .utils import (
+    create_text_attachment,
+    decode_att,
+    ignore_connection_warnings,
+    ignore_fail_silently_warning,
+    override_settings,
+    sample_image_content,
+)
 
 
 @tag("sparkpost")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.sparkpost.EmailBackend",
-    ANYMAIL={"SPARKPOST_API_KEY": "test_api_key"},
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.sparkpost.EmailBackend",
+            "OPTIONS": {"api_key": "test_api_key"},
+        },
+    },
 )
 class SparkPostBackendMockAPITestCase(RequestsBackendMockAPITestCase):
     """TestCase that uses SparkPostEmailBackend with a mocked transmissions.send API"""
@@ -71,7 +82,6 @@ class SparkPostBackendStandardEmailTests(SparkPostBackendMockAPITestCase):
             "Here is the message.",
             "from@example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
 
         self.assert_esp_called("/api/v1/transmissions/")
@@ -332,6 +342,7 @@ class SparkPostBackendStandardEmailTests(SparkPostBackendMockAPITestCase):
         with self.assertRaises(AnymailUnsupportedFeature):
             self.message.send()
 
+    @ignore_fail_silently_warning()
     def test_alternatives_fail_silently(self):
         # Make sure fail_silently is respected
         self.message.attach_alternative("{'not': 'allowed'}", "application/json")
@@ -370,6 +381,7 @@ class SparkPostBackendStandardEmailTests(SparkPostBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailAPIError, "SparkPost API response 400"):
             self.message.send()
 
+    @ignore_fail_silently_warning()
     def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
         self.set_mock_response(status_code=400)
@@ -782,6 +794,7 @@ class SparkPostBackendAnymailFeatureTests(SparkPostBackendMockAPITestCase):
         )
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=400)
@@ -840,6 +853,7 @@ class SparkPostBackendRecipientsRefusedTests(SparkPostBackendMockAPITestCase):
         with self.assertRaises(AnymailRecipientsRefused):
             msg.send()
 
+    @ignore_fail_silently_warning()
     def test_fail_silently(self):
         self.set_mock_result(accepted=0, rejected=2)
         sent = mail.send_mail(
@@ -893,27 +907,34 @@ class SparkPostBackendConfigurationTests(SparkPostBackendMockAPITestCase):
     """Test various SparkPost client options"""
 
     @override_settings(
-        # clear SPARKPOST_API_KEY from SparkPostBackendMockAPITestCase:
-        ANYMAIL={}
+        MAILERS={
+            "default": {"BACKEND": "anymail.backends.sparkpost.EmailBackend"},
+        },
     )
     def test_missing_api_key(self):
-        with self.assertRaises(AnymailConfigurationError) as cm:
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'api_key'|\bSPARKPOST_API_KEY.*ANYMAIL_SPARKPOST_API_KEY",
+        ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
-        errmsg = str(cm.exception)
-        # Make sure the error mentions the different places to set the key
-        self.assertRegex(errmsg, r"\bSPARKPOST_API_KEY\b")
-        self.assertRegex(errmsg, r"\bANYMAIL_SPARKPOST_API_KEY\b")
 
     @override_settings(
-        ANYMAIL={
-            "SPARKPOST_API_URL": "https://api.eu.sparkpost.com/api/v1",
-            "SPARKPOST_API_KEY": "test_api_key",
-        }
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.sparkpost.EmailBackend",
+                "OPTIONS": {
+                    "api_url": "https://api.eu.sparkpost.com/api/v1",
+                    "api_key": "test_api_key",
+                },
+            },
+        },
     )
     def test_sparkpost_api_url(self):
         mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])
         self.assert_esp_called("https://api.eu.sparkpost.com/api/v1/transmissions/")
 
+    @ignore_connection_warnings()
+    def test_sparkpost_api_url_get_connection_override(self):
         # can also override on individual connection
         # (and even use non-versioned labs endpoint)
         connection = mail.get_connection(api_url="https://api.sparkpost.com/api/labs")
@@ -926,6 +947,7 @@ class SparkPostBackendConfigurationTests(SparkPostBackendMockAPITestCase):
         )
         self.assert_esp_called("https://api.sparkpost.com/api/labs/transmissions/")
 
+    @ignore_connection_warnings()
     def test_subaccount(self):
         # A likely use case is supplying subaccount for a particular message.
         # (For all messages, just set SPARKPOST_SUBACCOUNT in ANYMAIL settings.)

--- a/tests/test_sparkpost_integration.py
+++ b/tests/test_sparkpost_integration.py
@@ -3,12 +3,12 @@ import unittest
 from datetime import datetime, timedelta
 from email.utils import formataddr
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin, sample_image_path
+from .utils import AnymailTestMixin, override_settings, sample_image_path
 
 ANYMAIL_TEST_SPARKPOST_API_KEY = os.getenv("ANYMAIL_TEST_SPARKPOST_API_KEY")
 ANYMAIL_TEST_SPARKPOST_DOMAIN = os.getenv("ANYMAIL_TEST_SPARKPOST_DOMAIN")
@@ -21,8 +21,12 @@ ANYMAIL_TEST_SPARKPOST_DOMAIN = os.getenv("ANYMAIL_TEST_SPARKPOST_DOMAIN")
     "environment variables to run SparkPost integration tests",
 )
 @override_settings(
-    ANYMAIL_SPARKPOST_API_KEY=ANYMAIL_TEST_SPARKPOST_API_KEY,
-    EMAIL_BACKEND="anymail.backends.sparkpost.EmailBackend",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.sparkpost.EmailBackend",
+            "OPTIONS": {"api_key": ANYMAIL_TEST_SPARKPOST_API_KEY},
+        },
+    },
 )
 class SparkPostBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """SparkPost API integration tests
@@ -160,7 +164,14 @@ class SparkPostBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             recipient_status["to1@test.sink.sparkpostmail.com"].status, "queued"
         )
 
-    @override_settings(ANYMAIL_SPARKPOST_API_KEY="Hey, that's not an API key!")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.sparkpost.EmailBackend",
+                "OPTIONS": {"api_key": "Hey, that's not an API key!"},
+            },
+        },
+    )
     def test_invalid_api_key(self):
         with self.assertRaises(AnymailAPIError) as cm:
             self.message.send()

--- a/tests/test_unisender_go_backend.py
+++ b/tests/test_unisender_go_backend.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 from django.core import mail
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 from django.utils.timezone import (
     get_fixed_timezone,
     override as override_current_timezone,
@@ -27,16 +27,22 @@ from .utils import (
     AnymailTestMixin,
     create_text_attachment,
     decode_att,
+    ignore_fail_silently_warning,
+    override_settings,
     sample_image_content,
 )
 
 
 @tag("unisender_go")
 @override_settings(
-    EMAIL_BACKEND="anymail.backends.unisender_go.EmailBackend",
-    ANYMAIL={
-        "UNISENDER_GO_API_KEY": "test_api_key",
-        "UNISENDER_GO_API_URL": "https://go1.unisender.ru/ru/transactional/api/v1",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.unisender_go.EmailBackend",
+            "OPTIONS": {
+                "api_key": "test_api_key",
+                "api_url": "https://go1.unisender.ru/ru/transactional/api/v1",
+            },
+        },
     },
 )
 class UnisenderGoBackendMockAPITestCase(RequestsBackendMockAPITestCase):
@@ -104,7 +110,6 @@ class UnisenderGoBackendStandardEmailTests(UnisenderGoBackendMockAPITestCase):
             "Here is the message.",
             "from@sender.example.com",
             ["to@example.com"],
-            fail_silently=False,
         )
         self.assert_esp_called(
             "https://go1.unisender.ru/ru/transactional/api/v1/email/send.json"
@@ -371,6 +376,8 @@ class UnisenderGoBackendStandardEmailTests(UnisenderGoBackendMockAPITestCase):
         with self.assertRaisesMessage(AnymailAPIError, "Unisender Go API response 400"):
             mail.send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
 
+    @ignore_fail_silently_warning()
+    def test_api_failure_fail_silently(self):
         # Make sure fail_silently is respected
         self.set_mock_response(status_code=400)
         sent = mail.send_mail(
@@ -774,7 +781,18 @@ class UnisenderGoBackendAnymailFeatureTests(UnisenderGoBackendMockAPITestCase):
         self.assertEqual(recipient_status["spam-report@example.com"].status, "rejected")
         self.assertIsNone(recipient_status["spam-report@example.com"].message_id)
 
-    @override_settings(ANYMAIL_UNISENDER_GO_GENERATE_MESSAGE_ID=False)
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.unisender_go.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "test_api_key",
+                    "api_url": "https://go1.unisender.ru/ru/transactional/api/v1",
+                    "generate_message_id": False,
+                },
+            },
+        },
+    )
     def test_disable_generate_message_id(self):
         """
         When not generating per-recipient message_id,
@@ -796,6 +814,7 @@ class UnisenderGoBackendAnymailFeatureTests(UnisenderGoBackendMockAPITestCase):
         )
 
     # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
     def test_send_failed_anymail_status(self):
         """If the send fails, anymail_status should contain initial values"""
         self.set_mock_response(status_code=500)
@@ -836,6 +855,7 @@ class UnisenderGoBackendRecipientsRefusedTests(UnisenderGoBackendMockAPITestCase
         with self.assertRaises(AnymailRecipientsRefused):
             self.message.send()
 
+    @ignore_fail_silently_warning()
     def test_fail_silently(self):
         self.message.to = ["invalid@localhost", "reject@example.com"]
         self.set_mock_response(
@@ -895,12 +915,15 @@ class UnisenderGoBackendSessionSharingTestCase(
 
 
 @tag("unisender_go")
-@override_settings(EMAIL_BACKEND="anymail.backends.unisender_go.EmailBackend")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.unisender_go.EmailBackend"}},
+)
 class UnisenderGoBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
     """Test ESP backend without required settings in place"""
 
     def test_missing_auth(self):
         with self.assertRaisesRegex(
-            AnymailConfigurationError, r"\bUNISENDER_GO_API_KEY\b"
+            AnymailConfigurationError,
+            r"'api_key'|\bUNISENDER_GO_API_KEY.*ANYMAIL_UNISENDER_GO_API_KEY",
         ):
             mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])

--- a/tests/test_unisender_go_integration.py
+++ b/tests/test_unisender_go_integration.py
@@ -3,12 +3,12 @@ import unittest
 from datetime import datetime, timedelta
 from email.headerregistry import Address
 
-from django.test import SimpleTestCase, override_settings, tag
+from django.test import SimpleTestCase, tag
 
 from anymail.exceptions import AnymailAPIError
 from anymail.message import AnymailMessage
 
-from .utils import AnymailTestMixin
+from .utils import AnymailTestMixin, override_settings
 
 ANYMAIL_TEST_UNISENDER_GO_API_KEY = os.getenv("ANYMAIL_TEST_UNISENDER_GO_API_KEY")
 ANYMAIL_TEST_UNISENDER_GO_API_URL = os.getenv("ANYMAIL_TEST_UNISENDER_GO_API_URL")
@@ -28,9 +28,15 @@ ANYMAIL_TEST_UNISENDER_GO_TEMPLATE_ID = os.getenv(
     " integration tests",
 )
 @override_settings(
-    ANYMAIL_UNISENDER_GO_API_KEY=ANYMAIL_TEST_UNISENDER_GO_API_KEY,
-    ANYMAIL_UNISENDER_GO_API_URL=ANYMAIL_TEST_UNISENDER_GO_API_URL,
-    EMAIL_BACKEND="anymail.backends.unisender_go.EmailBackend",
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.unisender_go.EmailBackend",
+            "OPTIONS": {
+                "api_key": ANYMAIL_TEST_UNISENDER_GO_API_KEY,
+                "api_url": ANYMAIL_TEST_UNISENDER_GO_API_URL,
+            },
+        },
+    },
 )
 class UnisenderGoBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
     """
@@ -177,7 +183,17 @@ class UnisenderGoBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             recipient_status["test+to2@anymail.dev"].message_id,
         )
 
-    @override_settings(ANYMAIL_UNISENDER_GO_API_KEY="Hey, that's not an API key!")
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.unisender_go.EmailBackend",
+                "OPTIONS": {
+                    "api_key": "Hey, that's not an API key!",
+                    "api_url": ANYMAIL_TEST_UNISENDER_GO_API_URL,
+                },
+            },
+        },
+    )
     def test_invalid_api_key(self):
         # Make sure the exception message includes Unisender Go's response:
         with self.assertRaisesMessage(AnymailAPIError, "Can not decode key"):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,93 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.util import safe_repr
 
+import django.core.mail
 import django.test.client
+from django.test import ignore_warnings, override_settings as _override_settings
+from django.utils.module_loading import import_string
+
+from anymail.exceptions import AnymailImproperlyInstalled
+
+try:
+    from django.utils.deprecation import RemovedInDjango70Warning
+except ImportError:
+    RemovedInDjango70Warning = None
+
+
+def override_settings(**kwargs):
+    """
+    Wraps django.test.override_settings to translate MAILERS in older Django.
+
+    If the current Django version doesn't support the MAILERS setting (< 6.1),
+    convert MAILERS["default"] to EMAIL_BACKEND and ANYMAIL settings.
+    """
+    if "MAILERS" in kwargs and not hasattr(django.core.mail, "mailers"):
+        if "EMAIL_BACKEND" in kwargs:
+            raise ValueError("Cannot set both EMAIL_BACKEND and MAILERS")
+        mailers = kwargs.pop("MAILERS")
+        if set(mailers) != {"default"}:
+            raise ValueError("Don't know how to handle non-default MAILERS configs")
+        default = mailers["default"]
+        backend = default["BACKEND"]
+        kwargs["EMAIL_BACKEND"] = backend
+        if "OPTIONS" in default:
+            # Translate options to ANYMAIL = { "<ESP_NAME>_<OPTION_NAME>": value }
+            try:
+                backend_class = import_string(backend)
+            except AnymailImproperlyInstalled:
+                # Can occur during TestRunner init on test classes that will be skipped
+                # by tag filtering (e.g., AmazonSESBackendIntegrationTests in a tox
+                # *-mailgun env, when boto3 isn't installed). Restore original settings.
+                del kwargs["EMAIL_BACKEND"]
+                kwargs["MAILERS"] = mailers
+            else:
+                try:
+                    esp_name = backend_class.esp_name.replace(" ", "_")
+                except AttributeError:
+                    raise ValueError(
+                        f"Cannot determine ESP name for {backend!r}"
+                    ) from None
+                kwargs.setdefault("ANYMAIL", {}).update(
+                    {
+                        f"{esp_name}_{option}".upper(): value
+                        for option, value in default["OPTIONS"].items()
+                    }
+                )
+        else:
+            # Must clear any ANYMAIL from earlier override_settings calls.
+            kwargs.setdefault("ANYMAIL", {})
+    return _override_settings(**kwargs)
+
+
+# This helper can be replaced with `django.core.mail.mailers.default`
+# once the minimum supported version is Django 7.0.
+def get_default_mailer():
+    if hasattr(django.core.mail, "mailers"):
+        return django.core.mail.mailers.default
+    else:
+        return django.core.mail.get_connection()
+
+
+def ignore_fail_silently_warning():
+    if RemovedInDjango70Warning is not None:
+        return ignore_warnings(
+            category=RemovedInDjango70Warning,
+            message="The 'fail_silently' argument is deprecated.",
+        )
+    else:
+        # Noop decorator
+        return lambda f: f
+
+
+def ignore_connection_warnings():
+    if RemovedInDjango70Warning is not None:
+        return ignore_warnings(
+            category=RemovedInDjango70Warning,
+            message=r"(get_connection\(\)|The 'connection' argument) is deprecated.",
+        )
+    else:
+        # Noop decorator
+        return lambda f: f
 
 
 def decode_att(att):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -80,14 +80,21 @@ def get_default_mailer():
 
 
 def ignore_fail_silently_warning():
+    anymail_message = r"Anymail will drop support for fail_silently after Django 6.2."
     if RemovedInDjango70Warning is not None:
+        # Get lowest common superclass of RemovedInDjango70Warning, DeprecationWarning
+        # (which will vary by Django release, and might be Warning).
+        category = next(
+            cls
+            for cls in RemovedInDjango70Warning.__mro__
+            if cls in DeprecationWarning.__mro__
+        )
         return ignore_warnings(
-            category=RemovedInDjango70Warning,
-            message="The 'fail_silently' argument is deprecated.",
+            category=category,
+            message=rf"{anymail_message}|The 'fail_silently' argument is deprecated.",
         )
     else:
-        # Noop decorator
-        return lambda f: f
+        return ignore_warnings(category=DeprecationWarning, message=anymail_message)
 
 
 def ignore_connection_warnings():

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,10 @@ envlist =
     # Django 5.0: Python 3.10 (above), 3.11, and 3.12
     django50-py{311,312}-all
     # ... then pre-releases (if available) and current development:
-    # Django 6.1 dev: Python 3.12, 3.13, 3.14
-    djangoDev-py{312,313,314}-all
+    # Django 6.1: Python 3.12, 3.13, 3.14
+    django61-py{312,313,314}-all
+    # Django 6.2 dev: Python 3.12, 3.13, 3.14, 3.15
+    djangoDev-py{312,313,314,315}-all
     # ... then partial installation (limit extras):
     django60-py314-{none,amazon_ses,postal,resend,sendgrid}
     django60-py314-none-uts46
@@ -35,7 +37,8 @@ deps =
     django51: django~=5.1.0
     django52: django~=5.2.0
     django60: django~=6.0.0
-    # django61: django~=6.1.0a0
+    django61: django~=6.1.0a0
+    # django62: django~=6.2.0a0
     djangoDev: https://github.com/django/django/tarball/main
 extras =
     # Install [esp-name] extras only when testing "all" or esp_name factor.


### PR DESCRIPTION
* Enable testing on Django 6.1 prerelease builds
* Fix Amazon SES and Brevo backends to work with `MAILERS` OPTIONS
* Fully test `MAILERS` configuration and improve compatibility and error messages
* Deprecate `fail_silently`

Part of #472