### PR TITLE
Add MailKite ESP backend (transactional send)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ Anymail currently supports these ESPs:
 * **MailerSend**
 * **Mailgun** (Sinch transactional email)
 * **Mailjet** (Sinch transactional email)
+* **MailKite** (inbound-first email platform)
 * **Mailtrap**
 * **Mandrill** (MailChimp transactional email)
 * **Postal** (self-hosted ESP)

--- a/anymail/backends/mailkite.py
+++ b/anymail/backends/mailkite.py
@@ -1,0 +1,215 @@
+import mimetypes
+
+from ..exceptions import AnymailRequestsAPIError
+from ..message import AnymailRecipientStatus
+from ..utils import (
+    BASIC_NUMERIC_TYPES,
+    CaseInsensitiveCasePreservingDict,
+    get_anymail_setting,
+)
+from .base_requests import AnymailRequestsBackend, RequestsPayload
+
+
+class EmailBackend(AnymailRequestsBackend):
+    """
+    MailKite (mailkite.dev) API Email Backend
+
+    MailKite is an inbound-first email platform: receive email as a webhook,
+    send with one API. This backend implements transactional *sending* through
+    MailKite's REST API. (Tracking and inbound webhook handling are not yet
+    implemented; see the PR notes.)
+    """
+
+    esp_name = "MailKite"
+
+    def __init__(self, **kwargs):
+        """Init options from Django settings"""
+        esp_name = self.esp_name
+        self.api_key = get_anymail_setting(
+            "api_key", esp_name=esp_name, kwargs=kwargs, allow_bare=True
+        )
+        api_url = get_anymail_setting(
+            "api_url",
+            esp_name=esp_name,
+            kwargs=kwargs,
+            default="https://api.mailkite.dev/",
+        )
+        if not api_url.endswith("/"):
+            api_url += "/"
+        super().__init__(api_url, **kwargs)
+
+    def build_message_payload(self, message, defaults):
+        return MailKitePayload(message, defaults, self)
+
+    def parse_recipient_status(self, response, payload, message):
+        parsed_response = self.deserialize_json_response(response, payload, message)
+        try:
+            message_id = parsed_response["id"]
+        except (KeyError, TypeError) as err:
+            raise AnymailRequestsAPIError(
+                "Invalid MailKite API response format",
+                email_message=message,
+                payload=payload,
+                response=response,
+                backend=self,
+            ) from err
+
+        # MailKite returns a single send-level status with the response id:
+        #   "sent"      -> accepted + handed to the provider for delivery
+        #   "scheduled" -> parked for a future "send later" drain
+        status = parsed_response.get("status", "sent")
+        recipient_status_name = "queued" if status == "scheduled" else "sent"
+
+        recipient_status = CaseInsensitiveCasePreservingDict(
+            {
+                recip.addr_spec: AnymailRecipientStatus(
+                    message_id=message_id, status=recipient_status_name
+                )
+                for recip in payload.recipients
+            }
+        )
+        return dict(recipient_status)
+
+
+class MailKitePayload(RequestsPayload):
+    def __init__(self, message, defaults, backend, *args, **kwargs):
+        self.recipients = []  # all to/cc/bcc, for parse_recipient_status
+        headers = kwargs.pop("headers", {})
+        headers["Authorization"] = "Bearer %s" % backend.api_key
+        headers["Content-Type"] = "application/json"
+        headers["Accept"] = "application/json"
+        super().__init__(message, defaults, backend, headers=headers, *args, **kwargs)
+
+    def get_api_endpoint(self):
+        # MailKite has a single send endpoint; there is no batch variant.
+        return "v1/send"
+
+    def serialize_data(self):
+        # MailKite's API takes a JSON body.
+        return self.serialize_json(self.data)
+
+    #
+    # Payload construction
+    #
+
+    def init_payload(self):
+        self.data = {}  # becomes json
+
+    def set_from_email(self, email):
+        # MailKite's `from` is a single address on a verified domain.
+        self.data["from"] = email.format(idna_encode=self.backend.idna_encode)
+
+    def set_recipients(self, recipient_type, emails):
+        assert recipient_type in ["to", "cc", "bcc"]
+        if emails:
+            self.data[recipient_type] = [
+                email.format(idna_encode=self.backend.idna_encode) for email in emails
+            ]
+            self.recipients += emails
+
+    def set_subject(self, subject):
+        self.data["subject"] = subject
+
+    def set_reply_to(self, emails):
+        # MailKite's `replyTo` is a single string. Comma-join multiple addresses
+        # into one RFC 5322 Reply-To value.
+        if emails:
+            self.data["replyTo"] = ", ".join(
+                [email.format(idna_encode=self.backend.idna_encode) for email in emails]
+            )
+
+    def set_extra_headers(self, headers):
+        # MailKite accepts extra raw MIME headers as a {name: value} object.
+        # Stringify ints/floats; anything else is the caller's responsibility.
+        self.data.setdefault("headers", {}).update(
+            {
+                k: str(v) if isinstance(v, BASIC_NUMERIC_TYPES) else v
+                for k, v in headers.items()
+            }
+        )
+
+    def set_text_body(self, body):
+        self.data["text"] = body
+
+    def set_html_body(self, body):
+        if "html" in self.data:
+            # second html body could show up through multiple alternatives,
+            # or html body + alternative
+            self.unsupported_feature("multiple html parts")
+        self.data["html"] = body
+
+    def make_attachment(self, attachment):
+        """Returns a MailKite attachment dict for an Anymail attachment"""
+        if attachment.inline:
+            # MailKite's send API attachment has no content-id / inline field,
+            # so inline (cid-referenced) attachments can't be expressed without
+            # silently breaking the reference. Surface it rather than mis-handle.
+            self.unsupported_feature("inline attachments")
+
+        # MailKite requires a filename. Generate one if Django didn't provide it.
+        filename = attachment.name or ""
+        if not filename:
+            ext = mimetypes.guess_extension(attachment.mimetype)
+            filename = "attachment%s" % ext if ext else "attachment"
+
+        att = {
+            "filename": filename,
+            "content": attachment.b64content,
+            "contentType": attachment.content_type,
+        }
+        return att
+
+    def set_attachments(self, attachments):
+        if attachments:
+            self.data["attachments"] = [
+                self.make_attachment(attachment) for attachment in attachments
+            ]
+
+    def set_send_at(self, send_at):
+        try:
+            # MailKite can't handle microseconds; truncate to milliseconds if necessary.
+            send_at = send_at.isoformat(
+                timespec="milliseconds" if send_at.microsecond else "seconds"
+            )
+        except AttributeError:
+            # User is responsible for formatting their own string
+            pass
+        self.data["scheduledAt"] = send_at
+
+    def set_template_id(self, template_id):
+        # MailKite templates are server-rendered from a saved template
+        # (user `tpl_…` or base `base_…`), filled via `templateData`.
+        self.data["templateId"] = template_id
+
+    def set_merge_global_data(self, merge_global_data):
+        # MailKite template merge variables (the {{merge_tags}} in a template).
+        self.data["templateData"] = merge_global_data
+
+    def set_track_opens(self, track_opens):
+        self.data["trackOpens"] = track_opens
+
+    # MailKite's send API has no dedicated tags, metadata, or per-recipient
+    # batch/merge fields. (Extra headers can carry ad-hoc X-… header values via
+    # `extra_headers` / `esp_extra`.)
+    def set_tags(self, tags):
+        self.unsupported_feature("tags")
+
+    def set_metadata(self, metadata):
+        self.unsupported_feature("metadata")
+
+    def set_merge_data(self, merge_data):
+        # Empty merge_data is a no-op request to hide the To list from other
+        # recipients; MailKite has no batch send, so it degrades to a single
+        # message with no per-recipient splitting. Any actual per-recipient data
+        # is unsupported.
+        if any(recipient_data for recipient_data in merge_data.values()):
+            self.unsupported_feature("merge_data")
+
+    def set_merge_metadata(self, merge_metadata):
+        self.unsupported_feature("merge_metadata")
+
+    def set_merge_headers(self, merge_headers):
+        self.unsupported_feature("merge_headers")
+
+    def set_esp_extra(self, extra):
+        self.data.update(extra)

--- a/docs/esps/esp-feature-matrix.csv
+++ b/docs/esps/esp-feature-matrix.csv
@@ -1,21 +1,21 @@
-Email Service Provider,:ref:`amazon-ses-backend`,:ref:`brevo-backend`,:ref:`mailersend-backend`,:ref:`mailgun-backend`,:ref:`mailjet-backend`,:ref:`mailtrap-backend`,:ref:`mandrill-backend`,:ref:`postal-backend`,:ref:`postmark-backend`,:ref:`resend-backend`,:ref:`scaleway-backend`,:ref:`sendgrid-backend`,:ref:`sparkpost-backend`,:ref:`unisender-go-backend`
-Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Full,Limited,Limited,Full,Full,Full,**Unsupported**,Full,Full
-.. rubric:: :ref:`Anymail send options <anymail-send-options>`,,,,,,,,,,,,,,
-:attr:`~AnymailMessage.envelope_sender`,Yes,No,No,Domain only,Yes,No,Domain only,Yes,No,No,No,No,Yes,No
-:attr:`~AnymailMessage.merge_headers`,Yes [#caveats]_,Yes,No,Yes,Yes,Yes,No,No,Yes,Yes,No,Yes,Yes [#caveats]_,Yes [#caveats]_
-:attr:`~AnymailMessage.metadata`,Yes,Yes,No,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_metadata`,Yes [#caveats]_,Yes,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,No,Yes,No,No,Yes,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.tags`,Yes,Yes,Yes,Yes,Max 1 tag,Max 1 tag,Yes,Max 1 tag,Max 1 tag,Yes,Yes,Yes,Max 1 tag,Yes
-:attr:`~AnymailMessage.track_clicks`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.track_opens`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
-:ref:`amp-email`,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,Yes
-.. rubric:: :ref:`templates-and-merge`,,,,,,,,,,,,,,
-:attr:`~AnymailMessage.template_id`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_global_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
-.. rubric:: :ref:`Status <esp-send-status>` and :ref:`event tracking <event-tracking>`,,,,,,,,,,,,,,
-:attr:`~AnymailMessage.anymail_status`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes
-:class:`~anymail.signals.AnymailTrackingEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Not yet,Yes,Yes,Yes
-.. rubric:: :ref:`Inbound handling <inbound>`,,,,,,,,,,,,,,
-:class:`~anymail.signals.AnymailInboundEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No
+Email Service Provider,:ref:`amazon-ses-backend`,:ref:`brevo-backend`,:ref:`mailersend-backend`,:ref:`mailgun-backend`,:ref:`mailjet-backend`,:ref:`mailkite-backend`,:ref:`mailtrap-backend`,:ref:`mandrill-backend`,:ref:`postal-backend`,:ref:`postmark-backend`,:ref:`resend-backend`,:ref:`scaleway-backend`,:ref:`sendgrid-backend`,:ref:`sparkpost-backend`,:ref:`unisender-go-backend`
+Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Unsupported,Full,Limited,Limited,Full,Full,Full,**Unsupported**,Full,Full
+.. rubric:: :ref:`Anymail send options <anymail-send-options>`,,,,,,,,,,,,,,,
+:attr:`~AnymailMessage.envelope_sender`,Yes,No,No,Domain only,Yes,No,No,Domain only,Yes,No,No,No,No,Yes,No
+:attr:`~AnymailMessage.merge_headers`,Yes [#caveats]_,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,No,Yes,Yes [#caveats]_,Yes [#caveats]_
+:attr:`~AnymailMessage.metadata`,Yes,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes
+:attr:`~AnymailMessage.merge_metadata`,Yes [#caveats]_,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.tags`,Yes,Yes,Yes,Yes,Max 1 tag,No,Max 1 tag,Yes,Max 1 tag,Max 1 tag,Yes,Yes,Yes,Max 1 tag,Yes
+:attr:`~AnymailMessage.track_clicks`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.track_opens`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,Yes,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
+:ref:`amp-email`,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,Yes
+.. rubric:: :ref:`templates-and-merge`,,,,,,,,,,,,,,,
+:attr:`~AnymailMessage.template_id`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.merge_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.merge_global_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
+.. rubric:: :ref:`Status <esp-send-status>` and :ref:`event tracking <event-tracking>`,,,,,,,,,,,,,,,
+:attr:`~AnymailMessage.anymail_status`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes
+:class:`~anymail.signals.AnymailTrackingEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,Not yet,Yes,Yes,Yes
+.. rubric:: :ref:`Inbound handling <inbound>`,,,,,,,,,,,,,,,
+:class:`~anymail.signals.AnymailInboundEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,No,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No

--- a/docs/esps/index.rst
+++ b/docs/esps/index.rst
@@ -17,6 +17,7 @@ and notes about any quirks or limitations:
    mailersend
    mailgun
    mailjet
+   mailkite
    mailtrap
    mandrill
    postal

--- a/docs/esps/mailkite.rst
+++ b/docs/esps/mailkite.rst
@@ -1,0 +1,165 @@
+.. _mailkite-backend:
+
+MailKite
+========
+
+Anymail integrates with the `MailKite`_ email platform, using its
+`send API`_ endpoint. MailKite is an *inbound-first* email service: it
+receives email as a webhook and sends transactional mail through a single
+API — useful if you want one vendor for both sending and (separately, planned)
+inbound handling.
+
+.. _MailKite: https://mailkite.dev/
+.. _send API: https://mailkite.dev/docs
+.. _MailKite API keys: https://app.mailkite.dev
+
+
+.. _mailkite-installation:
+
+Installation
+------------
+
+MailKite's send API is a standard JSON-over-HTTPS API, so Anymail's MailKite
+backend has no additional dependencies beyond Anymail's usual ``requests``
+package. Just install Anymail:
+
+.. code-block:: console
+
+    $ python -m pip install django-anymail
+
+
+Settings
+--------
+
+.. rubric:: EMAIL_BACKEND
+
+To use Anymail's MailKite backend, set:
+
+.. code-block:: python
+
+    EMAIL_BACKEND = "anymail.backends.mailkite.EmailBackend"
+
+in your settings.py.
+
+
+.. setting:: ANYMAIL_MAILKITE_API_KEY
+
+.. rubric:: MAILKITE_API_KEY
+
+Required for sending. A MailKite API key (`mk_live_…`) from your
+`MailKite API keys`_ page.
+
+.. code-block:: python
+
+    ANYMAIL = {
+        ...
+        "MAILKITE_API_KEY": "mk_live_...",
+    }
+
+Anymail will also look for ``MAILKITE_API_KEY`` at the root of the settings
+file if neither ``ANYMAIL["MAILKITE_API_KEY"]`` nor
+``ANYMAIL_MAILKITE_API_KEY`` is set.
+
+
+.. setting:: ANYMAIL_MAILKITE_API_URL
+
+.. rubric:: MAILKITE_API_URL
+
+The base url for calling the MailKite API.
+
+The default is ``MAILKITE_API_URL = "https://api.mailkite.dev/"``.
+(It's unlikely you would need to change this.)
+
+
+.. _mailkite-quirks:
+
+Limitations and quirks
+----------------------
+
+Anymail normally raises an :exc:`~anymail.exceptions.AnymailUnsupportedFeature`
+error when you try to send a message using features the backend doesn't (yet)
+support. You can tell Anymail to suppress these errors and send the messages
+anyway — see :ref:`unsupported-features`.
+
+**No inline attachments**
+  MailKite's send API does not currently expose a content-id / inline field on
+  attachments, so Anymail can't express inline (``cid:``-referenced) images.
+  Trying to send one raises an
+  :exc:`~anymail.exceptions.AnymailUnsupportedFeature` error. Regular
+  (non-inline) attachments are fully supported.
+
+**No tags or metadata**
+  MailKite's send API has no dedicated ``tags`` or ``metadata`` fields, so
+  Anymail's normalized :attr:`~anymail.message.AnymailMessage.tags` and
+  :attr:`~anymail.message.AnymailMessage.metadata` attributes are unsupported.
+  (If you need to pass arbitrary key/value data on a send, you can attach it
+  as a custom header via :attr:`~anymail.message.AnymailMessage.extra_headers`
+  or :ref:`esp_extra <mailkite-esp-extra>` — but note custom headers may be
+  visible to recipients via "show original".)
+
+**No batch sending / per-recipient merge data**
+  MailKite has a single send endpoint (no batch variant) and no per-recipient
+  merge, so Anymail's :attr:`~anymail.message.AnymailMessage.merge_data`,
+  :attr:`~anymail.message.AnymailMessage.merge_metadata`, and
+  :attr:`~anymail.message.AnymailMessage.merge_headers` are unsupported.
+  (Setting ``merge_data`` to an empty dict is allowed as a no-op — it just
+  sends one message to all recipients, without hiding the *To* list.)
+
+**reply_to is a single address**
+  MailKite's ``replyTo`` is a single address. If you supply multiple reply-to
+  addresses, Anymail joins them into a single comma-separated ``Reply-To``
+  value.
+
+**No envelope sender**
+  MailKite does not support specifying the
+  :attr:`~anymail.message.AnymailMessage.envelope_sender`.
+
+**Status tracking and inbound webhooks**
+  MailKite itself supports both delivery tracking and inbound email (received
+  messages delivered as signed webhooks). Wiring those into Anymail's
+  :ref:`status tracking <event-tracking>` and :ref:`inbound <inbound>` signals
+  is not part of this initial send backend — it's the planned next step.
+
+
+.. _mailkite-esp-extra:
+
+esp_extra support
+-----------------
+
+Anymail's MailKite backend passes
+:attr:`~anymail.message.AnymailMessage.esp_extra` values directly into the
+MailKite `send API`_ JSON body. This is the way to reach MailKite-specific
+fields that don't map to a normalized Anymail attribute — for example
+``inReplyTo`` (to thread a reply under an existing Message-ID) or
+``trackOpens``:
+
+.. code-block:: python
+
+    message = AnymailMessage(...)
+    message.esp_extra = {
+        # Thread this message under an earlier one (sets In-Reply-To/References):
+        "inReplyTo": "<original.message@example.com>",
+    }
+
+
+.. _mailkite-templates:
+
+Templates
+---------
+
+MailKite supports server-rendered templates: a saved template
+(``tpl_…``) or a built-in base template (``base_…``) supplies the subject,
+html and/or text, and ``templateData`` fills its ``{{merge_tags}}``.
+
+Use Anymail's normalized :attr:`~anymail.message.AnymailMessage.template_id`
+and :attr:`~anymail.message.AnymailMessage.merge_global_data` attributes:
+
+.. code-block:: python
+
+    message = AnymailMessage(
+        from_email="orders@example.com",
+        to="customer@example.com",
+        template_id="tpl_receipt",
+        merge_global_data={"name": "Sam", "order_no": "1024"},
+    )
+    message.send()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = """\
 Django email backends and webhooks for Amazon SES, Brevo,
- MailerSend, Mailgun, Mailjet, Mailtrap, Mandrill, Postal, Postmark, Resend,
+ MailerSend, Mailgun, Mailjet, MailKite, Mailtrap, Mandrill, Postal, Postmark, Resend,
  Scaleway TEM, SendGrid, SparkPost, and Unisender Go
  (EmailBackend, transactional email tracking and inbound email signals)\
 """
@@ -27,6 +27,7 @@ keywords = [
     "Brevo", "SendinBlue",
     "MailerSend",
     "Mailgun", "Mailjet", "Sinch",
+    "MailKite",
     "Mailtrap",
     "Mandrill", "MailChimp",
     "Postal",
@@ -78,6 +79,7 @@ brevo = []
 mailersend = []
 mailgun = []
 mailjet = []
+mailkite = []
 mailtrap = []
 mandrill = []
 postal = ["cryptography"]

--- a/tests/test_mailkite_backend.py
+++ b/tests/test_mailkite_backend.py
@@ -1,0 +1,363 @@
+from datetime import date, datetime
+
+from django.core import mail
+from django.test import SimpleTestCase, tag
+from django.utils.timezone import (
+    get_fixed_timezone,
+    override as override_current_timezone,
+)
+
+from anymail.exceptions import (
+    AnymailAPIError,
+    AnymailConfigurationError,
+    AnymailUnsupportedFeature,
+)
+from anymail.message import AnymailMessage, attach_inline_image
+
+from .mock_requests_backend import RequestsBackendMockAPITestCase
+from .utils import (
+    AnymailTestMixin,
+    create_text_attachment,
+    decode_att,
+    override_settings,
+    sample_image_content,
+)
+
+
+@tag("mailkite")
+@override_settings(
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailkite.EmailBackend",
+            "OPTIONS": {"api_key": "test_api_key"},
+        },
+    },
+)
+class MailKiteBackendMockAPITestCase(RequestsBackendMockAPITestCase):
+    DEFAULT_RAW_RESPONSE = (
+        b'{"id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "status": "sent"}'
+    )
+
+    def setUp(self):
+        super().setUp()
+        # Simple message useful for many tests
+        self.message = mail.EmailMultiAlternatives(
+            "Subject", "Text Body", "from@example.com", ["to@example.com"]
+        )
+
+
+@tag("mailkite")
+class MailKiteBackendStandardEmailTests(MailKiteBackendMockAPITestCase):
+    """Test backend support for Django standard email features"""
+
+    def test_send_mail(self):
+        """Test basic API for simple send"""
+        mail.send_mail(
+            "Subject here",
+            "Here is the message.",
+            "from@sender.example.com",
+            ["to@example.com"],
+        )
+        self.assert_esp_called("https://api.mailkite.dev/v1/send")
+        headers = self.get_api_call_headers()
+        self.assertEqual(headers["Authorization"], "Bearer test_api_key")
+        data = self.get_api_call_json()
+        self.assertEqual(data["subject"], "Subject here")
+        self.assertEqual(data["text"], "Here is the message.")
+        self.assertEqual(data["from"], "from@sender.example.com")
+        self.assertEqual(data["to"], ["to@example.com"])
+
+    def test_name_addr(self):
+        """Make sure RFC2822 name-addr format (with display-name) is allowed"""
+        msg = mail.EmailMessage(
+            "Subject",
+            "Message",
+            "From Name <from@example.com>",
+            ["Recipient #1 <to1@example.com>", "to2@example.com"],
+            cc=["Carbon Copy <cc1@example.com>", "cc2@example.com"],
+            bcc=["Blind Copy <bcc1@example.com>", "bcc2@example.com"],
+        )
+        msg.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["from"], "From Name <from@example.com>")
+        self.assertEqual(
+            data["to"],
+            ["Recipient #1 <to1@example.com>", "to2@example.com"],
+        )
+        self.assertEqual(
+            data["cc"], ["Carbon Copy <cc1@example.com>", "cc2@example.com"]
+        )
+        self.assertEqual(
+            data["bcc"], ["Blind Copy <bcc1@example.com>", "bcc2@example.com"]
+        )
+
+    def test_html_message(self):
+        msg = mail.EmailMultiAlternatives(
+            "Subject", "Text Body", "from@example.com", ["to@example.com"]
+        )
+        msg.attach_alternative("<p>HTML body</p>", "text/html")
+        msg.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["text"], "Text Body")
+        self.assertEqual(data["html"], "<p>HTML body</p>")
+
+    def test_reply_to(self):
+        # MailKite's replyTo is a single string; multiple addresses are
+        # comma-joined into one Reply-To value.
+        email = mail.EmailMessage(
+            "Subject",
+            "Body goes here",
+            "from@example.com",
+            ["to1@example.com"],
+            reply_to=["reply@example.com", "Other <reply2@example.com>"],
+        )
+        email.send()
+        data = self.get_api_call_json()
+        self.assertEqual(
+            data["replyTo"], "reply@example.com, Other <reply2@example.com>"
+        )
+
+    def test_extra_headers(self):
+        email = mail.EmailMessage(
+            "Subject",
+            "Body",
+            "from@example.com",
+            ["to@example.com"],
+            headers={"X-Extra": "extra value"},
+        )
+        email.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["headers"], {"X-Extra": "extra value"})
+
+    def test_extra_headers_numeric(self):
+        # MailKite (like the API generally) wants header values as strings.
+        email = mail.EmailMessage(
+            "Subject",
+            "Body",
+            "from@example.com",
+            ["to@example.com"],
+            headers={"X-Count": 4, "X-Rate": 1.5},
+        )
+        email.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["headers"], {"X-Count": "4", "X-Rate": "1.5"})
+
+    def test_attachments(self):
+        text_content = "pièce jointe\n"
+        self.message.attach(
+            create_text_attachment("pièce jointe\n", charset="iso-8859-1")
+        )
+        self.message.attach("émoticône.img", b";-)", "image/x-emoticon")
+
+        self.message.send()
+        data = self.get_api_call_json()
+
+        attachments = data["attachments"]
+        self.assertEqual(len(attachments), 2)
+
+        self.assertEqual(
+            attachments[0]["contentType"], 'text/plain; charset="iso-8859-1"'
+        )
+        self.assertEqual(attachments[0]["filename"], "attachment.txt")  # generated
+        self.assertEqual(
+            decode_att(attachments[0]["content"]).decode("iso-8859-1"), text_content
+        )
+
+        self.assertEqual(attachments[1]["contentType"], "image/x-emoticon")
+        self.assertEqual(attachments[1]["filename"], "émoticône.img")
+        self.assertEqual(decode_att(attachments[1]["content"]), b";-)")
+
+    def test_inline_attachments_unsupported(self):
+        # MailKite's send API attachment has no content-id / inline field, so
+        # inline (cid-referenced) attachments can't be expressed.
+        attach_inline_image(self.message, sample_image_content(), "test.png")
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "inline attachments"):
+            self.message.send()
+
+
+@tag("mailkite")
+class MailKiteBackendAnymailFeatureTests(MailKiteBackendMockAPITestCase):
+    """Test backend support for Anymail added features"""
+
+    def test_template_id(self):
+        # MailKite server-rendered templates: templateId (+ templateData).
+        message = AnymailMessage(
+            "Subject",
+            "Text Body",
+            "from@example.com",
+            ["to@example.com"],
+            template_id="tpl_abc123",
+            merge_global_data={"name": "Sam", "plan": "Pro"},
+        )
+        message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["templateId"], "tpl_abc123")
+        self.assertEqual(data["templateData"], {"name": "Sam", "plan": "Pro"})
+
+    def test_send_at(self):
+        utc_plus_6 = get_fixed_timezone(6 * 60)
+        utc_minus_8 = get_fixed_timezone(-8 * 60)
+
+        with override_current_timezone(utc_plus_6):
+            # Timezone-naive datetime assumed to be Django current_timezone
+            self.message.send_at = datetime(2022, 10, 11, 12, 13, 14, 123456)
+            self.message.send()
+            data = self.get_api_call_json()
+            self.assertEqual(data["scheduledAt"], "2022-10-11T12:13:14.123+06:00")
+
+            # Timezone-aware datetime converted to UTC:
+            self.message.send_at = datetime(2016, 3, 4, 5, 6, 7, tzinfo=utc_minus_8)
+            self.message.send()
+            data = self.get_api_call_json()
+            self.assertEqual(data["scheduledAt"], "2016-03-04T05:06:07-08:00")
+
+            # Date-only treated as midnight in current timezone
+            self.message.send_at = date(2022, 10, 22)
+            self.message.send()
+            data = self.get_api_call_json()
+            self.assertEqual(data["scheduledAt"], "2022-10-22T00:00:00+06:00")
+
+            # String passed unchanged (this is *not* portable between ESPs)
+            self.message.send_at = "2013-11-12T01:02:03Z"
+            self.message.send()
+            data = self.get_api_call_json()
+            self.assertEqual(data["scheduledAt"], "2013-11-12T01:02:03Z")
+
+    def test_track_opens(self):
+        self.message.track_opens = True
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["trackOpens"], True)
+
+    def test_unsupported_tags(self):
+        self.message.tags = ["receipt"]
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "tags"):
+            self.message.send()
+
+    def test_unsupported_metadata(self):
+        self.message.metadata = {"order_id": "123"}
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "metadata"):
+            self.message.send()
+
+    def test_unsupported_merge_data(self):
+        self.message.merge_data = {
+            "alice@example.com": {"name": "Alice"},
+            "bob@example.com": {"name": "Bob"},
+        }
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "merge_data"):
+            self.message.send()
+
+    def test_empty_merge_data_allowed(self):
+        # Empty merge_data is a no-op (MailKite has no batch send, so it just
+        # degrades to a single message). It must not raise.
+        self.message.merge_data = {}
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertNotIn("templateData", data)
+
+    def test_esp_extra(self):
+        # esp_extra is merged into the API payload (e.g. inReplyTo for threading)
+        message = AnymailMessage(
+            "Subject",
+            "Text Body",
+            "from@example.com",
+            ["to@example.com"],
+            esp_extra={"inReplyTo": "<original@example.com>"},
+        )
+        message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["inReplyTo"], "<original@example.com>")
+
+
+@tag("mailkite")
+class MailKiteBackendRecipientsStatusTests(MailKiteBackendMockAPITestCase):
+    """Test the recipient status parsing for various responses"""
+
+    def test_send_attaches_anymail_status(self):
+        """The anymail_status should be attached to the message when it is sent"""
+        msg = mail.EmailMessage(
+            "Subject",
+            "Message",
+            "from@example.com",
+            ["Recipient <to1@example.com>"],
+        )
+        sent = msg.send()
+        self.assertEqual(sent, 1)
+        self.assertEqual(msg.anymail_status.status, {"sent"})
+        self.assertEqual(
+            msg.anymail_status.message_id, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        )
+        self.assertEqual(
+            msg.anymail_status.recipients["to1@example.com"].status, "sent"
+        )
+        self.assertEqual(
+            msg.anymail_status.recipients["to1@example.com"].message_id,
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        )
+        self.assertEqual(
+            msg.anymail_status.esp_response.content, self.DEFAULT_RAW_RESPONSE
+        )
+
+    def test_scheduled_status(self):
+        """A 'scheduled' response marks recipients as queued"""
+        self.set_mock_response(raw=b'{"id": "sched_123", "status": "scheduled"}')
+        msg = mail.EmailMessage(
+            "Subject", "Message", "from@example.com", ["to@example.com"]
+        )
+        msg.send()
+        self.assertEqual(msg.anymail_status.status, {"queued"})
+        self.assertEqual(msg.anymail_status.message_id, "sched_123")
+
+    def test_all_recipients_share_message_id(self):
+        msg = mail.EmailMessage(
+            "Subject",
+            "Message",
+            "from@example.com",
+            ["to1@example.com", "to2@example.com"],
+            cc=["cc@example.com"],
+            bcc=["bcc@example.com"],
+        )
+        msg.send()
+        recipients = msg.anymail_status.recipients
+        # MailKite returns a single send-level message id shared by all recipients
+        for addr in [
+            "to1@example.com",
+            "to2@example.com",
+            "cc@example.com",
+            "bcc@example.com",
+        ]:
+            self.assertEqual(recipients[addr].message_id, msg.anymail_status.message_id)
+            self.assertEqual(recipients[addr].status, "sent")
+
+    def test_invalid_response_raises(self):
+        self.set_mock_response(raw=b'{"unexpected": "format"}')
+        msg = mail.EmailMessage(
+            "Subject", "Message", "from@example.com", ["to@example.com"]
+        )
+        with self.assertRaises(AnymailAPIError):
+            msg.send()
+
+    def test_send_failed_anymail_status(self):
+        msg = mail.EmailMessage(
+            "Subject", "Message", "from@example.com", ["to@example.com"]
+        )
+        self.set_mock_response(status_code=500)
+        with self.assertRaises(AnymailAPIError):
+            msg.send()
+        self.assertIsNone(msg.anymail_status.status)
+        self.assertIsNone(msg.anymail_status.message_id)
+
+
+@tag("mailkite")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.mailkite.EmailBackend"}},
+)
+class MailKiteBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
+    """Test ESP backend without required settings in place"""
+
+    def test_missing_api_key(self):
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'api_key'|\bMAILKITE_API_KEY.*ANYMAIL_MAILKITE_API_KEY",
+        ):
+            mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ setenv =
     mailersend: ANYMAIL_ONLY_TEST=mailersend
     mailgun: ANYMAIL_ONLY_TEST=mailgun
     mailjet: ANYMAIL_ONLY_TEST=mailjet
+    mailkite: ANYMAIL_ONLY_TEST=mailkite
     mailtrap: ANYMAIL_ONLY_TEST=mailtrap
     mandrill: ANYMAIL_ONLY_TEST=mandrill
     postal: ANYMAIL_ONLY_TEST=postal


### PR DESCRIPTION
This adds support for **MailKite** (https://mailkite.dev) as an Anymail ESP, following `ADDING_ESPS.md`. I'm opening this on behalf of MailKite, and happy to maintain the backend going forward.

MailKite is a transactional ESP with a straightforward JSON-over-HTTPS send API (`POST /v1/send`, Bearer auth). The backend is modeled on the existing **Resend** backend, which is the closest modern JSON/REST analog in the tree.

## What's included

**Backend** — `anymail/backends/mailkite.py`
`AnymailRequestsBackend` + `RequestsPayload`. Supported:
- `from` / `to` / `cc` / `bcc`, `subject`, text + html bodies
- `reply_to` (MailKite's `replyTo` is a single string — multiple addresses are comma-joined into one `Reply-To`)
- `extra_headers` (raw MIME header object), `attachments` (filename is required by the API; generated from mimetype if absent)
- `send_at` → `scheduledAt` (MailKite supports "send later")
- `template_id` + `merge_global_data` → `templateId` / `templateData` (server-rendered templates)
- `track_opens`, and `esp_extra` passed straight into the JSON body

Unsupported — surfaced as `AnymailUnsupportedFeature` rather than mis-handled:
- **inline attachments** — MailKite's send API has no content-id / inline field on attachments, so `cid:`-referenced images can't be expressed without silently breaking the reference
- **tags** and **metadata** — the API has no dedicated fields (custom headers remain available via `extra_headers`/`esp_extra`)
- **`merge_data` / `merge_metadata` / `merge_headers`** — single send endpoint, no per-recipient batch (empty `merge_data` is allowed as a no-op, consistent with the other backends)

Recipient status is parsed from MailKite's `{id, status}` response (`sent` → sent, `scheduled` → queued).

## Tests
`tests/test_mailkite_backend.py` — 22 mock tests covering standard Django email features, the Anymail-specific features, recipient-status parsing (both `sent` and `scheduled` responses), configuration errors, and each unsupported feature. All pass under Django 6.0 / Python 3.13:

```
$ python runtests.py tests.test_mailkite_backend
Ran 22 tests in 0.049s
OK
```

## Docs
`docs/esps/mailkite.rst` (install, settings, quirks, `esp_extra`, templates), added to the ESP toctree and the `esp-feature-matrix.csv`.

## Boilerplate
`pyproject.toml` (description, keywords, `[mailkite]` extra — no extra deps), `tox.ini` (test factor), per `ADDING_ESPS.md`.

## Deliberately out of scope (planned follow-ups)
- **Tracking and inbound webhooks.** MailKite itself supports both delivery tracking and inbound email (received messages delivered as signed webhooks); wiring those into Anymail's tracking/inbound signals is the natural next PR. The feature-matrix reflects that (tracking/inbound rows = "No" for now).
- **Live integration tests.** Would need a CI testing account / sandbox; happy to set that up if you'd like to move the support-status from "Unsupported" to "Full".

Happy to adjust anything to match your conventions. Thanks for Anymail — the extension points made this very pleasant to implement.
