### PR TITLE
fix(postmark): report unsupported feature for merge_data without template_id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,12 @@ Fixes
 * **Amazon SES, Brevo:** Fix ``InvalidMailer`` error about "Unknown options"
   when used with Django 6.1 ``MAILERS`` setting.
 
+* **Postmark:** Raise an unsupported feature error when ``merge_data`` or
+  ``merge_global_data`` is used without a ``template_id``. Anymail passes that
+  data to Postmark in its ``TemplateModel`` field, which is silently ignored
+  when sending through a non-template API. (Thanks to `@slinkymanbyday`_ for
+  reporting the issue and `@Sanjays2402`_ for the fix.)
+
 Other
 ~~~~~
 
@@ -2040,6 +2046,7 @@ Features
 .. _@puru02: https://github.com/puru02
 .. _@RignonNoel: https://github.com/RignonNoel
 .. _@rodrigondec: https://github.com/rodrigondec
+.. _@Sanjays2402: https://github.com/Sanjays2402
 .. _@sblondon: https://github.com/sblondon
 .. _@scur-iolus: https://github.com/scur-iolus
 .. _@sdarwin: https://github.com/sdarwin

--- a/anymail/backends/postmark.py
+++ b/anymail/backends/postmark.py
@@ -222,11 +222,7 @@ class PostmarkPayload(RequestsPayload):
 
     def get_api_endpoint(self):
         batch_send = self.is_batch()
-        if (
-            "TemplateAlias" in self.data
-            or "TemplateId" in self.data
-            or "TemplateModel" in self.data
-        ):
+        if "TemplateAlias" in self.data or "TemplateId" in self.data:
             if batch_send:
                 return "email/batchWithTemplates"
             else:
@@ -234,6 +230,11 @@ class PostmarkPayload(RequestsPayload):
                 # (Typo?)
                 return "email/withTemplate/"
         else:
+            # Postmark ignores TemplateModel unless using a template API.
+            if "TemplateModel" in self.data:
+                self.unsupported_feature("merge_global_data without template_id")
+            if self.merge_data:
+                self.unsupported_feature("merge_data without template_id")
             if batch_send:
                 return "email/batch"
             else:

--- a/docs/esps/postmark.rst
+++ b/docs/esps/postmark.rst
@@ -208,6 +208,13 @@ duplicated for *every* to-recipient.)
 If you want to use batch sending with a regular message (without a template), set
 merge data to an empty dict: `message.merge_data = {}`.
 
+Postmark only applies merge data through its template APIs, so non-empty
+:attr:`~anymail.message.AnymailMessage.merge_data` or
+:attr:`~anymail.message.AnymailMessage.merge_global_data` requires a
+:attr:`~anymail.message.AnymailMessage.template_id`. Anymail raises an
+:exc:`~anymail.exceptions.AnymailUnsupportedFeature` error otherwise, rather
+than sending a message where the merge data would be silently ignored.
+
 See this `Postmark blog post on templates`_ for more information.
 
 .. _Postmark blog post on templates:

--- a/tests/test_postmark_backend.py
+++ b/tests/test_postmark_backend.py
@@ -623,6 +623,39 @@ class PostmarkBackendAnymailFeatureTests(PostmarkBackendMockAPITestCase):
             "e2ecbbfc-fe12-463d-b933-9fe22915106d",
         )
 
+    def test_merge_data_without_template_unsupported(self):
+        # Postmark's batch send API ignores TemplateModel, so merge_data
+        # content can't be applied without an ESP template. (#470)
+        message = AnymailMessage(
+            from_email="from@example.com",
+            to=["alice@example.com", "Bob <bob@example.com>"],
+            subject="Test batch send",
+            body="Hello {{name}}",
+            merge_data={
+                "alice@example.com": {"name": "Alice"},
+                "bob@example.com": {"name": "Bob"},
+            },
+        )
+        with self.assertRaisesMessage(
+            AnymailUnsupportedFeature, "merge_data without template_id"
+        ):
+            message.send()
+
+    def test_merge_global_data_without_template_unsupported(self):
+        # Postmark ignores TemplateModel unless a template API is used, so
+        # merge_global_data can't be applied without an ESP template. (#470)
+        message = AnymailMessage(
+            from_email="from@example.com",
+            to=["alice@example.com"],
+            subject="Test",
+            body="Hello {{name}}",
+            merge_global_data={"name": "Alice"},
+        )
+        with self.assertRaisesMessage(
+            AnymailUnsupportedFeature, "merge_global_data without template_id"
+        ):
+            message.send()
+
     def test_merge_metadata(self):
         self.set_mock_response(raw=self._mock_batch_response)
         self.message.to = ["alice@example.com", "Bob <bob@example.com>"]


### PR DESCRIPTION
Fixes #470

Postmark's batch send API (`/email/batch`) ignores `TemplateModel`, so per-recipient `merge_data` sent without a `template_id` was silently dropped and recipients got the un-substituted body. `serialize_data` now raises `AnymailUnsupportedFeature` in that case, as suggested on the issue. `merge_data={}` still forces batch sending without a template.

New `test_merge_data_without_template_unsupported` fails without the backend change and passes with it; the rest of `tests.test_postmark_backend` (60 tests) is green.
