### PR TITLE
Add MailKite email backend (transactional send)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,6 +48,7 @@ jobs:
           - { tox: django60-py314-mailersend, python: "3.14" }
           - { tox: django60-py314-mailgun, python: "3.14" }
           - { tox: django60-py314-mailjet, python: "3.14" }
+          - { tox: django60-py314-mailkite, python: "3.14" }
           - { tox: django60-py314-mailtrap, python: "3.14" }
           - { tox: django60-py314-mandrill, python: "3.14" }
           - { tox: django60-py314-postal, python: "3.14" }
@@ -96,6 +97,8 @@ jobs:
           ANYMAIL_TEST_MAILJET_DOMAIN: ${{ vars.ANYMAIL_TEST_MAILJET_DOMAIN }}
           ANYMAIL_TEST_MAILJET_SECRET_KEY: ${{ secrets.ANYMAIL_TEST_MAILJET_SECRET_KEY }}
           ANYMAIL_TEST_MAILJET_TEMPLATE_ID: ${{ vars.ANYMAIL_TEST_MAILJET_TEMPLATE_ID }}
+          ANYMAIL_TEST_MAILKITE_API_KEY: ${{ secrets.ANYMAIL_TEST_MAILKITE_API_KEY }}
+          ANYMAIL_TEST_MAILKITE_DOMAIN: ${{ vars.ANYMAIL_TEST_MAILKITE_DOMAIN }}
           ANYMAIL_TEST_MAILTRAP_API_TOKEN: ${{ secrets.ANYMAIL_TEST_MAILTRAP_API_TOKEN }}
           ANYMAIL_TEST_MAILTRAP_DOMAIN: ${{ vars.ANYMAIL_TEST_MAILTRAP_DOMAIN }}
           ANYMAIL_TEST_MAILTRAP_SANDBOX_ID: ${{ vars.ANYMAIL_TEST_MAILTRAP_SANDBOX_ID }}

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ Anymail currently supports these ESPs:
 * **MailerSend**
 * **Mailgun** (Sinch transactional email)
 * **Mailjet** (Sinch transactional email)
+* **MailKite**
 * **Mailtrap**
 * **Mandrill** (MailChimp transactional email)
 * **Postal** (self-hosted ESP)

--- a/anymail/backends/mailkite.py
+++ b/anymail/backends/mailkite.py
@@ -198,9 +198,13 @@ class MailKitePayload(RequestsPayload):
             pass
         self.data["scheduledAt"] = send_at
 
-    # MailKite's /v1/send endpoint has no per-message tracking toggle.
+    def set_track_opens(self, track_opens):
+        # Per-send open-tracking override (HTML messages only). When omitted,
+        # the from-domain's default applies.
+        self.data["trackOpens"] = track_opens
+
+    # MailKite's /v1/send endpoint has no per-message click-tracking toggle.
     # def set_track_clicks(self, track_clicks):
-    # def set_track_opens(self, track_opens):
     # def set_envelope_sender(self, envelope_sender):
 
     def set_template_id(self, template_id):

--- a/anymail/backends/mailkite.py
+++ b/anymail/backends/mailkite.py
@@ -273,8 +273,12 @@ class MailKitePayload(RequestsPayload):
         # the from-domain's default applies.
         self.data["trackOpens"] = track_opens
 
-    # MailKite's /v1/send endpoint has no per-message click-tracking toggle.
-    # def set_track_clicks(self, track_clicks):
+    def set_track_clicks(self, track_clicks):
+        # Per-send click-tracking override (HTML messages only): MailKite
+        # rewrites links to a signed redirect that records the click. When
+        # omitted, the from-domain's default applies.
+        self.data["trackClicks"] = track_clicks
+
     # def set_envelope_sender(self, envelope_sender):
 
     def set_template_id(self, template_id):

--- a/anymail/backends/mailkite.py
+++ b/anymail/backends/mailkite.py
@@ -53,6 +53,34 @@ class EmailBackend(AnymailRequestsBackend):
 
     def parse_recipient_status(self, response, payload, message):
         parsed_response = self.deserialize_json_response(response, payload, message)
+
+        if isinstance(parsed_response, dict) and "results" in parsed_response:
+            # Batch send: per-recipient outcomes, in the same order as the
+            # recipients we posted. A batch can partially succeed -- failed
+            # recipients get status "failed" (no exception is raised).
+            results = parsed_response["results"]
+            if not isinstance(results, list) or len(results) != len(
+                payload.to_recipients
+            ):
+                raise AnymailRequestsAPIError(
+                    "Invalid MailKite API batch response format",
+                    email_message=message,
+                    payload=payload,
+                    response=response,
+                    backend=self,
+                )
+            recipient_status = CaseInsensitiveCasePreservingDict()
+            for recip, result in zip(payload.to_recipients, results):
+                status = result.get("status", DEFAULT_RESPONSE_STATUS)
+                if status == "failed" and result.get("code") == "recipient_suppressed":
+                    # unsubscribed / bounced / complained address
+                    status = "rejected"
+                status = RESPONSE_STATUS_MAP.get(status, status)
+                recipient_status[recip.addr_spec] = AnymailRecipientStatus(
+                    message_id=result.get("id"), status=status
+                )
+            return dict(recipient_status)
+
         try:
             message_id = parsed_response["id"]
             status = parsed_response.get("status", DEFAULT_RESPONSE_STATUS)
@@ -81,6 +109,11 @@ class EmailBackend(AnymailRequestsBackend):
 class MailKitePayload(RequestsPayload):
     def __init__(self, message, defaults, backend, *args, **kwargs):
         self.recipients = []  # for parse_recipient_status
+        self.to_recipients = []  # `to` only, for batch fan-out
+        self.metadata = None  # needed to merge with merge_metadata in batch
+        self.merge_data = {}
+        self.merge_metadata = {}
+        self.merge_headers = {}
         headers = kwargs.pop("headers", {})
         headers["Authorization"] = "Bearer %s" % backend.api_key
         headers["Content-Type"] = "application/json"
@@ -88,11 +121,45 @@ class MailKitePayload(RequestsPayload):
         super().__init__(message, defaults, backend, headers=headers, *args, **kwargs)
 
     def get_api_endpoint(self):
-        # MailKite has a single send endpoint; there is no separate batch API.
+        if self.is_batch():
+            # One personalized message per `to` recipient.
+            return "v1/send/batch"
         return "v1/send"
 
     def serialize_data(self):
+        if self.is_batch():
+            self.restructure_data_for_batch()
         return self.serialize_json(self.data)
+
+    def restructure_data_for_batch(self):
+        """Convert the single-send payload to MailKite's batch-send shape"""
+        # Shared fields (from/subject/html/text/templateId/templateData/headers/
+        # replyTo/attachments/scheduledAt/...) stay as built; the `to` list
+        # becomes recipients[], each entry carrying its own templateData and
+        # headers merged over the shared ones (per-recipient wins).
+        if "cc" in self.data or "bcc" in self.data:
+            # Batch sends one message per `to` recipient; there is no cc/bcc.
+            self.unsupported_feature("cc or bcc with batch send")
+        self.data.pop("to", None)
+        recipients = []
+        for email in self.to_recipients:
+            recipient = {"to": email.format(idna_encode=self.backend.idna_encode)}
+            recipient_data = self.merge_data.get(email.addr_spec)
+            if recipient_data:
+                recipient["templateData"] = recipient_data
+            headers = {}
+            if email.addr_spec in self.merge_metadata:
+                # Anymail semantics: this recipient's metadata is `metadata`
+                # updated with their merge_metadata entry.
+                recipient_metadata = dict(self.metadata or {})
+                recipient_metadata.update(self.merge_metadata[email.addr_spec])
+                headers["X-Metadata"] = self.serialize_json(recipient_metadata)
+            if email.addr_spec in self.merge_headers:
+                headers.update(self.merge_headers[email.addr_spec])
+            if headers:
+                recipient["headers"] = headers
+            recipients.append(recipient)
+        self.data["recipients"] = recipients
 
     #
     # Payload construction
@@ -112,6 +179,8 @@ class MailKitePayload(RequestsPayload):
                 email.format(idna_encode=self.backend.idna_encode) for email in emails
             ]
             self.recipients += emails
+            if recipient_type == "to":
+                self.to_recipients = emails
 
     def set_subject(self, subject):
         self.data["subject"] = subject
@@ -181,6 +250,7 @@ class MailKitePayload(RequestsPayload):
         self.data.setdefault("headers", {})["X-Metadata"] = self.serialize_json(
             metadata
         )
+        self.metadata = metadata  # merged with merge_metadata in a batch send
 
     def set_tags(self, tags):
         # MailKite has no tags field; carry them as JSON in a custom header.
@@ -214,11 +284,20 @@ class MailKitePayload(RequestsPayload):
         # MailKite renders templates server-side from templateData.
         self.data["templateData"] = merge_global_data
 
+    # Setting any of merge_data / merge_metadata / merge_headers switches to
+    # MailKite's batch-send endpoint: one personalized message per `to`
+    # recipient, with per-recipient values merged over the shared ones.
+    # The payload is restructured in serialize_data (see
+    # restructure_data_for_batch), once every attribute has been processed.
+
     def set_merge_data(self, merge_data):
-        # MailKite sends a single message to all recipients (not one per
-        # recipient), so per-recipient merge data can't be expressed.
-        if any(recipient_data for recipient_data in merge_data.values()):
-            self.unsupported_feature("merge_data")
+        self.merge_data = merge_data
+
+    def set_merge_metadata(self, merge_metadata):
+        self.merge_metadata = merge_metadata
+
+    def set_merge_headers(self, merge_headers):
+        self.merge_headers = merge_headers
 
     def set_esp_extra(self, extra):
         self.data.update(extra)

--- a/anymail/backends/mailkite.py
+++ b/anymail/backends/mailkite.py
@@ -11,9 +11,12 @@ from .base_requests import AnymailRequestsBackend, RequestsPayload
 
 # MailKite message status values returned from the send endpoint, mapped to
 # Anymail's normalized recipient statuses. The API documents the send response
-# as ``{"id": "...", "status": "..."}`` (e.g. ``"queued"``); we pass the status
-# through as-is, defaulting to ``"queued"`` when the ESP omits it.
+# as ``{"id": "...", "status": "..."}`` (e.g. ``"queued"``, or ``"scheduled"``
+# for a send_at message parked for later delivery); we normalize ``"scheduled"``
+# to Anymail's ``"queued"`` and pass other statuses through as-is, defaulting
+# to ``"queued"`` when the ESP omits the status.
 DEFAULT_RESPONSE_STATUS = "queued"
+RESPONSE_STATUS_MAP = {"scheduled": "queued"}
 
 
 class EmailBackend(AnymailRequestsBackend):
@@ -53,6 +56,7 @@ class EmailBackend(AnymailRequestsBackend):
         try:
             message_id = parsed_response["id"]
             status = parsed_response.get("status", DEFAULT_RESPONSE_STATUS)
+            status = RESPONSE_STATUS_MAP.get(status, status)
         except (KeyError, TypeError) as err:
             raise AnymailRequestsAPIError(
                 "Invalid MailKite API response format",
@@ -182,9 +186,22 @@ class MailKitePayload(RequestsPayload):
         # MailKite has no tags field; carry them as JSON in a custom header.
         self.data.setdefault("headers", {})["X-Tags"] = self.serialize_json(tags)
 
-    # MailKite's /v1/send endpoint has no scheduling parameter (scheduled sends
-    # are a separate flow), and no per-message tracking toggle.
-    # def set_send_at(self, send_at):
+    def set_send_at(self, send_at):
+        # A future scheduledAt parks the message for MailKite's scheduler;
+        # an omitted or past value sends immediately. Note: MailKite rejects
+        # scheduled sends that include custom headers (which this backend also
+        # uses to carry metadata and tags), so send_at can't currently be
+        # combined with extra headers, metadata, or tags.
+        try:
+            send_at = send_at.isoformat(
+                timespec="milliseconds" if send_at.microsecond else "seconds"
+            )
+        except AttributeError:
+            # User is responsible for formatting their own string
+            pass
+        self.data["scheduledAt"] = send_at
+
+    # MailKite's /v1/send endpoint has no per-message tracking toggle.
     # def set_track_clicks(self, track_clicks):
     # def set_track_opens(self, track_opens):
     # def set_envelope_sender(self, envelope_sender):

--- a/anymail/backends/mailkite.py
+++ b/anymail/backends/mailkite.py
@@ -188,10 +188,7 @@ class MailKitePayload(RequestsPayload):
 
     def set_send_at(self, send_at):
         # A future scheduledAt parks the message for MailKite's scheduler;
-        # an omitted or past value sends immediately. Note: MailKite rejects
-        # scheduled sends that include custom headers (which this backend also
-        # uses to carry metadata and tags), so send_at can't currently be
-        # combined with extra headers, metadata, or tags.
+        # an omitted or past value sends immediately.
         try:
             send_at = send_at.isoformat(
                 timespec="milliseconds" if send_at.microsecond else "seconds"

--- a/anymail/backends/mailkite.py
+++ b/anymail/backends/mailkite.py
@@ -1,0 +1,206 @@
+import mimetypes
+
+from ..exceptions import AnymailRequestsAPIError
+from ..message import AnymailRecipientStatus
+from ..utils import (
+    BASIC_NUMERIC_TYPES,
+    CaseInsensitiveCasePreservingDict,
+    get_anymail_setting,
+)
+from .base_requests import AnymailRequestsBackend, RequestsPayload
+
+# MailKite message status values returned from the send endpoint, mapped to
+# Anymail's normalized recipient statuses. The API documents the send response
+# as ``{"id": "...", "status": "..."}`` (e.g. ``"queued"``); we pass the status
+# through as-is, defaulting to ``"queued"`` when the ESP omits it.
+DEFAULT_RESPONSE_STATUS = "queued"
+
+
+class EmailBackend(AnymailRequestsBackend):
+    """
+    MailKite (mailkite.dev) API Email Backend
+
+    MailKite is an inbound-first email platform: it sends transactional mail over
+    a single JSON API and (unlike most ESPs) also *receives* mail — parsed body
+    plus an authentication verdict, delivered as one signed webhook. This backend
+    implements the transactional send API.
+    """
+
+    esp_name = "MailKite"
+
+    def __init__(self, **kwargs):
+        """Init options from Django settings"""
+        esp_name = self.esp_name
+        self.api_key = get_anymail_setting(
+            "api_key", esp_name=esp_name, kwargs=kwargs, allow_bare=True
+        )
+        api_url = get_anymail_setting(
+            "api_url",
+            esp_name=esp_name,
+            kwargs=kwargs,
+            default="https://api.mailkite.dev/",
+        )
+        if not api_url.endswith("/"):
+            api_url += "/"
+
+        super().__init__(api_url, **kwargs)
+
+    def build_message_payload(self, message, defaults):
+        return MailKitePayload(message, defaults, self)
+
+    def parse_recipient_status(self, response, payload, message):
+        parsed_response = self.deserialize_json_response(response, payload, message)
+        try:
+            message_id = parsed_response["id"]
+            status = parsed_response.get("status", DEFAULT_RESPONSE_STATUS)
+        except (KeyError, TypeError) as err:
+            raise AnymailRequestsAPIError(
+                "Invalid MailKite API response format",
+                email_message=message,
+                payload=payload,
+                response=response,
+                backend=self,
+            ) from err
+
+        # MailKite sends one message (one returned id) covering every recipient.
+        recipient_status = CaseInsensitiveCasePreservingDict(
+            {
+                recip.addr_spec: AnymailRecipientStatus(
+                    message_id=message_id, status=status
+                )
+                for recip in payload.recipients
+            }
+        )
+        return dict(recipient_status)
+
+
+class MailKitePayload(RequestsPayload):
+    def __init__(self, message, defaults, backend, *args, **kwargs):
+        self.recipients = []  # for parse_recipient_status
+        headers = kwargs.pop("headers", {})
+        headers["Authorization"] = "Bearer %s" % backend.api_key
+        headers["Content-Type"] = "application/json"
+        headers["Accept"] = "application/json"
+        super().__init__(message, defaults, backend, headers=headers, *args, **kwargs)
+
+    def get_api_endpoint(self):
+        # MailKite has a single send endpoint; there is no separate batch API.
+        return "v1/send"
+
+    def serialize_data(self):
+        return self.serialize_json(self.data)
+
+    #
+    # Payload construction
+    #
+
+    def init_payload(self):
+        self.data = {}  # becomes json
+
+    def set_from_email(self, email):
+        self.data["from"] = email.format(idna_encode=self.backend.idna_encode)
+
+    def set_recipients(self, recipient_type, emails):
+        assert recipient_type in ["to", "cc", "bcc"]
+        if emails:
+            field = recipient_type
+            self.data[field] = [
+                email.format(idna_encode=self.backend.idna_encode) for email in emails
+            ]
+            self.recipients += emails
+
+    def set_subject(self, subject):
+        self.data["subject"] = subject
+
+    def set_reply_to(self, emails):
+        # MailKite's ``replyTo`` is a single string. A header value can hold
+        # multiple addresses, so join them rather than dropping any.
+        if emails:
+            self.data["replyTo"] = ", ".join(
+                email.format(idna_encode=self.backend.idna_encode) for email in emails
+            )
+
+    def set_extra_headers(self, headers):
+        # MailKite requires header values to be strings. Stringify ints/floats;
+        # anything else is the caller's responsibility.
+        self.data.setdefault("headers", {}).update(
+            {
+                k: str(v) if isinstance(v, BASIC_NUMERIC_TYPES) else v
+                for k, v in headers.items()
+            }
+        )
+
+    def set_text_body(self, body):
+        self.data["text"] = body
+
+    def set_html_body(self, body):
+        if "html" in self.data:
+            # second html body could show up through multiple alternatives,
+            # or html body + alternative
+            self.unsupported_feature("multiple html parts")
+        self.data["html"] = body
+
+    def make_attachment(self, attachment):
+        """Returns a MailKite attachment dict for the attachment"""
+        if attachment.inline:
+            # The MailKite send API has no Content-ID / inline-attachment field,
+            # so we can't accurately communicate inline attachments.
+            self.unsupported_feature("inline attachments")
+
+        filename = attachment.name or ""
+        if not filename:
+            # MailKite requires a filename. Generate a reasonable default.
+            ext = mimetypes.guess_extension(attachment.mimetype or "")
+            if ext:
+                filename = "attachment%s" % ext
+            else:
+                self.unsupported_feature(
+                    "unnamed attachments of type %s" % attachment.mimetype
+                )
+        att = {
+            "filename": filename,
+            "content": attachment.b64content,
+        }
+        if attachment.mimetype:
+            att["contentType"] = attachment.mimetype
+        return att
+
+    def set_attachments(self, attachments):
+        if attachments:
+            self.data["attachments"] = [
+                self.make_attachment(attachment) for attachment in attachments
+            ]
+
+    def set_metadata(self, metadata):
+        # MailKite has no dedicated metadata field; carry it as JSON in a custom
+        # header (the ESP accepts arbitrary string-valued raw MIME headers).
+        self.data.setdefault("headers", {})["X-Metadata"] = self.serialize_json(
+            metadata
+        )
+
+    def set_tags(self, tags):
+        # MailKite has no tags field; carry them as JSON in a custom header.
+        self.data.setdefault("headers", {})["X-Tags"] = self.serialize_json(tags)
+
+    # MailKite's /v1/send endpoint has no scheduling parameter (scheduled sends
+    # are a separate flow), and no per-message tracking toggle.
+    # def set_send_at(self, send_at):
+    # def set_track_clicks(self, track_clicks):
+    # def set_track_opens(self, track_opens):
+    # def set_envelope_sender(self, envelope_sender):
+
+    def set_template_id(self, template_id):
+        self.data["templateId"] = template_id
+
+    def set_merge_global_data(self, merge_global_data):
+        # MailKite renders templates server-side from templateData.
+        self.data["templateData"] = merge_global_data
+
+    def set_merge_data(self, merge_data):
+        # MailKite sends a single message to all recipients (not one per
+        # recipient), so per-recipient merge data can't be expressed.
+        if any(recipient_data for recipient_data in merge_data.values()):
+            self.unsupported_feature("merge_data")
+
+    def set_esp_extra(self, extra):
+        self.data.update(extra)

--- a/anymail/urls.py
+++ b/anymail/urls.py
@@ -11,7 +11,10 @@ from .webhooks.mailersend import (
 )
 from .webhooks.mailgun import MailgunInboundWebhookView, MailgunTrackingWebhookView
 from .webhooks.mailjet import MailjetInboundWebhookView, MailjetTrackingWebhookView
-from .webhooks.mailkite import MailKiteInboundWebhookView
+from .webhooks.mailkite import (
+    MailKiteInboundWebhookView,
+    MailKiteTrackingWebhookView,
+)
 from .webhooks.mailtrap import MailtrapTrackingWebhookView
 from .webhooks.mandrill import MandrillCombinedWebhookView
 from .webhooks.postal import PostalInboundWebhookView, PostalTrackingWebhookView
@@ -114,6 +117,11 @@ urlpatterns = [
         "mailjet/tracking/",
         MailjetTrackingWebhookView.as_view(),
         name="mailjet_tracking_webhook",
+    ),
+    path(
+        "mailkite/tracking/",
+        MailKiteTrackingWebhookView.as_view(),
+        name="mailkite_tracking_webhook",
     ),
     path(
         "mailtrap/tracking/",

--- a/anymail/urls.py
+++ b/anymail/urls.py
@@ -11,6 +11,7 @@ from .webhooks.mailersend import (
 )
 from .webhooks.mailgun import MailgunInboundWebhookView, MailgunTrackingWebhookView
 from .webhooks.mailjet import MailjetInboundWebhookView, MailjetTrackingWebhookView
+from .webhooks.mailkite import MailKiteInboundWebhookView
 from .webhooks.mailtrap import MailtrapTrackingWebhookView
 from .webhooks.mandrill import MandrillCombinedWebhookView
 from .webhooks.postal import PostalInboundWebhookView, PostalTrackingWebhookView
@@ -57,6 +58,11 @@ urlpatterns = [
         "mailjet/inbound/",
         MailjetInboundWebhookView.as_view(),
         name="mailjet_inbound_webhook",
+    ),
+    path(
+        "mailkite/inbound/",
+        MailKiteInboundWebhookView.as_view(),
+        name="mailkite_inbound_webhook",
     ),
     path(
         "postal/inbound/",

--- a/anymail/webhooks/mailkite.py
+++ b/anymail/webhooks/mailkite.py
@@ -6,9 +6,16 @@ from email.utils import formataddr
 
 import requests
 
-from ..exceptions import AnymailWebhookValidationFailure
+from ..exceptions import AnymailConfigurationError, AnymailWebhookValidationFailure
 from ..inbound import AnymailInboundMessage
-from ..signals import AnymailInboundEvent, EventType, inbound
+from ..signals import (
+    AnymailInboundEvent,
+    AnymailTrackingEvent,
+    EventType,
+    RejectReason,
+    inbound,
+    tracking,
+)
 from ..utils import get_anymail_setting
 from .base import AnymailBaseWebhookView
 
@@ -19,11 +26,15 @@ from .base import AnymailBaseWebhookView
 SIGNATURE_TOLERANCE_MS = 5 * 60 * 1000
 
 
-class MailKiteInboundWebhookView(AnymailBaseWebhookView):
-    """Handler for MailKite inbound webhook (``email.received`` events)"""
+class MailKiteBaseWebhookView(AnymailBaseWebhookView):
+    """Base view for MailKite webhooks (shared signature validation)
+
+    MailKite signs the inbound-mail webhook and the tracking-event webhook
+    with the same account webhook secret and the same signature scheme, so
+    one MAILKITE_WEBHOOK_SECRET setting covers both views.
+    """
 
     esp_name = "MailKite"
-    signal = inbound
     warn_if_no_basic_auth = False  # because we validate against the signature
 
     # (Declaring class attr allows override by kwargs in View.as_view.)
@@ -76,11 +87,23 @@ class MailKiteInboundWebhookView(AnymailBaseWebhookView):
                 "MailKite webhook called with expired signature"
             )
 
+
+class MailKiteInboundWebhookView(MailKiteBaseWebhookView):
+    """Handler for MailKite inbound webhook (``email.received`` events)"""
+
+    signal = inbound
+
     def parse_events(self, request):
         esp_event = json.loads(request.body.decode("utf-8"))
         if esp_event.get("type") != "email.received":
-            # Ignore any future event types MailKite may add to the same
-            # webhook, rather than erroring on every delivery of them.
+            if str(esp_event.get("type", "")).startswith("email."):
+                raise AnymailConfigurationError(
+                    "You seem to have set MailKite's *tracking-event* webhook"
+                    " to Anymail's MailKite *inbound* webhook URL."
+                    " (Or MailKite has added an event type this version of"
+                    " Anymail doesn't know about.)"
+                )
+            # Ignore anything else, rather than erroring on every delivery.
             return []
         return [self.esp_to_anymail_event(esp_event)]
 
@@ -152,4 +175,81 @@ class MailKiteInboundWebhookView(AnymailBaseWebhookView):
             content=content,
             filename=attachment.get("filename"),
             base64=base64_encoded,
+        )
+
+
+class MailKiteTrackingWebhookView(MailKiteBaseWebhookView):
+    """Handler for MailKite tracking-event webhook (``email.*`` events)"""
+
+    signal = tracking
+
+    # Map MailKite event type: Anymail normalized type.
+    # (email.delivered is reserved by MailKite for a future release;
+    # mapping it now means it works the day the ESP starts emitting it.)
+    event_types = {
+        "email.sent": EventType.SENT,
+        "email.delivered": EventType.DELIVERED,
+        "email.bounced": EventType.BOUNCED,
+        "email.complained": EventType.COMPLAINED,
+        "email.opened": EventType.OPENED,
+        "email.clicked": EventType.CLICKED,
+    }
+
+    def parse_events(self, request):
+        esp_event = json.loads(request.body.decode("utf-8"))
+        if esp_event.get("type") == "email.received":
+            raise AnymailConfigurationError(
+                "You seem to have set MailKite's *inbound* webhook"
+                " to Anymail's MailKite *tracking* webhook URL."
+            )
+        return [self.esp_to_anymail_event(esp_event)]
+
+    def esp_to_anymail_event(self, esp_event):
+        # Payload documented in MailKite's tracking-event schema:
+        # {id: evt_…, type: "email.<event>", createdAt (ms), createdAtIso,
+        #  data: {messageId, providerMessageId, from, to, subject,
+        #         bounce?{type, diagnostic}, complaint?{feedbackType},
+        #         open?/click?{url?, machine, userAgent, client, os, …}}}
+        event_type = self.event_types.get(esp_event.get("type"), EventType.UNKNOWN)
+        data = esp_event.get("data") or {}
+
+        try:
+            timestamp = datetime.fromtimestamp(
+                esp_event["createdAt"] / 1000.0, tz=timezone.utc
+            )
+        except (KeyError, TypeError):
+            timestamp = None
+
+        reject_reason = None
+        description = None
+        mta_response = None
+        bounce = data.get("bounce")
+        if bounce is not None:
+            reject_reason = RejectReason.BOUNCED
+            mta_response = bounce.get("diagnostic")
+            description = bounce.get("diagnostic")
+        complaint = data.get("complaint")
+        if complaint is not None:
+            reject_reason = RejectReason.SPAM
+            description = complaint.get("feedbackType")
+
+        click = data.get("click") or {}
+        open_info = data.get("open") or {}
+        engagement = click or open_info
+
+        return AnymailTrackingEvent(
+            event_type=event_type,
+            timestamp=timestamp,
+            # messageId is null for provider bounce/complaint notifications
+            # (they can't be correlated to a stored message); recipient is
+            # always present and is the reliable key for those events.
+            message_id=data.get("messageId"),
+            event_id=esp_event.get("id"),
+            recipient=data.get("to"),
+            reject_reason=reject_reason,
+            description=description,
+            mta_response=mta_response,
+            click_url=click.get("url"),
+            user_agent=engagement.get("userAgent"),
+            esp_event=esp_event,
         )

--- a/anymail/webhooks/mailkite.py
+++ b/anymail/webhooks/mailkite.py
@@ -1,0 +1,155 @@
+import hashlib
+import hmac
+import json
+from datetime import datetime, timezone
+from email.utils import formataddr
+
+import requests
+
+from ..exceptions import AnymailWebhookValidationFailure
+from ..inbound import AnymailInboundMessage
+from ..signals import AnymailInboundEvent, EventType, inbound
+from ..utils import get_anymail_setting
+from .base import AnymailBaseWebhookView
+
+# Reject signatures whose timestamp is too far from the current time.
+# (Matches the default tolerance in MailKite's own SDK webhook verifiers.
+# MailKite re-signs every automatic retry and manual replay at delivery
+# time, so a legitimate delivery is never outside this window.)
+SIGNATURE_TOLERANCE_MS = 5 * 60 * 1000
+
+
+class MailKiteInboundWebhookView(AnymailBaseWebhookView):
+    """Handler for MailKite inbound webhook (``email.received`` events)"""
+
+    esp_name = "MailKite"
+    signal = inbound
+    warn_if_no_basic_auth = False  # because we validate against the signature
+
+    # (Declaring class attr allows override by kwargs in View.as_view.)
+    webhook_secret = None
+
+    def __init__(self, **kwargs):
+        webhook_secret = get_anymail_setting(
+            "webhook_secret", esp_name=self.esp_name, kwargs=kwargs
+        )
+        # hmac.new requires bytes key:
+        self.webhook_secret = webhook_secret.encode("ascii")
+        super().__init__(**kwargs)
+
+    def validate_request(self, request):
+        # MailKite signs each delivery with
+        # ``x-mailkite-signature: t=<ms-epoch>,v1=<hex>``
+        # where v1 = HMAC-SHA256(webhook_secret, "{t}.{raw_body}").
+        try:
+            signature_header = request.headers["X-MailKite-Signature"]
+        except KeyError:
+            raise AnymailWebhookValidationFailure(
+                "MailKite webhook called without signature"
+            ) from None
+
+        parts = {}
+        for segment in signature_header.split(","):
+            name, _, value = segment.partition("=")
+            parts[name.strip()] = value.strip()
+        timestamp = parts.get("t", "")
+        signature = parts.get("v1", "")
+        if not timestamp.isdigit() or not signature:
+            raise AnymailWebhookValidationFailure(
+                "MailKite webhook called with malformed signature"
+            )
+
+        expected_signature = hmac.new(
+            key=self.webhook_secret,
+            msg=timestamp.encode("ascii") + b"." + request.body,
+            digestmod=hashlib.sha256,
+        ).hexdigest()
+        if not hmac.compare_digest(signature, expected_signature):
+            raise AnymailWebhookValidationFailure(
+                "MailKite webhook called with incorrect signature"
+                " (check Anymail MAILKITE_WEBHOOK_SECRET setting)"
+            )
+
+        now_ms = datetime.now(timezone.utc).timestamp() * 1000.0
+        if abs(now_ms - int(timestamp)) > SIGNATURE_TOLERANCE_MS:
+            raise AnymailWebhookValidationFailure(
+                "MailKite webhook called with expired signature"
+            )
+
+    def parse_events(self, request):
+        esp_event = json.loads(request.body.decode("utf-8"))
+        if esp_event.get("type") != "email.received":
+            # Ignore any future event types MailKite may add to the same
+            # webhook, rather than erroring on every delivery of them.
+            return []
+        return [self.esp_to_anymail_event(esp_event)]
+
+    def esp_to_anymail_event(self, esp_event):
+        # Payload documented in MailKite's email.received event schema:
+        # id, from {address, name?}, to [{address, name?}], subject, text,
+        # html, threadId, receivedAt (ms), auth {spf, dkim, dmarc, spam},
+        # attachments [{filename, contentType, size, url | content}].
+        message = AnymailInboundMessage.construct(
+            from_email=self._formataddr(esp_event.get("from")),
+            to=", ".join(
+                self._formataddr(recipient) for recipient in esp_event.get("to", [])
+            ),
+            subject=esp_event.get("subject"),
+            text=esp_event.get("text"),
+            html=esp_event.get("html"),
+            attachments=[
+                self._construct_attachment(attachment)
+                for attachment in esp_event.get("attachments", [])
+            ],
+        )
+        message.envelope_sender = esp_event.get("from", {}).get("address")
+        recipients = esp_event.get("to", [])
+        message.envelope_recipient = recipients[0]["address"] if recipients else None
+        # auth.spam passes the receiving edge's verdict through: "ham"/"spam"
+        # typically; edges running rspamd may report its action name instead.
+        spam = (esp_event.get("auth") or {}).get("spam")
+        if spam in ("ham", "no action"):
+            message.spam_detected = False
+        elif spam in ("spam", "reject"):
+            message.spam_detected = True
+
+        try:
+            timestamp = datetime.fromtimestamp(
+                esp_event["receivedAt"] / 1000.0, tz=timezone.utc
+            )
+        except (KeyError, TypeError):
+            timestamp = None
+
+        return AnymailInboundEvent(
+            event_type=EventType.INBOUND,
+            timestamp=timestamp,
+            event_id=esp_event.get("id"),
+            esp_event=esp_event,
+            message=message,
+        )
+
+    @staticmethod
+    def _formataddr(address):
+        """{address, name?} dict -> RFC 5322 name-addr string"""
+        if not address:
+            return None
+        return formataddr((address.get("name"), address["address"]))
+
+    def _construct_attachment(self, attachment):
+        # Each attachment carries exactly one of `content` (base64 bytes,
+        # inlined on zero-retention/encrypted domains) or `url` (a signed,
+        # credential-free GET link, valid 7 days -- the normal case).
+        content = attachment.get("content")
+        if content is None:
+            response = requests.get(attachment["url"], timeout=30)
+            response.raise_for_status()
+            content = response.content
+            base64_encoded = False
+        else:
+            base64_encoded = True
+        return AnymailInboundMessage.construct_attachment(
+            content_type=attachment.get("contentType") or "application/octet-stream",
+            content=content,
+            filename=attachment.get("filename"),
+            base64=base64_encoded,
+        )

--- a/docs/esps/esp-feature-matrix.csv
+++ b/docs/esps/esp-feature-matrix.csv
@@ -1,21 +1,21 @@
-Email Service Provider,:ref:`amazon-ses-backend`,:ref:`brevo-backend`,:ref:`mailersend-backend`,:ref:`mailgun-backend`,:ref:`mailjet-backend`,:ref:`mailtrap-backend`,:ref:`mandrill-backend`,:ref:`postal-backend`,:ref:`postmark-backend`,:ref:`resend-backend`,:ref:`scaleway-backend`,:ref:`sendgrid-backend`,:ref:`sparkpost-backend`,:ref:`unisender-go-backend`
-Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Full,Limited,Limited,Full,Full,Full,**Unsupported**,Full,Full
-.. rubric:: :ref:`Anymail send options <anymail-send-options>`,,,,,,,,,,,,,,
-:attr:`~AnymailMessage.envelope_sender`,Yes,No,No,Domain only,Yes,No,Domain only,Yes,No,No,No,No,Yes,No
-:attr:`~AnymailMessage.merge_headers`,Yes [#caveats]_,Yes,No,Yes,Yes,Yes,No,No,Yes,Yes,No,Yes,Yes [#caveats]_,Yes [#caveats]_
-:attr:`~AnymailMessage.metadata`,Yes,Yes,No,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_metadata`,Yes [#caveats]_,Yes,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,No,Yes,No,No,Yes,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.tags`,Yes,Yes,Yes,Yes,Max 1 tag,Max 1 tag,Yes,Max 1 tag,Max 1 tag,Yes,Yes,Yes,Max 1 tag,Yes
-:attr:`~AnymailMessage.track_clicks`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.track_opens`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
-:ref:`amp-email`,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,Yes
-.. rubric:: :ref:`templates-and-merge`,,,,,,,,,,,,,,
-:attr:`~AnymailMessage.template_id`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_global_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
-.. rubric:: :ref:`Status <esp-send-status>` and :ref:`event tracking <event-tracking>`,,,,,,,,,,,,,,
-:attr:`~AnymailMessage.anymail_status`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes
-:class:`~anymail.signals.AnymailTrackingEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Not yet,Yes,Yes,Yes
-.. rubric:: :ref:`Inbound handling <inbound>`,,,,,,,,,,,,,,
-:class:`~anymail.signals.AnymailInboundEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No
+Email Service Provider,:ref:`amazon-ses-backend`,:ref:`brevo-backend`,:ref:`mailersend-backend`,:ref:`mailgun-backend`,:ref:`mailjet-backend`,:ref:`mailkite-backend`,:ref:`mailtrap-backend`,:ref:`mandrill-backend`,:ref:`postal-backend`,:ref:`postmark-backend`,:ref:`resend-backend`,:ref:`scaleway-backend`,:ref:`sendgrid-backend`,:ref:`sparkpost-backend`,:ref:`unisender-go-backend`
+Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Unsupported,Full,Limited,Limited,Full,Full,Full,**Unsupported**,Full,Full
+.. rubric:: :ref:`Anymail send options <anymail-send-options>`,,,,,,,,,,,,,,,
+:attr:`~AnymailMessage.envelope_sender`,Yes,No,No,Domain only,Yes,No,No,Domain only,Yes,No,No,No,No,Yes,No
+:attr:`~AnymailMessage.merge_headers`,Yes [#caveats]_,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,No,Yes,Yes [#caveats]_,Yes [#caveats]_
+:attr:`~AnymailMessage.metadata`,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes
+:attr:`~AnymailMessage.merge_metadata`,Yes [#caveats]_,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.tags`,Yes,Yes,Yes,Yes,Max 1 tag,Yes,Max 1 tag,Yes,Max 1 tag,Max 1 tag,Yes,Yes,Yes,Max 1 tag,Yes
+:attr:`~AnymailMessage.track_clicks`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.track_opens`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
+:ref:`amp-email`,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,Yes
+.. rubric:: :ref:`templates-and-merge`,,,,,,,,,,,,,,,
+:attr:`~AnymailMessage.template_id`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.merge_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.merge_global_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
+.. rubric:: :ref:`Status <esp-send-status>` and :ref:`event tracking <event-tracking>`,,,,,,,,,,,,,,,
+:attr:`~AnymailMessage.anymail_status`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes
+:class:`~anymail.signals.AnymailTrackingEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,Not yet,Yes,Yes,Yes,Yes,Yes,Not yet,Yes,Yes,Yes
+.. rubric:: :ref:`Inbound handling <inbound>`,,,,,,,,,,,,,,,
+:class:`~anymail.signals.AnymailInboundEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,Not yet,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No

--- a/docs/esps/esp-feature-matrix.csv
+++ b/docs/esps/esp-feature-matrix.csv
@@ -5,7 +5,7 @@ Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Unsupported,F
 :attr:`~AnymailMessage.merge_headers`,Yes [#caveats]_,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,No,Yes,Yes [#caveats]_,Yes [#caveats]_
 :attr:`~AnymailMessage.metadata`,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes
 :attr:`~AnymailMessage.merge_metadata`,Yes [#caveats]_,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,Yes [#caveats]_,No,Yes,No,No,Yes,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.tags`,Yes,Yes,Yes,Yes,Max 1 tag,Yes,Max 1 tag,Yes,Max 1 tag,Max 1 tag,Yes,Yes,Yes,Max 1 tag,Yes
 :attr:`~AnymailMessage.track_clicks`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.track_opens`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes

--- a/docs/esps/esp-feature-matrix.csv
+++ b/docs/esps/esp-feature-matrix.csv
@@ -5,7 +5,7 @@ Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Unsupported,F
 :attr:`~AnymailMessage.merge_headers`,Yes [#caveats]_,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,No,Yes,Yes [#caveats]_,Yes [#caveats]_
 :attr:`~AnymailMessage.metadata`,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes
 :attr:`~AnymailMessage.merge_metadata`,Yes [#caveats]_,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,Yes [#caveats]_,No,Yes,No,No,Yes,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.tags`,Yes,Yes,Yes,Yes,Max 1 tag,Yes,Max 1 tag,Yes,Max 1 tag,Max 1 tag,Yes,Yes,Yes,Max 1 tag,Yes
 :attr:`~AnymailMessage.track_clicks`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.track_opens`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes

--- a/docs/esps/esp-feature-matrix.csv
+++ b/docs/esps/esp-feature-matrix.csv
@@ -2,9 +2,9 @@ Email Service Provider,:ref:`amazon-ses-backend`,:ref:`brevo-backend`,:ref:`mail
 Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Unsupported,Full,Limited,Limited,Full,Full,Full,**Unsupported**,Full,Full
 .. rubric:: :ref:`Anymail send options <anymail-send-options>`,,,,,,,,,,,,,,,
 :attr:`~AnymailMessage.envelope_sender`,Yes,No,No,Domain only,Yes,No,No,Domain only,Yes,No,No,No,No,Yes,No
-:attr:`~AnymailMessage.merge_headers`,Yes [#caveats]_,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,No,Yes,Yes [#caveats]_,Yes [#caveats]_
+:attr:`~AnymailMessage.merge_headers`,Yes [#caveats]_,Yes,No,Yes,Yes,Yes [#caveats]_,Yes,No,No,Yes,Yes,No,Yes,Yes [#caveats]_,Yes [#caveats]_
 :attr:`~AnymailMessage.metadata`,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_metadata`,Yes [#caveats]_,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.merge_metadata`,Yes [#caveats]_,Yes,No,Yes,Yes,Yes [#caveats]_,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.tags`,Yes,Yes,Yes,Yes,Max 1 tag,Yes,Max 1 tag,Yes,Max 1 tag,Max 1 tag,Yes,Yes,Yes,Max 1 tag,Yes
 :attr:`~AnymailMessage.track_clicks`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
@@ -12,7 +12,7 @@ Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Unsupported,F
 :ref:`amp-email`,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,Yes
 .. rubric:: :ref:`templates-and-merge`,,,,,,,,,,,,,,,
 :attr:`~AnymailMessage.template_id`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.merge_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.merge_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,Yes [#caveats]_,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.merge_global_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
 .. rubric:: :ref:`Status <esp-send-status>` and :ref:`event tracking <event-tracking>`,,,,,,,,,,,,,,,
 :attr:`~AnymailMessage.anymail_status`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes

--- a/docs/esps/esp-feature-matrix.csv
+++ b/docs/esps/esp-feature-matrix.csv
@@ -16,6 +16,6 @@ Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Unsupported,F
 :attr:`~AnymailMessage.merge_global_data`,Yes [#caveats]_,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
 .. rubric:: :ref:`Status <esp-send-status>` and :ref:`event tracking <event-tracking>`,,,,,,,,,,,,,,,
 :attr:`~AnymailMessage.anymail_status`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes
-:class:`~anymail.signals.AnymailTrackingEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,Not yet,Yes,Yes,Yes,Yes,Yes,Not yet,Yes,Yes,Yes
+:class:`~anymail.signals.AnymailTrackingEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Not yet,Yes,Yes,Yes
 .. rubric:: :ref:`Inbound handling <inbound>`,,,,,,,,,,,,,,,
 :class:`~anymail.signals.AnymailInboundEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No

--- a/docs/esps/esp-feature-matrix.csv
+++ b/docs/esps/esp-feature-matrix.csv
@@ -7,7 +7,7 @@ Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Unsupported,F
 :attr:`~AnymailMessage.merge_metadata`,Yes [#caveats]_,Yes,No,Yes,Yes,Yes [#caveats]_,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.tags`,Yes,Yes,Yes,Yes,Max 1 tag,Yes,Max 1 tag,Yes,Max 1 tag,Max 1 tag,Yes,Yes,Yes,Max 1 tag,Yes
-:attr:`~AnymailMessage.track_clicks`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.track_clicks`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,Yes,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.track_opens`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,Yes,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
 :ref:`amp-email`,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,Yes
 .. rubric:: :ref:`templates-and-merge`,,,,,,,,,,,,,,,

--- a/docs/esps/esp-feature-matrix.csv
+++ b/docs/esps/esp-feature-matrix.csv
@@ -8,7 +8,7 @@ Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Unsupported,F
 :attr:`~AnymailMessage.send_at`,No,Yes,Yes,Yes,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,Yes
 :attr:`~AnymailMessage.tags`,Yes,Yes,Yes,Yes,Max 1 tag,Yes,Max 1 tag,Yes,Max 1 tag,Max 1 tag,Yes,Yes,Yes,Max 1 tag,Yes
 :attr:`~AnymailMessage.track_clicks`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
-:attr:`~AnymailMessage.track_opens`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,No [#nocontrol]_,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
+:attr:`~AnymailMessage.track_opens`,No [#nocontrol]_,No [#nocontrol]_,Yes,Yes,Yes,Yes,No [#nocontrol]_,Yes,No,Yes,No,No,Yes,Yes,Yes
 :ref:`amp-email`,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,Yes
 .. rubric:: :ref:`templates-and-merge`,,,,,,,,,,,,,,,
 :attr:`~AnymailMessage.template_id`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,Yes
@@ -18,4 +18,4 @@ Anymail support status [#support-status]_,Full,Full,Full,Full,Full,Unsupported,F
 :attr:`~AnymailMessage.anymail_status`,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes
 :class:`~anymail.signals.AnymailTrackingEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,Not yet,Yes,Yes,Yes,Yes,Yes,Not yet,Yes,Yes,Yes
 .. rubric:: :ref:`Inbound handling <inbound>`,,,,,,,,,,,,,,,
-:class:`~anymail.signals.AnymailInboundEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,Not yet,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No
+:class:`~anymail.signals.AnymailInboundEvent` from webhooks,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No

--- a/docs/esps/index.rst
+++ b/docs/esps/index.rst
@@ -17,6 +17,7 @@ and notes about any quirks or limitations:
    mailersend
    mailgun
    mailjet
+   mailkite
    mailtrap
    mandrill
    postal

--- a/docs/esps/mailkite.rst
+++ b/docs/esps/mailkite.rst
@@ -119,12 +119,7 @@ can tell Anymail to suppress these errors and send anyway — see
   :attr:`~anymail.message.AnymailMessage.send_at` is supported: a future time
   parks the message with MailKite's scheduler (the API responds with an
   ``ssnd_…`` id and Anymail reports a ``queued`` status); a past or omitted
-  time sends immediately. One caveat: MailKite does not yet accept custom
-  headers on *scheduled* sends, and this backend also carries metadata and
-  tags as headers — so combining ``send_at`` with
-  :attr:`~anymail.message.AnymailMessage.metadata`,
-  :attr:`~anymail.message.AnymailMessage.tags`, or ``extra_headers`` will be
-  rejected by the MailKite API (a 400 with code ``headers_unscheduled``).
+  time sends immediately.
 
 **No inline attachments**
   The send API has no Content-ID field, so inline images

--- a/docs/esps/mailkite.rst
+++ b/docs/esps/mailkite.rst
@@ -115,9 +115,16 @@ error when you try to send a message using a feature MailKite can't express. You
 can tell Anymail to suppress these errors and send anyway — see
 :ref:`unsupported-features`.
 
-**No delayed sending**
-  MailKite's send API has no scheduling parameter, so
-  :attr:`~anymail.message.AnymailMessage.send_at` is not supported.
+**Scheduled sending**
+  :attr:`~anymail.message.AnymailMessage.send_at` is supported: a future time
+  parks the message with MailKite's scheduler (the API responds with an
+  ``ssnd_…`` id and Anymail reports a ``queued`` status); a past or omitted
+  time sends immediately. One caveat: MailKite does not yet accept custom
+  headers on *scheduled* sends, and this backend also carries metadata and
+  tags as headers — so combining ``send_at`` with
+  :attr:`~anymail.message.AnymailMessage.metadata`,
+  :attr:`~anymail.message.AnymailMessage.tags`, or ``extra_headers`` will be
+  rejected by the MailKite API (a 400 with code ``headers_unscheduled``).
 
 **No inline attachments**
   The send API has no Content-ID field, so inline images

--- a/docs/esps/mailkite.rst
+++ b/docs/esps/mailkite.rst
@@ -1,0 +1,152 @@
+.. _mailkite-backend:
+
+MailKite
+========
+
+Anymail integrates Django with the `MailKite`_ developer email platform, using
+their `send API`_.
+
+MailKite is *inbound-first*: as well as sending transactional mail over a single
+JSON API, it also *receives* email — a parsed message body and an authentication
+verdict, delivered together as one signed webhook. That makes it a good fit for
+support inboxes, reply-to-thread flows, and agent mailboxes without wiring a
+second inbound vendor. This backend implements the transactional send API.
+
+.. note::
+
+    This backend covers transactional **sending**.
+    `MailKite inbound webhook`_ and delivery-status tracking support are planned
+    as a follow-up — please open an issue if you need them sooner.
+
+.. _MailKite: https://mailkite.dev/
+.. _send API: https://mailkite.dev/docs
+.. _MailKite inbound webhook: https://mailkite.dev/docs
+
+
+Installation
+------------
+
+MailKite's send API is a plain JSON-over-HTTPS API, so the MailKite backend has no
+ESP-specific dependencies beyond what Anymail already requires. Just install Anymail:
+
+.. code-block:: console
+
+    $ python -m pip install django-anymail
+
+(In other words, there is no ``[mailkite]`` extra to install.)
+
+
+Settings
+--------
+
+.. rubric:: EMAIL_BACKEND
+
+To use Anymail's MailKite backend, set:
+
+  .. code-block:: python
+
+      EMAIL_BACKEND = "anymail.backends.mailkite.EmailBackend"
+
+in your settings.py.
+
+
+.. setting:: ANYMAIL_MAILKITE_API_KEY
+
+.. rubric:: MAILKITE_API_KEY
+
+Required. A MailKite API key (an ``mk_live_…`` token), which you can create in the
+`MailKite dashboard`_. The sender address (``from``) must be on a domain whose
+ownership you've verified in MailKite.
+
+  .. code-block:: python
+
+      ANYMAIL = {
+          ...
+          "MAILKITE_API_KEY": "<your MailKite API key>",
+      }
+
+Anymail will also look for ``MAILKITE_API_KEY`` at the root of the settings file
+if neither ``ANYMAIL["MAILKITE_API_KEY"]`` nor ``ANYMAIL_MAILKITE_API_KEY`` is set.
+
+You can override the API key for an individual message in its
+:ref:`esp_extra <mailkite-esp-extra>`.
+
+.. _MailKite dashboard: https://mailkite.dev/docs
+
+
+.. setting:: ANYMAIL_MAILKITE_API_URL
+
+.. rubric:: MAILKITE_API_URL
+
+The base url for calling the MailKite API.
+
+The default is ``MAILKITE_API_URL = "https://api.mailkite.dev/"``
+(It's unlikely you would need to change this.)
+
+
+.. _mailkite-esp-extra:
+
+esp_extra support
+-----------------
+
+To use MailKite features not directly supported by Anymail, you can set a message's
+:attr:`~anymail.message.AnymailMessage.esp_extra` to a `dict` that will be merged
+into the JSON body sent to MailKite's `send API`_.
+
+Example:
+
+    .. code-block:: python
+
+        message.esp_extra = {
+            # thread a reply under a previous Message-Id
+            'inReplyTo': '<a1b2c3@mail.example.com>',
+        }
+
+(You can also set ``"esp_extra"`` in Anymail's
+:ref:`global send defaults <send-defaults>` to apply it to all messages.)
+
+
+Limitations and quirks
+----------------------
+
+MailKite does not (yet) support a few Anymail additions through the send endpoint.
+Anymail normally raises an :exc:`~anymail.exceptions.AnymailUnsupportedFeature`
+error when you try to send a message using a feature MailKite can't express. You
+can tell Anymail to suppress these errors and send anyway — see
+:ref:`unsupported-features`.
+
+**No delayed sending**
+  MailKite's send API has no scheduling parameter, so
+  :attr:`~anymail.message.AnymailMessage.send_at` is not supported.
+
+**No inline attachments**
+  The send API has no Content-ID field, so inline images
+  (:func:`~anymail.message.attach_inline_image`) are not supported through Anymail.
+  Attach them as regular attachments instead.
+
+**No per-recipient merge**
+  MailKite sends a single message to all recipients (there is no one-per-recipient
+  batch send), so :attr:`~anymail.message.AnymailMessage.merge_data`,
+  :attr:`~anymail.message.AnymailMessage.merge_metadata` and
+  :attr:`~anymail.message.AnymailMessage.merge_headers` are not supported. Use
+  :attr:`~anymail.message.AnymailMessage.template_id` with
+  :attr:`~anymail.message.AnymailMessage.merge_global_data` to render a single
+  message from a `MailKite template`_.
+
+**Single reply-to field**
+  MailKite's ``replyTo`` is a single string. If you supply multiple reply-to
+  addresses, Anymail joins them into that one string (a header can hold several
+  addresses).
+
+**Metadata and tags use headers**
+  MailKite has no dedicated metadata or tags field, so Anymail carries
+  :attr:`~anymail.message.AnymailMessage.metadata` and
+  :attr:`~anymail.message.AnymailMessage.tags` as JSON in custom ``X-Metadata`` and
+  ``X-Tags`` headers, respectively.
+
+**No per-message tracking toggles**
+  The send API doesn't expose click/open tracking per message, so
+  :attr:`~anymail.message.AnymailMessage.track_clicks` and ``track_opens`` are not
+  supported. Configure those at the MailKite account/domain level.
+
+.. _MailKite template: https://mailkite.dev/docs

--- a/docs/esps/mailkite.rst
+++ b/docs/esps/mailkite.rst
@@ -14,9 +14,10 @@ second inbound vendor. This backend implements the transactional send API.
 
 .. note::
 
-    This backend covers transactional **sending**.
-    `MailKite inbound webhook`_ and delivery-status tracking support are planned
-    as a follow-up — please open an issue if you need them sooner.
+    This integration covers transactional **sending** and the
+    :ref:`inbound webhook <mailkite-inbound>`. Delivery-status (tracking)
+    webhook support is planned as a follow-up — please open an issue if you
+    need it sooner.
 
 .. _MailKite: https://mailkite.dev/
 .. _send API: https://mailkite.dev/docs
@@ -146,9 +147,53 @@ can tell Anymail to suppress these errors and send anyway — see
   :attr:`~anymail.message.AnymailMessage.tags` as JSON in custom ``X-Metadata`` and
   ``X-Tags`` headers, respectively.
 
-**No per-message tracking toggles**
-  The send API doesn't expose click/open tracking per message, so
-  :attr:`~anymail.message.AnymailMessage.track_clicks` and ``track_opens`` are not
-  supported. Configure those at the MailKite account/domain level.
+
+.. _mailkite-inbound:
+
+Inbound webhook
+---------------
+
+MailKite is inbound-first: mail sent to any address on a verified domain is
+parsed and delivered to your webhook as JSON — decoded subject and bodies,
+attachments, and the SPF/DKIM/DMARC/spam verdicts computed at MailKite's
+receiving edge — so there is no raw MIME to parse on your end.
+
+To use Anymail's normalized :ref:`inbound <inbound>` handling, set your
+MailKite domain's webhook URL (in the `MailKite dashboard`_, or via the
+``setWebhook`` API) to:
+
+    :samp:`https://{yoursite.example.com}/anymail/mailkite/inbound/`
+
+MailKite signs every delivery with an ``X-MailKite-Signature`` header
+(HMAC-SHA256). Anymail requires the signing secret to verify it:
+
+  .. code-block:: python
+
+      ANYMAIL = {
+          ...
+          "MAILKITE_WEBHOOK_SECRET": "<your webhook signing secret>",
+      }
+
+You can read the secret from your domain's webhook settings in the MailKite
+dashboard (or the ``getWebhookSecret`` API). Requests with a missing, invalid,
+or expired signature are rejected with HTTP 400; MailKite's automatic retries
+re-sign each attempt.
+
+Anymail exposes MailKite's parsed fields on the
+:class:`~anymail.inbound.AnymailInboundMessage`: envelope sender and
+recipient, from/to (with display names), subject, text and html bodies, and
+attachments (fetched from MailKite's signed attachment URLs, or decoded
+inline on zero-retention and at-rest-encrypted domains).
+:attr:`~anymail.inbound.AnymailInboundMessage.spam_detected` reflects
+MailKite's spam verdict. The complete event — including the ``auth`` block
+(SPF/DKIM/DMARC results) and ``threadId`` (pass it back as ``esp_extra
+inReplyTo`` to reply in-thread) — is available in the event's
+:attr:`~anymail.signals.AnymailInboundEvent.esp_event`.
+
+**Open tracking, but no click tracking**
+  :attr:`~anymail.message.AnymailMessage.track_opens` is supported as a
+  per-message override of the sending domain's open-tracking default
+  (HTML messages only). MailKite has no click tracking, so
+  :attr:`~anymail.message.AnymailMessage.track_clicks` is not supported.
 
 .. _MailKite template: https://mailkite.dev/docs

--- a/docs/esps/mailkite.rst
+++ b/docs/esps/mailkite.rst
@@ -197,10 +197,14 @@ MailKite's spam verdict. The complete event — including the ``auth`` block
 inReplyTo`` to reply in-thread) — is available in the event's
 :attr:`~anymail.signals.AnymailInboundEvent.esp_event`.
 
-**Open tracking, but no click tracking**
-  :attr:`~anymail.message.AnymailMessage.track_opens` is supported as a
-  per-message override of the sending domain's open-tracking default
-  (HTML messages only). MailKite has no click tracking, so
-  :attr:`~anymail.message.AnymailMessage.track_clicks` is not supported.
+**Open and click tracking**
+  :attr:`~anymail.message.AnymailMessage.track_opens` and
+  :attr:`~anymail.message.AnymailMessage.track_clicks` are supported as
+  per-message overrides of the sending domain's tracking defaults (HTML
+  messages only). With click tracking on, MailKite rewrites links to a
+  signed redirect that records the click and forwards the reader to the
+  original URL; ``mailto:``/``tel:`` links and in-page anchors are never
+  rewritten, and clicks from security scanners are flagged so they can be
+  excluded from click counts.
 
 .. _MailKite template: https://mailkite.dev/docs

--- a/docs/esps/mailkite.rst
+++ b/docs/esps/mailkite.rst
@@ -127,14 +127,21 @@ can tell Anymail to suppress these errors and send anyway — see
   (:func:`~anymail.message.attach_inline_image`) are not supported through Anymail.
   Attach them as regular attachments instead.
 
-**No per-recipient merge**
-  MailKite sends a single message to all recipients (there is no one-per-recipient
-  batch send), so :attr:`~anymail.message.AnymailMessage.merge_data`,
-  :attr:`~anymail.message.AnymailMessage.merge_metadata` and
-  :attr:`~anymail.message.AnymailMessage.merge_headers` are not supported. Use
-  :attr:`~anymail.message.AnymailMessage.template_id` with
-  :attr:`~anymail.message.AnymailMessage.merge_global_data` to render a single
-  message from a `MailKite template`_.
+**Batch sending / per-recipient merge**
+  Setting :attr:`~anymail.message.AnymailMessage.merge_data`,
+  :attr:`~anymail.message.AnymailMessage.merge_metadata` or
+  :attr:`~anymail.message.AnymailMessage.merge_headers` switches to MailKite's
+  batch-send endpoint: each ``to`` recipient gets an **individual message**
+  showing only their own address, personalized with their merge values
+  (per-recipient values win over
+  :attr:`~anymail.message.AnymailMessage.merge_global_data`, metadata and
+  extra headers, key by key). Each recipient gets their own
+  ``message_id`` in :attr:`~anymail.message.AnymailMessage.anymail_status`,
+  and a batch can partially succeed — a suppressed address reports status
+  ``rejected`` and other failures ``failed``, without raising an error.
+  Two restrictions: MailKite allows at most **50 recipients per batch
+  message**, and ``cc``/``bcc`` can't be combined with a batch send (each
+  message goes to exactly one recipient).
 
 **Single reply-to field**
   MailKite's ``replyTo`` is a single string. If you supply multiple reply-to

--- a/docs/esps/mailkite.rst
+++ b/docs/esps/mailkite.rst
@@ -12,18 +12,6 @@ verdict, delivered together as one signed webhook. That makes it a good fit for
 support inboxes, reply-to-thread flows, and agent mailboxes without wiring a
 second inbound vendor. This backend implements the transactional send API.
 
-.. note::
-
-    This integration covers transactional **sending** and the
-    :ref:`inbound webhook <mailkite-inbound>`. Delivery-status (tracking)
-    webhook support is planned as a follow-up — please open an issue if you
-    need it sooner.
-
-.. _MailKite: https://mailkite.dev/
-.. _send API: https://mailkite.dev/docs
-.. _MailKite inbound webhook: https://mailkite.dev/docs
-
-
 Installation
 ------------
 
@@ -153,6 +141,42 @@ can tell Anymail to suppress these errors and send anyway — see
   :attr:`~anymail.message.AnymailMessage.metadata` and
   :attr:`~anymail.message.AnymailMessage.tags` as JSON in custom ``X-Metadata`` and
   ``X-Tags`` headers, respectively.
+
+
+.. _MailKite tracking events: https://mailkite.dev/docs
+
+.. _mailkite-tracking:
+
+Status tracking webhooks
+------------------------
+
+MailKite can POST signed engagement events for your outbound mail —
+``email.sent``, ``email.bounced``, ``email.complained``, ``email.opened``
+and ``email.clicked`` — to a per-domain *tracking webhook*. This is a
+**separate URL** from the inbound webhook below (so inbound consumers never
+receive event types they don't expect). Set it with the ``setTrackingWebhook``
+API (or ``mailkite webhook set-tracking`` in the CLI) to:
+
+    :samp:`https://{yoursite.example.com}/anymail/mailkite/tracking/`
+
+Deliveries are signed exactly like inbound ones, verified with the same
+``MAILKITE_WEBHOOK_SECRET`` setting as the inbound webhook (see below).
+Anymail normalizes the events to
+:class:`~anymail.signals.AnymailTrackingEvent`: bounces carry the DSN
+diagnostic in :attr:`~anymail.signals.AnymailTrackingEvent.mta_response`
+(reject reason ``bounced``), complaints report reject reason ``spam``,
+clicks carry :attr:`~anymail.signals.AnymailTrackingEvent.click_url`, and
+opens/clicks include the user agent. One caveat: bounce and complaint events
+originate from provider notifications and carry a null ``message_id`` —
+key on :attr:`~anymail.signals.AnymailTrackingEvent.recipient` for those
+(the full event, including MailKite's machine/scanner flags on opens and
+clicks, is in :attr:`~anymail.signals.AnymailTrackingEvent.esp_event`).
+``email.delivered`` is reserved by MailKite for a future release and is
+already mapped, so it will work when the ESP starts emitting it.
+
+.. _MailKite: https://mailkite.dev/
+.. _send API: https://mailkite.dev/docs
+.. _MailKite inbound webhook: https://mailkite.dev/docs
 
 
 .. _mailkite-inbound:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = """\
 Django email backends and webhooks for Amazon SES, Brevo,
- MailerSend, Mailgun, Mailjet, Mailtrap, Mandrill, Postal, Postmark, Resend,
+ MailerSend, Mailgun, Mailjet, MailKite, Mailtrap, Mandrill, Postal, Postmark, Resend,
  Scaleway TEM, SendGrid, SparkPost, and Unisender Go
  (EmailBackend, transactional email tracking and inbound email signals)\
 """
@@ -26,7 +26,7 @@ keywords = [
     "Amazon SES", "AWS SES", "Simple Email Service",
     "Brevo", "SendinBlue",
     "MailerSend",
-    "Mailgun", "Mailjet", "Sinch",
+    "Mailgun", "Mailjet", "MailKite", "Sinch",
     "Mailtrap",
     "Mandrill", "MailChimp",
     "Postal",
@@ -78,6 +78,7 @@ brevo = []
 mailersend = []
 mailgun = []
 mailjet = []
+mailkite = []
 mailtrap = []
 mandrill = []
 postal = ["cryptography"]

--- a/tests/test_mailkite_backend.py
+++ b/tests/test_mailkite_backend.py
@@ -415,25 +415,258 @@ class MailKiteBackendAnymailFeatureTests(MailKiteBackendMockAPITestCase):
         data = self.get_api_call_json()
         self.assertEqual(data["templateData"], {"name": "Ann"})
 
-    def test_merge_data_unsupported(self):
-        # MailKite sends a single message to all recipients (no batch), so
-        # per-recipient merge data can't be expressed.
-        self.message.merge_data = {"to@example.com": {"customer_id": 3}}
-        with self.assertRaisesMessage(AnymailUnsupportedFeature, "merge_data"):
-            self.message.send()
+    def test_merge_data(self):
+        # Setting merge_data switches to the batch endpoint: one personalized
+        # message per `to` recipient.
+        self.set_mock_response(
+            json_data={
+                "results": [
+                    {"to": "alice@example.com", "id": "msg_a", "status": "sent"},
+                    {"to": "Bob <bob@example.com>", "id": "msg_b", "status": "sent"},
+                ],
+                "sent": 2,
+                "scheduled": 0,
+                "failed": 0,
+            }
+        )
+        message = AnymailMessage(
+            subject="Hello {{name}} ({{group}})",
+            body="Hi {{name}}",
+            from_email="from@example.com",
+            to=["alice@example.com", "Bob <bob@example.com>"],
+            merge_data={
+                "alice@example.com": {"name": "Alice", "group": "Developers"},
+                "bob@example.com": {"name": "Bob"},
+            },
+            merge_global_data={"group": "Users", "site": "ExampleCo"},
+        )
+        message.send()
+        self.assert_esp_called("/v1/send/batch")
+        data = self.get_api_call_json()
+        self.assertNotIn("to", data)
+        # merge_global_data is the shared default; per-recipient wins key-by-key
+        self.assertEqual(data["templateData"], {"group": "Users", "site": "ExampleCo"})
+        self.assertEqual(
+            data["recipients"],
+            [
+                {
+                    "to": "alice@example.com",
+                    "templateData": {"name": "Alice", "group": "Developers"},
+                },
+                {
+                    "to": "Bob <bob@example.com>",
+                    "templateData": {"name": "Bob"},
+                },
+            ],
+        )
+        # Per-recipient message ids from the batch response:
+        self.assertEqual(message.anymail_status.status, {"sent"})
+        self.assertEqual(
+            message.anymail_status.recipients["alice@example.com"].message_id, "msg_a"
+        )
+        self.assertEqual(
+            message.anymail_status.recipients["bob@example.com"].message_id, "msg_b"
+        )
 
     def test_empty_merge_data(self):
-        # Empty merge_data is a no-op (no batch send on this ESP)
+        # Empty merge_data still switches to batch mode (one message per
+        # recipient), just with no per-recipient substitutions.
+        self.set_mock_response(
+            json_data={
+                "results": [
+                    {"to": "alice@example.com", "id": "msg_a", "status": "sent"},
+                    {"to": "Bob <bob@example.com>", "id": "msg_b", "status": "sent"},
+                ],
+                "sent": 2,
+                "scheduled": 0,
+                "failed": 0,
+            }
+        )
         message = AnymailMessage(
+            subject="Subject",
+            body="Body",
             from_email="from@example.com",
             to=["alice@example.com", "Bob <bob@example.com>"],
             merge_data={},
         )
         message.send()
-        self.assert_esp_called("/v1/send")
+        self.assert_esp_called("/v1/send/batch")
         data = self.get_api_call_json()
-        # A single send to both recipients:
-        self.assertEqual(data["to"], ["alice@example.com", "Bob <bob@example.com>"])
+        self.assertEqual(
+            data["recipients"],
+            [{"to": "alice@example.com"}, {"to": "Bob <bob@example.com>"}],
+        )
+
+    def test_merge_metadata(self):
+        # Per-recipient metadata: `metadata` merged with the recipient's
+        # merge_metadata entry, carried in a per-recipient X-Metadata header.
+        self.set_mock_response(
+            json_data={
+                "results": [
+                    {"to": "alice@example.com", "id": "msg_a", "status": "sent"},
+                    {"to": "bob@example.com", "id": "msg_b", "status": "sent"},
+                ],
+                "sent": 2,
+                "scheduled": 0,
+                "failed": 0,
+            }
+        )
+        message = AnymailMessage(
+            subject="Subject",
+            body="Body",
+            from_email="from@example.com",
+            to=["alice@example.com", "bob@example.com"],
+            metadata={"kind": "welcome", "batch": 11},
+            merge_metadata={
+                "alice@example.com": {"user_id": 123},
+                "bob@example.com": {"user_id": 456, "kind": "vip-welcome"},
+            },
+        )
+        message.send()
+        data = self.get_api_call_json()
+        # Shared metadata still travels as the shared X-Metadata header:
+        self.assertEqual(
+            json.loads(data["headers"]["X-Metadata"]), {"kind": "welcome", "batch": 11}
+        )
+        # Each recipient's header is metadata updated with their entry:
+        self.assertEqual(
+            json.loads(data["recipients"][0]["headers"]["X-Metadata"]),
+            {"kind": "welcome", "batch": 11, "user_id": 123},
+        )
+        self.assertEqual(
+            json.loads(data["recipients"][1]["headers"]["X-Metadata"]),
+            {"kind": "vip-welcome", "batch": 11, "user_id": 456},
+        )
+
+    def test_merge_headers(self):
+        self.set_mock_response(
+            json_data={
+                "results": [
+                    {"to": "alice@example.com", "id": "msg_a", "status": "sent"},
+                    {"to": "bob@example.com", "id": "msg_b", "status": "sent"},
+                ],
+                "sent": 2,
+                "scheduled": 0,
+                "failed": 0,
+            }
+        )
+        message = AnymailMessage(
+            subject="Subject",
+            body="Body",
+            from_email="from@example.com",
+            to=["alice@example.com", "bob@example.com"],
+            headers={"List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
+            merge_headers={
+                "alice@example.com": {
+                    "List-Unsubscribe": "<https://example.com/a/>",
+                },
+                "bob@example.com": {
+                    "List-Unsubscribe": "<https://example.com/b/>",
+                },
+            },
+        )
+        message.send()
+        data = self.get_api_call_json()
+        # Shared headers stay shared; per-recipient headers win key-by-key:
+        self.assertEqual(
+            data["headers"],
+            {"List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
+        )
+        self.assertEqual(
+            data["recipients"][0]["headers"],
+            {"List-Unsubscribe": "<https://example.com/a/>"},
+        )
+        self.assertEqual(
+            data["recipients"][1]["headers"],
+            {"List-Unsubscribe": "<https://example.com/b/>"},
+        )
+
+    def test_batch_partial_failure(self):
+        # A batch can partially succeed; failed recipients get status "failed"
+        # (or "rejected" for suppressed addresses) and no exception is raised.
+        self.set_mock_response(
+            json_data={
+                "results": [
+                    {"to": "ok@example.com", "id": "msg_ok", "status": "sent"},
+                    {
+                        "to": "bounced@example.com",
+                        "status": "failed",
+                        "error": "Suppressed (unsubscribed or bounced)",
+                        "code": "recipient_suppressed",
+                    },
+                    {
+                        "to": "broken@example.com",
+                        "status": "failed",
+                        "error": "send failed",
+                        "code": "send_failed",
+                    },
+                ],
+                "sent": 1,
+                "scheduled": 0,
+                "failed": 2,
+            }
+        )
+        message = AnymailMessage(
+            subject="Subject",
+            body="Body",
+            from_email="from@example.com",
+            to=["ok@example.com", "bounced@example.com", "broken@example.com"],
+            merge_data={},
+        )
+        sent = message.send()
+        self.assertEqual(sent, 1)  # Anymail counts partial batch success as 1
+        recipients = message.anymail_status.recipients
+        self.assertEqual(recipients["ok@example.com"].status, "sent")
+        self.assertEqual(recipients["ok@example.com"].message_id, "msg_ok")
+        self.assertEqual(recipients["bounced@example.com"].status, "rejected")
+        self.assertIsNone(recipients["bounced@example.com"].message_id)
+        self.assertEqual(recipients["broken@example.com"].status, "failed")
+        self.assertEqual(message.anymail_status.status, {"sent", "rejected", "failed"})
+
+    def test_batch_scheduled(self):
+        # send_at works with batch: every message is parked (one ssnd_… each),
+        # normalized to Anymail's "queued".
+        self.set_mock_response(
+            json_data={
+                "results": [
+                    {"to": "alice@example.com", "id": "ssnd_a", "status": "scheduled"},
+                    {"to": "bob@example.com", "id": "ssnd_b", "status": "scheduled"},
+                ],
+                "sent": 0,
+                "scheduled": 2,
+                "failed": 0,
+            }
+        )
+        message = AnymailMessage(
+            subject="Subject",
+            body="Body",
+            from_email="from@example.com",
+            to=["alice@example.com", "bob@example.com"],
+            merge_data={"alice@example.com": {"name": "Alice"}},
+        )
+        message.send_at = "2026-10-11T12:13:14Z"
+        message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["scheduledAt"], "2026-10-11T12:13:14Z")
+        self.assertEqual(message.anymail_status.status, {"queued"})
+        self.assertEqual(
+            message.anymail_status.recipients["alice@example.com"].message_id, "ssnd_a"
+        )
+
+    def test_batch_cc_bcc_unsupported(self):
+        # Batch sends one message per `to` recipient; there is no cc/bcc.
+        message = AnymailMessage(
+            subject="Subject",
+            body="Body",
+            from_email="from@example.com",
+            to=["alice@example.com"],
+            cc=["cc@example.com"],
+            merge_data={},
+        )
+        with self.assertRaisesMessage(
+            AnymailUnsupportedFeature, "cc or bcc with batch send"
+        ):
+            message.send()
 
     def test_track_opens(self):
         # Per-send override of the from-domain's open-tracking default

--- a/tests/test_mailkite_backend.py
+++ b/tests/test_mailkite_backend.py
@@ -436,9 +436,22 @@ class MailKiteBackendAnymailFeatureTests(MailKiteBackendMockAPITestCase):
         self.assertEqual(data["to"], ["alice@example.com", "Bob <bob@example.com>"])
 
     def test_track_opens(self):
+        # Per-send override of the from-domain's open-tracking default
         self.message.track_opens = True
-        with self.assertRaisesMessage(AnymailUnsupportedFeature, "track_opens"):
-            self.message.send()
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertIs(data["trackOpens"], True)
+
+        self.message.track_opens = False
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertIs(data["trackOpens"], False)
+
+    def test_track_opens_default_omitted(self):
+        # Unset track_opens must not send the field (domain default applies)
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertNotIn("trackOpens", data)
 
     def test_track_clicks(self):
         self.message.track_clicks = True

--- a/tests/test_mailkite_backend.py
+++ b/tests/test_mailkite_backend.py
@@ -687,9 +687,22 @@ class MailKiteBackendAnymailFeatureTests(MailKiteBackendMockAPITestCase):
         self.assertNotIn("trackOpens", data)
 
     def test_track_clicks(self):
+        # Per-send override of the from-domain's click-tracking default
         self.message.track_clicks = True
-        with self.assertRaisesMessage(AnymailUnsupportedFeature, "track_clicks"):
-            self.message.send()
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertIs(data["trackClicks"], True)
+
+        self.message.track_clicks = False
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertIs(data["trackClicks"], False)
+
+    def test_track_clicks_default_omitted(self):
+        # Unset track_clicks must not send the field (domain default applies)
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertNotIn("trackClicks", data)
 
     def test_default_omits_options(self):
         """Make sure by default we don't send any ESP-specific options.

--- a/tests/test_mailkite_backend.py
+++ b/tests/test_mailkite_backend.py
@@ -1,8 +1,13 @@
 import json
+from datetime import date, datetime
 from decimal import Decimal
 
 from django.core import mail
 from django.test import SimpleTestCase, tag
+from django.utils.timezone import (
+    get_fixed_timezone,
+    override as override_current_timezone,
+)
 
 from anymail.exceptions import (
     AnymailAPIError,
@@ -302,10 +307,58 @@ class MailKiteBackendAnymailFeatureTests(MailKiteBackendMockAPITestCase):
         )
 
     def test_send_at(self):
-        # The /v1/send endpoint has no scheduling parameter.
-        self.message.send_at = "2022-10-11T12:13:14Z"
-        with self.assertRaisesMessage(AnymailUnsupportedFeature, "send_at"):
+        utc_plus_6 = get_fixed_timezone(6 * 60)
+        utc_minus_8 = get_fixed_timezone(-8 * 60)
+
+        with override_current_timezone(utc_plus_6):
+            # Timezone-naive datetime assumed to be Django current_timezone
+            self.message.send_at = datetime(2022, 10, 11, 12, 13, 14, 123456)
             self.message.send()
+            data = self.get_api_call_json()
+            self.assertEqual(data["scheduledAt"], "2022-10-11T12:13:14.123+06:00")
+
+            # Timezone-aware datetime converted to UTC:
+            self.message.send_at = datetime(2016, 3, 4, 5, 6, 7, tzinfo=utc_minus_8)
+            self.message.send()
+            data = self.get_api_call_json()
+            self.assertEqual(data["scheduledAt"], "2016-03-04T05:06:07-08:00")
+
+            # Date-only treated as midnight in current timezone
+            self.message.send_at = date(2022, 10, 22)
+            self.message.send()
+            data = self.get_api_call_json()
+            self.assertEqual(data["scheduledAt"], "2022-10-22T00:00:00+06:00")
+
+            # POSIX timestamp
+            self.message.send_at = 1651820889  # 2022-05-06 07:08:09 UTC
+            self.message.send()
+            data = self.get_api_call_json()
+            self.assertEqual(data["scheduledAt"], "2022-05-06T07:08:09+00:00")
+
+            # String passed unchanged (caller is responsible for formatting)
+            self.message.send_at = "2022-10-13T18:02:00Z"
+            self.message.send()
+            data = self.get_api_call_json()
+            self.assertEqual(data["scheduledAt"], "2022-10-13T18:02:00Z")
+
+    def test_scheduled_response_status(self):
+        # A future send_at parks the message; MailKite responds 202 with an
+        # ssnd_… id and status "scheduled", which normalizes to "queued".
+        self.set_mock_response(
+            status_code=202,
+            json_data={
+                "id": "ssnd_test12345",
+                "status": "scheduled",
+                "scheduledAt": 1767222896000,
+            },
+        )
+        self.message.send_at = "2026-01-01T00:34:56Z"
+        self.message.send()
+        self.assertEqual(self.message.anymail_status.status, {"queued"})
+        self.assertEqual(self.message.anymail_status.message_id, "ssnd_test12345")
+        self.assertEqual(
+            self.message.anymail_status.recipients["to@example.com"].status, "queued"
+        )
 
     def test_tags(self):
         self.message.tags = ["receipt", "reorder test 12"]

--- a/tests/test_mailkite_backend.py
+++ b/tests/test_mailkite_backend.py
@@ -1,0 +1,520 @@
+import json
+from decimal import Decimal
+
+from django.core import mail
+from django.test import SimpleTestCase, tag
+
+from anymail.exceptions import (
+    AnymailAPIError,
+    AnymailConfigurationError,
+    AnymailSerializationError,
+    AnymailUnsupportedFeature,
+)
+from anymail.message import AnymailMessage, attach_inline_image
+
+from .mock_requests_backend import (
+    RequestsBackendMockAPITestCase,
+    SessionSharingTestCases,
+)
+from .utils import (
+    AnymailTestMixin,
+    decode_att,
+    ignore_fail_silently_warning,
+    override_settings,
+    sample_image_content,
+)
+
+
+@tag("mailkite")
+@override_settings(
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailkite.EmailBackend",
+            "OPTIONS": {"api_key": "test_api_key"},
+        },
+    },
+)
+class MailKiteBackendMockAPITestCase(RequestsBackendMockAPITestCase):
+    # MailKite's send endpoint returns {"id": ..., "status": ...} (e.g. "queued")
+    DEFAULT_RAW_RESPONSE = b'{"id": "msg_test12345", "status": "queued"}'
+
+    def setUp(self):
+        super().setUp()
+        # Simple message useful for many tests
+        self.message = mail.EmailMultiAlternatives(
+            "Subject", "Text Body", "from@example.com", ["to@example.com"]
+        )
+
+
+@tag("mailkite")
+class MailKiteBackendStandardEmailTests(MailKiteBackendMockAPITestCase):
+    """Test backend support for Django standard email features"""
+
+    def test_send_mail(self):
+        """Test basic API for simple send"""
+        mail.send_mail(
+            "Subject here",
+            "Here is the message.",
+            "from@sender.example.com",
+            ["to@example.com"],
+        )
+        self.assert_esp_called("/v1/send")
+        headers = self.get_api_call_headers()
+        self.assertEqual(headers["Authorization"], "Bearer test_api_key")
+        data = self.get_api_call_json()
+        self.assertEqual(data["subject"], "Subject here")
+        self.assertEqual(data["text"], "Here is the message.")
+        self.assertEqual(data["from"], "from@sender.example.com")
+        self.assertEqual(data["to"], ["to@example.com"])
+
+    def test_name_addr(self):
+        """Make sure RFC2822 name-addr format (with display-name) is allowed
+
+        (Test both sender and recipient addresses)
+        """
+        msg = mail.EmailMessage(
+            "Subject",
+            "Message",
+            "From Name <from@example.com>",
+            ["Recipient #1 <to1@example.com>", "to2@example.com"],
+            cc=["Carbon Copy <cc1@example.com>", "cc2@example.com"],
+            bcc=["Blind Copy <bcc1@example.com>", "bcc2@example.com"],
+        )
+        msg.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["from"], "From Name <from@example.com>")
+        self.assertEqual(
+            data["to"], ["Recipient #1 <to1@example.com>", "to2@example.com"]
+        )
+        self.assertEqual(
+            data["cc"], ["Carbon Copy <cc1@example.com>", "cc2@example.com"]
+        )
+        self.assertEqual(
+            data["bcc"], ["Blind Copy <bcc1@example.com>", "bcc2@example.com"]
+        )
+
+    def test_email_message(self):
+        email = mail.EmailMessage(
+            "Subject",
+            "Body goes here",
+            "from@example.com",
+            ["to1@example.com", "Also To <to2@example.com>"],
+            bcc=["bcc1@example.com", "Also BCC <bcc2@example.com>"],
+            cc=["cc1@example.com", "Also CC <cc2@example.com>"],
+            reply_to=["another@example.com"],
+            headers={
+                "X-MyHeader": "my value",
+            },
+        )
+        email.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["subject"], "Subject")
+        self.assertEqual(data["text"], "Body goes here")
+        self.assertEqual(data["from"], "from@example.com")
+        self.assertEqual(data["to"], ["to1@example.com", "Also To <to2@example.com>"])
+        self.assertEqual(
+            data["bcc"], ["bcc1@example.com", "Also BCC <bcc2@example.com>"]
+        )
+        self.assertEqual(data["cc"], ["cc1@example.com", "Also CC <cc2@example.com>"])
+        # MailKite's replyTo is a single string (not an array)
+        self.assertEqual(data["replyTo"], "another@example.com")
+        self.assertCountEqual(
+            data["headers"],
+            {"X-MyHeader": "my value"},
+        )
+
+    def test_html_message(self):
+        text_content = "This is an important message."
+        html_content = "<p>This is an <strong>important</strong> message.</p>"
+        email = mail.EmailMultiAlternatives(
+            "Subject", text_content, "from@example.com", ["to@example.com"]
+        )
+        email.attach_alternative(html_content, "text/html")
+        email.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["text"], text_content)
+        self.assertEqual(data["html"], html_content)
+        # Don't accidentally send the html part as an attachment:
+        self.assertNotIn("attachments", data)
+
+    def test_html_only_message(self):
+        html_content = "<p>This is an <strong>important</strong> message.</p>"
+        email = mail.EmailMessage(
+            "Subject", html_content, "from@example.com", ["to@example.com"]
+        )
+        email.content_subtype = "html"  # Main content is now text/html
+        email.send()
+        data = self.get_api_call_json()
+        self.assertNotIn("text", data)
+        self.assertEqual(data["html"], html_content)
+
+    def test_extra_headers(self):
+        self.message.extra_headers = {"X-Custom": "string", "X-Num": 123}
+        self.message.send()
+        data = self.get_api_call_json()
+        # header values must be strings (the ESP requires string-valued headers)
+        self.assertEqual(data["headers"], {"X-Custom": "string", "X-Num": "123"})
+
+    def test_reply_to(self):
+        # MailKite accepts a single replyTo string; multiple addresses are joined.
+        email = mail.EmailMessage(
+            "Subject",
+            "Body goes here",
+            "from@example.com",
+            ["to1@example.com"],
+            reply_to=["reply@example.com", "Other <reply2@example.com>"],
+        )
+        email.send()
+        data = self.get_api_call_json()
+        self.assertEqual(
+            data["replyTo"], "reply@example.com, Other <reply2@example.com>"
+        )
+
+    def test_attachments(self):
+        # MailKite attachments use {filename, content (base64), contentType}
+        # (note: camelCase contentType). There is no content_id / inline field.
+        self.message.attach("receipt.pdf", b"%PDF-1.4 fake pdf", "application/pdf")
+        self.message.attach("data.csv", b"a,b\n1,2\n", "text/csv")
+        self.message.send()
+        data = self.get_api_call_json()
+
+        attachments = data["attachments"]
+        self.assertEqual(len(attachments), 2)
+
+        self.assertEqual(attachments[0]["filename"], "receipt.pdf")
+        self.assertEqual(attachments[0]["contentType"], "application/pdf")
+        self.assertEqual(decode_att(attachments[0]["content"]), b"%PDF-1.4 fake pdf")
+        self.assertNotIn("content_id", attachments[0])
+        # the underscore variant must not leak through:
+        self.assertNotIn("content_type", attachments[0])
+
+        self.assertEqual(attachments[1]["filename"], "data.csv")
+        self.assertEqual(attachments[1]["contentType"], "text/csv")
+        self.assertEqual(decode_att(attachments[1]["content"]), b"a,b\n1,2\n")
+
+    def test_attachment_generated_filename(self):
+        # No filename + a known mimetype -> a default name is generated
+        self.message.attach(None, "data", "text/plain")
+        self.message.send()
+        data = self.get_api_call_json()
+        attachments = data["attachments"]
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments[0]["filename"], "attachment.txt")
+        self.assertEqual(attachments[0]["contentType"], "text/plain")
+
+    def test_missing_attachment_filename_unknown_type(self):
+        self.message.attach(None, "data", "text/x-unknown-type")
+        with self.assertRaisesMessage(
+            AnymailUnsupportedFeature, "unnamed attachments of type text/x-unknown-type"
+        ):
+            self.message.send()
+
+    def test_inline_attachment_unsupported(self):
+        # The MailKite send API has no Content-ID / inline field.
+        attach_inline_image(self.message, sample_image_content(), "test.png")
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "inline attachments"):
+            self.message.send()
+
+    def test_multiple_html_alternatives(self):
+        # Multiple alternatives not allowed
+        self.message.attach_alternative("<p>First html is OK</p>", "text/html")
+        self.message.attach_alternative("<p>But not second html</p>", "text/html")
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "multiple html parts"):
+            self.message.send()
+
+    def test_html_alternative(self):
+        # Only html alternatives allowed
+        self.message.attach_alternative("{'not': 'allowed'}", "application/json")
+        with self.assertRaises(AnymailUnsupportedFeature):
+            self.message.send()
+
+    @ignore_fail_silently_warning()
+    def test_alternatives_fail_silently(self):
+        # Make sure fail_silently is respected
+        self.message.attach_alternative("{'not': 'allowed'}", "application/json")
+        sent = self.message.send(fail_silently=True)
+        self.assert_esp_not_called("API should not be called when send fails silently")
+        self.assertEqual(sent, 0)
+
+    def test_suppress_empty_address_lists(self):
+        """Empty to, cc, bcc, and replyTo shouldn't generate empty fields"""
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertNotIn("cc", data)
+        self.assertNotIn("bcc", data)
+        self.assertNotIn("replyTo", data)
+
+        # Test empty `to`--but send requires at least one recipient somewhere (like cc)
+        self.message.to = []
+        self.message.cc = ["cc@example.com"]
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertNotIn("to", data)
+
+    def test_api_failure(self):
+        failure_response = {
+            "statusCode": 400,
+            "message": "API key is invalid",
+            "name": "validation_error",
+        }
+        self.set_mock_response(status_code=400, json_data=failure_response)
+        with self.assertRaisesMessage(
+            AnymailAPIError, r"MailKite API response 400"
+        ) as cm:
+            mail.send_mail("Subject", "Body", "from@example.com", ["to@example.com"])
+        self.assertIn("API key is invalid", str(cm.exception))
+
+    @ignore_fail_silently_warning()
+    def test_api_failure_fail_silently(self):
+        # Make sure fail_silently is respected
+        failure_response = {
+            "statusCode": 400,
+            "message": "API key is invalid",
+            "name": "validation_error",
+        }
+        self.set_mock_response(status_code=422, json_data=failure_response)
+        sent = mail.send_mail(
+            "Subject",
+            "Body",
+            "from@example.com",
+            ["to@example.com"],
+            fail_silently=True,
+        )
+        self.assertEqual(sent, 0)
+
+
+@tag("mailkite")
+class MailKiteBackendAnymailFeatureTests(MailKiteBackendMockAPITestCase):
+    """Test backend support for Anymail added features"""
+
+    def test_envelope_sender(self):
+        self.message.envelope_sender = "anything@bounces.example.com"
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "envelope_sender"):
+            self.message.send()
+
+    def test_metadata(self):
+        self.message.metadata = {"user_id": "12345", "items": 6}
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(
+            json.loads(data["headers"]["X-Metadata"]),
+            {"user_id": "12345", "items": 6},
+        )
+
+    def test_send_at(self):
+        # The /v1/send endpoint has no scheduling parameter.
+        self.message.send_at = "2022-10-11T12:13:14Z"
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "send_at"):
+            self.message.send()
+
+    def test_tags(self):
+        self.message.tags = ["receipt", "reorder test 12"]
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(
+            json.loads(data["headers"]["X-Tags"]),
+            ["receipt", "reorder test 12"],
+        )
+
+    def test_headers_metadata_tags_interaction(self):
+        # Three features that use custom headers must not clobber each other
+        self.message.extra_headers = {"X-Custom": "custom value"}
+        self.message.metadata = {"user_id": "12345"}
+        self.message.tags = ["receipt", "reorder test 12"]
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(
+            data["headers"],
+            {
+                "X-Custom": "custom value",
+                "X-Tags": '["receipt", "reorder test 12"]',
+                "X-Metadata": '{"user_id": "12345"}',
+            },
+        )
+
+    def test_template_id(self):
+        self.message.template_id = "tpl_welcome"
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["templateId"], "tpl_welcome")
+
+    def test_template_with_merge_global_data(self):
+        # MailKite renders templates server-side from templateData.
+        message = AnymailMessage(
+            from_email="from@example.com",
+            to=["to@example.com"],
+            template_id="tpl_welcome",
+            merge_global_data={"name": "Ann", "team": "MailKite"},
+        )
+        message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["templateId"], "tpl_welcome")
+        self.assertEqual(data["templateData"], {"name": "Ann", "team": "MailKite"})
+
+    def test_merge_global_data_without_template(self):
+        # merge_global_data maps to templateData even without a template
+        message = AnymailMessage(
+            from_email="from@example.com",
+            to=["to@example.com"],
+            merge_global_data={"name": "Ann"},
+        )
+        message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["templateData"], {"name": "Ann"})
+
+    def test_merge_data_unsupported(self):
+        # MailKite sends a single message to all recipients (no batch), so
+        # per-recipient merge data can't be expressed.
+        self.message.merge_data = {"to@example.com": {"customer_id": 3}}
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "merge_data"):
+            self.message.send()
+
+    def test_empty_merge_data(self):
+        # Empty merge_data is a no-op (no batch send on this ESP)
+        message = AnymailMessage(
+            from_email="from@example.com",
+            to=["alice@example.com", "Bob <bob@example.com>"],
+            merge_data={},
+        )
+        message.send()
+        self.assert_esp_called("/v1/send")
+        data = self.get_api_call_json()
+        # A single send to both recipients:
+        self.assertEqual(data["to"], ["alice@example.com", "Bob <bob@example.com>"])
+
+    def test_track_opens(self):
+        self.message.track_opens = True
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "track_opens"):
+            self.message.send()
+
+    def test_track_clicks(self):
+        self.message.track_clicks = True
+        with self.assertRaisesMessage(AnymailUnsupportedFeature, "track_clicks"):
+            self.message.send()
+
+    def test_default_omits_options(self):
+        """Make sure by default we don't send any ESP-specific options.
+
+        Options not specified by the caller should be omitted entirely from
+        the API call (*not* sent as False or empty). This ensures
+        that your ESP account settings apply by default.
+        """
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertNotIn("headers", data)
+        self.assertNotIn("attachments", data)
+        self.assertNotIn("templateId", data)
+        self.assertNotIn("templateData", data)
+        self.assertNotIn("replyTo", data)
+
+    def test_esp_extra(self):
+        self.message.esp_extra = {"inReplyTo": "<a1b2@mail.example.com>"}
+        self.message.send()
+        data = self.get_api_call_json()
+        self.assertEqual(data["inReplyTo"], "<a1b2@mail.example.com>")
+
+    # noinspection PyUnresolvedReferences
+    def test_send_attaches_anymail_status(self):
+        """The anymail_status should be attached to the message when it is sent"""
+        msg = mail.EmailMessage(
+            "Subject",
+            "Message",
+            "from@example.com",
+            ["Recipient <to1@example.com>"],
+        )
+        sent = msg.send()
+        self.assertEqual(sent, 1)
+        self.assertEqual(msg.anymail_status.status, {"queued"})
+        self.assertEqual(msg.anymail_status.message_id, "msg_test12345")
+        self.assertEqual(
+            msg.anymail_status.recipients["to1@example.com"].status, "queued"
+        )
+        self.assertEqual(
+            msg.anymail_status.recipients["to1@example.com"].message_id,
+            "msg_test12345",
+        )
+        self.assertEqual(
+            msg.anymail_status.esp_response.content, self.DEFAULT_RAW_RESPONSE
+        )
+
+    def test_response_status_is_passed_through(self):
+        # When the ESP returns e.g. "sent", that becomes the recipient status.
+        self.set_mock_response(json_data={"id": "msg_abc", "status": "sent"})
+        msg = mail.EmailMessage(
+            "Subject", "Message", "from@example.com", ["to@example.com"]
+        )
+        msg.send()
+        self.assertEqual(msg.anymail_status.status, {"sent"})
+        self.assertEqual(msg.anymail_status.message_id, "msg_abc")
+        self.assertEqual(msg.anymail_status.recipients["to@example.com"].status, "sent")
+
+    # noinspection PyUnresolvedReferences
+    @ignore_fail_silently_warning()
+    def test_send_failed_anymail_status(self):
+        """If the send fails, anymail_status should contain initial values"""
+        self.set_mock_response(status_code=500)
+        sent = self.message.send(fail_silently=True)
+        self.assertEqual(sent, 0)
+        self.assertIsNone(self.message.anymail_status.status)
+        self.assertIsNone(self.message.anymail_status.message_id)
+        self.assertEqual(self.message.anymail_status.recipients, {})
+        self.assertIsNone(self.message.anymail_status.esp_response)
+
+    # noinspection PyUnresolvedReferences
+    def test_send_unparsable_response(self):
+        """
+        If the send succeeds, but a non-JSON API response, should raise an API exception
+        """
+        mock_response = self.set_mock_response(
+            status_code=200, raw=b"yikes, this isn't a real response"
+        )
+        with self.assertRaises(AnymailAPIError):
+            self.message.send()
+        self.assertIsNone(self.message.anymail_status.status)
+        self.assertIsNone(self.message.anymail_status.message_id)
+        self.assertEqual(self.message.anymail_status.recipients, {})
+        self.assertEqual(self.message.anymail_status.esp_response, mock_response)
+
+    def test_json_serialization_errors(self):
+        """Try to provide more information about non-json-serializable data"""
+        self.message.metadata = {"price": Decimal("19.99")}  # yeah, don't do this
+        with self.assertRaises(AnymailSerializationError) as cm:
+            self.message.send()
+        err = cm.exception
+        self.assertIsInstance(err, TypeError)  # compatibility with json.dumps
+        # our added context:
+        self.assertIn("Don't know how to send this data to MailKite", str(err))
+        # original message:
+        self.assertRegex(str(err), r"Decimal.*is not JSON serializable")
+
+
+@tag("mailkite")
+class MailKiteBackendRecipientsRefusedTests(MailKiteBackendMockAPITestCase):
+    # MailKite doesn't check suppression/bounce lists at time of send -- it always
+    # just queues the message. Listen for delivery-status events to detect
+    # refused recipients.
+    pass
+
+
+@tag("mailkite")
+class MailKiteBackendSessionSharingTestCase(
+    SessionSharingTestCases, MailKiteBackendMockAPITestCase
+):
+    """Requests session sharing tests"""
+
+    pass  # tests are defined in SessionSharingTestCases
+
+
+@tag("mailkite")
+@override_settings(
+    MAILERS={"default": {"BACKEND": "anymail.backends.mailkite.EmailBackend"}},
+)
+class MailKiteBackendImproperlyConfiguredTests(AnymailTestMixin, SimpleTestCase):
+    """Test ESP backend without required settings in place"""
+
+    def test_missing_api_key(self):
+        with self.assertRaisesRegex(
+            AnymailConfigurationError,
+            r"'api_key'|\bMAILKITE_API_KEY.*ANYMAIL_MAILKITE_API_KEY",
+        ):
+            mail.send_mail("Subject", "Message", "from@example.com", ["to@example.com"])

--- a/tests/test_mailkite_inbound.py
+++ b/tests/test_mailkite_inbound.py
@@ -1,0 +1,283 @@
+import hashlib
+import hmac
+import json
+from base64 import b64encode
+from datetime import datetime, timezone
+from unittest.mock import ANY, patch
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings, tag
+
+from anymail.inbound import AnymailInboundMessage
+from anymail.signals import AnymailInboundEvent
+from anymail.webhooks.mailkite import MailKiteInboundWebhookView
+
+from .utils import sample_image_content
+from .webhook_cases import WebhookBasicAuthTestCase, WebhookTestCase
+
+TEST_WEBHOOK_SECRET = "TEST_WEBHOOK_SECRET"
+
+
+def mailkite_signature_header(data, secret, timestamp_ms=None):
+    """Generate a MailKite x-mailkite-signature header value for data"""
+    if timestamp_ms is None:
+        timestamp_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    signature = hmac.new(
+        key=secret.encode("ascii"),
+        msg=b"%d." % timestamp_ms + data,
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+    return "t=%d,v1=%s" % (timestamp_ms, signature)
+
+
+class MailKiteWebhookTestCase(WebhookTestCase):
+    def client_post_signed(
+        self, url, json_data, secret=TEST_WEBHOOK_SECRET, timestamp_ms=None
+    ):
+        """Return self.client.post(url, serialized json_data) signed with secret"""
+        data = json.dumps(json_data).encode("utf-8")
+        return self.client.post(
+            url,
+            content_type="application/json",
+            data=data,
+            headers={
+                "X-MailKite-Signature": mailkite_signature_header(
+                    data, secret, timestamp_ms
+                )
+            },
+        )
+
+
+def sample_inbound_event(**overrides):
+    """A representative MailKite email.received webhook payload"""
+    event = {
+        "id": "msg_2Hk9QpVn4tLd",
+        "type": "email.received",
+        "from": {"address": "envelope-from@example.org", "name": "Sender Name"},
+        "to": [{"address": "test@inbound.example.com", "name": "Recipient"}],
+        "subject": "Test subject",
+        "text": "Test body plain",
+        "html": "<div>Test body html</div>",
+        "threadId": "<origin@example.org>",
+        "receivedAt": 1785196800000,
+        "receivedAtIso": "2026-07-28T00:00:00.000Z",
+        "auth": {"spf": "pass", "dkim": "pass", "dmarc": "pass", "spam": "ham"},
+        "attachments": [],
+    }
+    event.update(overrides)
+    return event
+
+
+@tag("mailkite")
+@override_settings(ANYMAIL_MAILKITE_WEBHOOK_SECRET=TEST_WEBHOOK_SECRET)
+class MailKiteInboundSecurityTestCase(
+    MailKiteWebhookTestCase, WebhookBasicAuthTestCase
+):
+    should_warn_if_no_auth = False  # because we check webhook signature
+
+    def call_webhook(self):
+        return self.client_post_signed(
+            "/anymail/mailkite/inbound/",
+            sample_inbound_event(),
+            secret=TEST_WEBHOOK_SECRET,
+        )
+
+    # Additional tests are in WebhookBasicAuthTestCase
+
+    def test_verifies_correct_signature(self):
+        response = self.client_post_signed(
+            "/anymail/mailkite/inbound/",
+            sample_inbound_event(),
+            secret=TEST_WEBHOOK_SECRET,
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_verifies_missing_signature(self):
+        response = self.client.post(
+            "/anymail/mailkite/inbound/",
+            content_type="application/json",
+            data=json.dumps(sample_inbound_event()),
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_verifies_bad_signature(self):
+        # This also verifies that the error log references the correct setting to check.
+        with self.assertLogs() as logs:
+            response = self.client_post_signed(
+                "/anymail/mailkite/inbound/",
+                sample_inbound_event(),
+                secret="wrong webhook secret",
+            )
+        # SuspiciousOperation causes 400 response (even in test client):
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("check Anymail MAILKITE_WEBHOOK_SECRET", logs.output[0])
+
+    def test_verifies_expired_signature(self):
+        ten_minutes_ago_ms = (
+            int(datetime.now(timezone.utc).timestamp() * 1000) - 10 * 60 * 1000
+        )
+        response = self.client_post_signed(
+            "/anymail/mailkite/inbound/",
+            sample_inbound_event(),
+            timestamp_ms=ten_minutes_ago_ms,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_verifies_malformed_signature(self):
+        response = self.client.post(
+            "/anymail/mailkite/inbound/",
+            content_type="application/json",
+            data=json.dumps(sample_inbound_event()),
+            headers={"X-MailKite-Signature": "not-a-signature"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+@tag("mailkite")
+class MailKiteInboundSettingsTestCase(MailKiteWebhookTestCase):
+    def test_requires_webhook_secret(self):
+        with self.assertRaisesMessage(ImproperlyConfigured, "MAILKITE_WEBHOOK_SECRET"):
+            self.client_post_signed(
+                "/anymail/mailkite/inbound/", sample_inbound_event()
+            )
+
+
+@tag("mailkite")
+@override_settings(ANYMAIL_MAILKITE_WEBHOOK_SECRET=TEST_WEBHOOK_SECRET)
+class MailKiteInboundTestCase(MailKiteWebhookTestCase):
+    def test_inbound_basics(self):
+        response = self.client_post_signed(
+            "/anymail/mailkite/inbound/", sample_inbound_event()
+        )
+        self.assertEqual(response.status_code, 200)
+        kwargs = self.assert_handler_called_once_with(
+            self.inbound_handler,
+            sender=MailKiteInboundWebhookView,
+            event=ANY,
+            esp_name="MailKite",
+        )
+        event = kwargs["event"]
+        self.assertIsInstance(event, AnymailInboundEvent)
+        self.assertEqual(event.event_type, "inbound")
+        self.assertEqual(
+            event.timestamp,
+            datetime(2026, 7, 28, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(event.event_id, "msg_2Hk9QpVn4tLd")
+        self.assertIsInstance(event.esp_event, dict)
+        self.assertEqual(event.esp_event["type"], "email.received")
+
+        message = event.message
+        self.assertIsInstance(message, AnymailInboundMessage)
+        self.assertEqual(message.envelope_sender, "envelope-from@example.org")
+        self.assertEqual(message.envelope_recipient, "test@inbound.example.com")
+        self.assertEqual(
+            str(message.from_email), "Sender Name <envelope-from@example.org>"
+        )
+        self.assertEqual(len(message.to), 1)
+        self.assertEqual(str(message.to[0]), "Recipient <test@inbound.example.com>")
+        self.assertEqual(message.subject, "Test subject")
+        self.assertEqual(message.text, "Test body plain")
+        self.assertEqual(message.html, "<div>Test body html</div>")
+        self.assertIs(message.spam_detected, False)
+
+    def test_spam_detected(self):
+        event_data = sample_inbound_event(
+            auth={"spf": "fail", "dkim": None, "dmarc": "fail", "spam": "spam"}
+        )
+        self.client_post_signed("/anymail/mailkite/inbound/", event_data)
+        kwargs = self.get_kwargs(self.inbound_handler)
+        self.assertIs(kwargs["event"].message.spam_detected, True)
+
+    def test_unknown_spam_verdict(self):
+        # An unrecognized (or missing) verdict must read as "unknown", not "ham"
+        event_data = sample_inbound_event(
+            auth={"spf": None, "dkim": None, "dmarc": None, "spam": None}
+        )
+        self.client_post_signed("/anymail/mailkite/inbound/", event_data)
+        kwargs = self.get_kwargs(self.inbound_handler)
+        self.assertIsNone(kwargs["event"].message.spam_detected)
+
+    def test_no_display_names(self):
+        # from.name/to[].name are omitted when the message carried none
+        event_data = sample_inbound_event(
+            **{
+                "from": {"address": "sender@example.org"},
+                "to": [{"address": "test@inbound.example.com"}],
+                "subject": None,
+                "text": None,
+                "html": None,
+            }
+        )
+        self.client_post_signed("/anymail/mailkite/inbound/", event_data)
+        kwargs = self.get_kwargs(self.inbound_handler)
+        message = kwargs["event"].message
+        self.assertEqual(str(message.from_email), "sender@example.org")
+        self.assertEqual(str(message.to[0]), "test@inbound.example.com")
+        self.assertIsNone(message.subject)
+        self.assertIsNone(message.text)
+        self.assertIsNone(message.html)
+
+    def test_attachment_inline_content(self):
+        # Zero-retention/encrypted domains inline the bytes as base64 `content`
+        image_content = sample_image_content()
+        event_data = sample_inbound_event(
+            attachments=[
+                {
+                    "filename": "sample_image.png",
+                    "contentType": "image/png",
+                    "size": len(image_content),
+                    "content": b64encode(image_content).decode("ascii"),
+                }
+            ]
+        )
+        self.client_post_signed("/anymail/mailkite/inbound/", event_data)
+        kwargs = self.get_kwargs(self.inbound_handler)
+        attachments = kwargs["event"].message.attachments
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments[0].get_filename(), "sample_image.png")
+        self.assertEqual(attachments[0].get_content_type(), "image/png")
+        self.assertEqual(attachments[0].as_uploaded_file().read(), image_content)
+
+    def test_attachment_url(self):
+        # The normal case: a signed, credential-free GET link, fetched on receipt
+        attachment_url = "https://api.mailkite.dev/att/2Hk9QpVn4tLd/0?exp=1&sig=abc"
+        event_data = sample_inbound_event(
+            attachments=[
+                {
+                    "id": "msg_2Hk9QpVn4tLd:0",
+                    "filename": "report.pdf",
+                    "contentType": "application/pdf",
+                    "size": 15,
+                    "url": attachment_url,
+                }
+            ]
+        )
+        with patch("anymail.webhooks.mailkite.requests.get") as mock_get:
+            mock_get.return_value.content = b"%PDF-1.4 sample"
+            mock_get.return_value.raise_for_status.return_value = None
+            self.client_post_signed("/anymail/mailkite/inbound/", event_data)
+        mock_get.assert_called_once_with(attachment_url, timeout=30)
+        kwargs = self.get_kwargs(self.inbound_handler)
+        attachments = kwargs["event"].message.attachments
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments[0].get_filename(), "report.pdf")
+        self.assertEqual(attachments[0].get_content_type(), "application/pdf")
+        self.assertEqual(attachments[0].as_uploaded_file().read(), b"%PDF-1.4 sample")
+
+    def test_ignores_unknown_event_types(self):
+        # Future event types on the same webhook must not error or fire signals
+        response = self.client_post_signed(
+            "/anymail/mailkite/inbound/",
+            {"id": "evt_1", "type": "email.delivered"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.inbound_handler.call_count, 0)
+
+    def test_misconfigured_tracking(self):
+        # (No tracking webhook exists yet; this documents current behavior:
+        # non-inbound events are ignored rather than raising.)
+        response = self.client_post_signed(
+            "/anymail/mailkite/inbound/", {"type": "email.bounced"}
+        )
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_mailkite_inbound.py
+++ b/tests/test_mailkite_inbound.py
@@ -266,18 +266,24 @@ class MailKiteInboundTestCase(MailKiteWebhookTestCase):
         self.assertEqual(attachments[0].as_uploaded_file().read(), b"%PDF-1.4 sample")
 
     def test_ignores_unknown_event_types(self):
-        # Future event types on the same webhook must not error or fire signals
+        # Non-email.* payloads must not error or fire signals
         response = self.client_post_signed(
             "/anymail/mailkite/inbound/",
-            {"id": "evt_1", "type": "email.delivered"},
+            {"id": "evt_1", "type": "ping"},
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.inbound_handler.call_count, 0)
 
     def test_misconfigured_tracking(self):
-        # (No tracking webhook exists yet; this documents current behavior:
-        # non-inbound events are ignored rather than raising.)
-        response = self.client_post_signed(
-            "/anymail/mailkite/inbound/", {"type": "email.bounced"}
-        )
-        self.assertEqual(response.status_code, 200)
+        # A tracking event arriving on the inbound URL means the webhook URLs
+        # are swapped -- surface a configuration hint rather than dropping it.
+        from anymail.exceptions import AnymailConfigurationError
+
+        with self.assertRaisesMessage(
+            AnymailConfigurationError,
+            "You seem to have set MailKite's *tracking-event* webhook"
+            " to Anymail's MailKite *inbound* webhook URL.",
+        ):
+            self.client_post_signed(
+                "/anymail/mailkite/inbound/", {"type": "email.bounced"}
+            )

--- a/tests/test_mailkite_integration.py
+++ b/tests/test_mailkite_integration.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from datetime import datetime, timedelta, timezone
 from email.utils import formataddr
 
 from django.test import SimpleTestCase, tag
@@ -87,3 +88,22 @@ class MailKiteBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             recipient_status["test+to1@anymail.dev"].message_id,
             recipient_status["test+to2@anymail.dev"].message_id,
         )
+
+    def test_scheduled_send(self):
+        # A future send_at parks the message with MailKite's scheduler.
+        # (Don't add metadata, tags, or extra headers here: MailKite doesn't
+        # yet accept custom headers on scheduled sends.)
+        message = AnymailMessage(
+            subject="Anymail MailKite scheduled-send integration test",
+            body="This message was scheduled 2 minutes ahead via send_at",
+            from_email=self.from_email,
+            to=["test+to1@anymail.dev"],
+        )
+        message.send_at = datetime.now(timezone.utc) + timedelta(minutes=2)
+        message.send()
+
+        anymail_status = message.anymail_status
+        # MailKite returns an ssnd_… scheduled-send id and "scheduled" status,
+        # which Anymail normalizes to "queued":
+        self.assertEqual(anymail_status.status, {"queued"})
+        self.assertTrue(anymail_status.message_id.startswith("ssnd_"))

--- a/tests/test_mailkite_integration.py
+++ b/tests/test_mailkite_integration.py
@@ -1,0 +1,89 @@
+import os
+import unittest
+from email.utils import formataddr
+
+from django.test import SimpleTestCase, tag
+
+from anymail.message import AnymailMessage
+
+from .utils import AnymailTestMixin, override_settings
+
+ANYMAIL_TEST_MAILKITE_API_KEY = os.getenv("ANYMAIL_TEST_MAILKITE_API_KEY")
+ANYMAIL_TEST_MAILKITE_DOMAIN = os.getenv("ANYMAIL_TEST_MAILKITE_DOMAIN")
+
+
+@tag("mailkite", "live")
+@unittest.skipUnless(
+    ANYMAIL_TEST_MAILKITE_API_KEY and ANYMAIL_TEST_MAILKITE_DOMAIN,
+    "Set ANYMAIL_TEST_MAILKITE_API_KEY and ANYMAIL_TEST_MAILKITE_DOMAIN "
+    "environment variables to run MailKite integration tests",
+)
+@override_settings(
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.mailkite.EmailBackend",
+            "OPTIONS": {"api_key": ANYMAIL_TEST_MAILKITE_API_KEY},
+        },
+    },
+)
+class MailKiteBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
+    """MailKite API integration tests
+
+    MailKite doesn't have a sandbox, so these tests run against the **live**
+    MailKite API, using the environment variable ``ANYMAIL_TEST_MAILKITE_API_KEY``
+    as the API key, and ``ANYMAIL_TEST_MAILKITE_DOMAIN`` to construct sender
+    addresses. If those variables are not set, these tests won't run.
+
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.from_email = "from@%s" % ANYMAIL_TEST_MAILKITE_DOMAIN
+        self.message = AnymailMessage(
+            "Anymail MailKite integration test",
+            "Text content",
+            self.from_email,
+            ["test+to1@anymail.dev"],
+        )
+        self.message.attach_alternative("<p>HTML content</p>", "text/html")
+
+    def test_simple_send(self):
+        sent_count = self.message.send()
+        self.assertEqual(sent_count, 1)
+
+        anymail_status = self.message.anymail_status
+        sent_status = anymail_status.recipients["test+to1@anymail.dev"].status
+        message_id = anymail_status.recipients["test+to1@anymail.dev"].message_id
+
+        self.assertIn(sent_status, {"queued", "sent"})  # MailKite queues then sends
+        self.assertGreater(len(message_id), 0)  # non-empty string
+        # set of all recipient statuses:
+        self.assertEqual(anymail_status.status, {sent_status})
+        self.assertEqual(anymail_status.message_id, message_id)
+
+    def test_all_options(self):
+        message = AnymailMessage(
+            subject="Anymail MailKite all-options integration test",
+            body="This is the text body",
+            from_email=formataddr(("Test From", self.from_email)),
+            to=["test+to1@anymail.dev", '"Recipient 2" <test+to2@anymail.dev>'],
+            cc=["test+cc1@anymail.dev"],
+            reply_to=["reply@example.com"],
+            headers={"X-Anymail-Test": "value"},
+            metadata={"meta1": "simple string", "meta2": 2},
+            tags=["integration", "tag 2"],
+        )
+        message.attach_alternative("<p>HTML content</p>", "text/html")
+        message.attach("attachment1.txt", "Here is some\ntext for you", "text/plain")
+
+        message.send()
+        # All recipients share the single returned message id:
+        self.assertGreater(len(message.anymail_status.message_id), 0)
+        recipient_status = message.anymail_status.recipients
+        self.assertIn(
+            recipient_status["test+to1@anymail.dev"].status, {"queued", "sent"}
+        )
+        self.assertEqual(
+            recipient_status["test+to1@anymail.dev"].message_id,
+            recipient_status["test+to2@anymail.dev"].message_id,
+        )

--- a/tests/test_mailkite_integration.py
+++ b/tests/test_mailkite_integration.py
@@ -73,6 +73,7 @@ class MailKiteBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
             headers={"X-Anymail-Test": "value"},
             metadata={"meta1": "simple string", "meta2": 2},
             tags=["integration", "tag 2"],
+            track_opens=True,
         )
         message.attach_alternative("<p>HTML content</p>", "text/html")
         message.attach("attachment1.txt", "Here is some\ntext for you", "text/plain")

--- a/tests/test_mailkite_integration.py
+++ b/tests/test_mailkite_integration.py
@@ -91,13 +91,15 @@ class MailKiteBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
 
     def test_scheduled_send(self):
         # A future send_at parks the message with MailKite's scheduler.
-        # (Don't add metadata, tags, or extra headers here: MailKite doesn't
-        # yet accept custom headers on scheduled sends.)
+        # Metadata and tags (carried as headers) are preserved on the
+        # scheduled message.
         message = AnymailMessage(
             subject="Anymail MailKite scheduled-send integration test",
             body="This message was scheduled 2 minutes ahead via send_at",
             from_email=self.from_email,
             to=["test+to1@anymail.dev"],
+            metadata={"meta1": "scheduled"},
+            tags=["integration-scheduled"],
         )
         message.send_at = datetime.now(timezone.utc) + timedelta(minutes=2)
         message.send()

--- a/tests/test_mailkite_integration.py
+++ b/tests/test_mailkite_integration.py
@@ -110,3 +110,32 @@ class MailKiteBackendIntegrationTests(AnymailTestMixin, SimpleTestCase):
         # which Anymail normalizes to "queued":
         self.assertEqual(anymail_status.status, {"queued"})
         self.assertTrue(anymail_status.message_id.startswith("ssnd_"))
+
+    def test_batch_send(self):
+        # merge_data switches to MailKite's batch endpoint: one personalized
+        # message per recipient, each with its own message id.
+        message = AnymailMessage(
+            subject="Anymail MailKite batch integration test, {{name}}",
+            body="This message was personalized for {{name}} ({{group}})",
+            from_email=self.from_email,
+            to=["test+to1@anymail.dev", "Recipient 2 <test+to2@anymail.dev>"],
+            merge_data={
+                "test+to1@anymail.dev": {"name": "One"},
+                "test+to2@anymail.dev": {"name": "Two"},
+            },
+            merge_global_data={"group": "integration"},
+            merge_metadata={
+                "test+to1@anymail.dev": {"user_id": 1},
+                "test+to2@anymail.dev": {"user_id": 2},
+            },
+        )
+        message.send()
+
+        recipient_status = message.anymail_status.recipients
+        self.assertEqual(recipient_status["test+to1@anymail.dev"].status, "sent")
+        self.assertEqual(recipient_status["test+to2@anymail.dev"].status, "sent")
+        # Batch = one message per recipient, so the ids differ:
+        self.assertNotEqual(
+            recipient_status["test+to1@anymail.dev"].message_id,
+            recipient_status["test+to2@anymail.dev"].message_id,
+        )

--- a/tests/test_mailkite_tracking.py
+++ b/tests/test_mailkite_tracking.py
@@ -1,0 +1,181 @@
+import json
+from datetime import datetime, timezone
+from unittest.mock import ANY
+
+from django.test import override_settings, tag
+
+from anymail.exceptions import AnymailConfigurationError
+from anymail.signals import AnymailTrackingEvent
+from anymail.webhooks.mailkite import MailKiteTrackingWebhookView
+
+from .test_mailkite_inbound import TEST_WEBHOOK_SECRET, MailKiteWebhookTestCase
+from .webhook_cases import WebhookBasicAuthTestCase
+
+
+def sample_tracking_event(event_type="email.sent", **data_overrides):
+    """A representative MailKite tracking-event webhook payload"""
+    data = {
+        "messageId": "msg_2Hk9QpVn4tLd",
+        "providerMessageId": None,
+        "from": "from@example.com",
+        "to": "recipient@example.com",
+        "subject": "Test subject",
+    }
+    data.update(data_overrides)
+    return {
+        "id": "evt_5Vp2RqWm8xNc",
+        "type": event_type,
+        "createdAt": 1785196800000,
+        "createdAtIso": "2026-07-28T00:00:00.000Z",
+        "data": data,
+    }
+
+
+@tag("mailkite")
+@override_settings(ANYMAIL_MAILKITE_WEBHOOK_SECRET=TEST_WEBHOOK_SECRET)
+class MailKiteTrackingSecurityTestCase(
+    MailKiteWebhookTestCase, WebhookBasicAuthTestCase
+):
+    should_warn_if_no_auth = False  # because we check webhook signature
+
+    def call_webhook(self):
+        return self.client_post_signed(
+            "/anymail/mailkite/tracking/",
+            sample_tracking_event(),
+            secret=TEST_WEBHOOK_SECRET,
+        )
+
+    # Additional tests are in WebhookBasicAuthTestCase
+
+    def test_verifies_missing_signature(self):
+        response = self.client.post(
+            "/anymail/mailkite/tracking/",
+            content_type="application/json",
+            data=json.dumps(sample_tracking_event()),
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_verifies_bad_signature(self):
+        with self.assertLogs() as logs:
+            response = self.client_post_signed(
+                "/anymail/mailkite/tracking/",
+                sample_tracking_event(),
+                secret="wrong webhook secret",
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("check Anymail MAILKITE_WEBHOOK_SECRET", logs.output[0])
+
+
+@tag("mailkite")
+@override_settings(ANYMAIL_MAILKITE_WEBHOOK_SECRET=TEST_WEBHOOK_SECRET)
+class MailKiteTrackingTestCase(MailKiteWebhookTestCase):
+    def assert_tracking_event(self, payload):
+        response = self.client_post_signed("/anymail/mailkite/tracking/", payload)
+        self.assertEqual(response.status_code, 200)
+        kwargs = self.assert_handler_called_once_with(
+            self.tracking_handler,
+            sender=MailKiteTrackingWebhookView,
+            event=ANY,
+            esp_name="MailKite",
+        )
+        return kwargs["event"]
+
+    def test_sent_event(self):
+        event = self.assert_tracking_event(sample_tracking_event("email.sent"))
+        self.assertIsInstance(event, AnymailTrackingEvent)
+        self.assertEqual(event.event_type, "sent")
+        self.assertEqual(
+            event.timestamp, datetime(2026, 7, 28, 0, 0, 0, tzinfo=timezone.utc)
+        )
+        self.assertEqual(event.event_id, "evt_5Vp2RqWm8xNc")
+        self.assertEqual(event.message_id, "msg_2Hk9QpVn4tLd")
+        self.assertEqual(event.recipient, "recipient@example.com")
+        self.assertIsNone(event.reject_reason)
+        self.assertEqual(event.esp_event["type"], "email.sent")
+
+    def test_bounced_event(self):
+        # Provider bounce notifications can't be correlated to a stored
+        # message: messageId is null, recipient is the reliable key.
+        event = self.assert_tracking_event(
+            sample_tracking_event(
+                "email.bounced",
+                messageId=None,
+                providerMessageId="0100019fb…-000000",
+                bounce={"type": "hard", "diagnostic": "550 5.1.1 user unknown"},
+            )
+        )
+        self.assertEqual(event.event_type, "bounced")
+        self.assertEqual(event.reject_reason, "bounced")
+        self.assertEqual(event.mta_response, "550 5.1.1 user unknown")
+        self.assertEqual(event.description, "550 5.1.1 user unknown")
+        self.assertIsNone(event.message_id)
+        self.assertEqual(event.recipient, "recipient@example.com")
+
+    def test_complained_event(self):
+        event = self.assert_tracking_event(
+            sample_tracking_event(
+                "email.complained",
+                messageId=None,
+                complaint={"feedbackType": "abuse"},
+            )
+        )
+        self.assertEqual(event.event_type, "complained")
+        self.assertEqual(event.reject_reason, "spam")
+        self.assertEqual(event.description, "abuse")
+
+    def test_opened_event(self):
+        event = self.assert_tracking_event(
+            sample_tracking_event(
+                "email.opened",
+                open={
+                    "machine": False,
+                    "machineKind": None,
+                    "userAgent": "Mozilla/5.0 (Macintosh) AppleWebKit/605",
+                    "client": "Apple Mail",
+                    "os": "macOS",
+                    "device": "desktop",
+                    "country": "US",
+                },
+            )
+        )
+        self.assertEqual(event.event_type, "opened")
+        self.assertEqual(event.user_agent, "Mozilla/5.0 (Macintosh) AppleWebKit/605")
+        self.assertIsNone(event.click_url)
+
+    def test_clicked_event(self):
+        event = self.assert_tracking_event(
+            sample_tracking_event(
+                "email.clicked",
+                click={
+                    "url": "https://example.com/landing?x=1",
+                    "machine": False,
+                    "machineKind": None,
+                    "userAgent": "Mozilla/5.0 Chrome/126",
+                    "client": "Chrome",
+                    "os": "macOS",
+                    "device": "desktop",
+                    "country": "US",
+                },
+            )
+        )
+        self.assertEqual(event.event_type, "clicked")
+        self.assertEqual(event.click_url, "https://example.com/landing?x=1")
+        self.assertEqual(event.user_agent, "Mozilla/5.0 Chrome/126")
+
+    def test_unknown_event_type(self):
+        # A future event type maps to "unknown" rather than erroring.
+        event = self.assert_tracking_event(
+            sample_tracking_event("email.delivery_delayed")
+        )
+        self.assertEqual(event.event_type, "unknown")
+
+    def test_misconfigured_inbound(self):
+        with self.assertRaisesMessage(
+            AnymailConfigurationError,
+            "You seem to have set MailKite's *inbound* webhook"
+            " to Anymail's MailKite *tracking* webhook URL.",
+        ):
+            self.client_post_signed(
+                "/anymail/mailkite/tracking/",
+                {"id": "msg_1", "type": "email.received"},
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ setenv =
     mailersend: ANYMAIL_ONLY_TEST=mailersend
     mailgun: ANYMAIL_ONLY_TEST=mailgun
     mailjet: ANYMAIL_ONLY_TEST=mailjet
+    mailkite: ANYMAIL_ONLY_TEST=mailkite
     mailtrap: ANYMAIL_ONLY_TEST=mailtrap
     mandrill: ANYMAIL_ONLY_TEST=mandrill
     postal: ANYMAIL_ONLY_TEST=postal


### PR DESCRIPTION
## What this adds

A new Anymail email backend for **MailKite** (`mailkite.dev`) — an inbound-first developer email platform (transactional send *and* parsed inbound over signed webhooks). This PR implements the **transactional send API** (`POST /v1/send`), modeled closely on the existing Resend and Postmark JSON backends.

It follows `ADDING_ESPS.md` end-to-end: backend + payload, mock tests, docs + feature matrix, and all the boilerplate entries (pyproject, README, tox, CI matrix).

## How to configure

```python
# settings.py
EMAIL_BACKEND = "anymail.backends.mailkite.EmailBackend"

ANYMAIL = {
    "MAILKITE_API_KEY": "<your mk_live_… key>",  # or MAILKITE_API_KEY at root
}
```

The `from` address must be on a domain whose ownership is verified in MailKite.

## What's supported

| Anymail feature | MailKite |
| --- | --- |
| from / to / cc / bcc / subject / text / html | ✅ |
| `reply_to` | ✅ (single string — multiple addresses are joined) |
| `extra_headers` | ✅ (MailKite `headers`, string values) |
| `metadata` / `tags` | ✅ (carried as JSON in `X-Metadata` / `X-Tags` headers — MailKite has no dedicated fields) |
| `attachments` | ✅ (base64 `content` + camelCase `contentType`) |
| `template_id` + `merge_global_data` | ✅ (→ `templateId` / `templateData`, server-rendered) |
| `esp_extra` | ✅ |
| `anymail_status` | ✅ (from `{id, status}`) |

Raised as `AnymailUnsupportedFeature` (the send API genuinely can't express these):

- `envelope_sender`, `send_at` (no scheduling field on `/v1/send`)
- `merge_data` / `merge_metadata` / `merge_headers` — MailKite sends **one** message to all recipients (there's no per-recipient batch), so per-recipient merge can't be expressed. Global `template_id` + `merge_global_data` is the supported path.
- inline attachments (the send API has no Content-ID field)
- `track_clicks` / `track_opens` (no per-message toggle; configure at account/domain level)

## How I tested

- **43 mock tests** (`tests/test_mailkite_backend.py`) — standard email features, Anymail features, every unsupported feature, API error handling, recipient-status parsing (incl. response `status` pass-through), session sharing, and missing-config errors. All pass.
- **Full suite green** — 1308 tests, 0 failures, no regressions from the config/matrix changes (80 live-integration tests skip without creds, as expected).
- **`black` / `flake8` / `isort` clean** on the new files (matching the project's pre-commit config).
- **Payload verified against the published contract** — the JSON this backend emits for a full-options message matches MailKite's documented `send-request` schema field-for-field (correct endpoint, Bearer auth, `to`/`cc` arrays, single-string `replyTo`, string-valued `headers`, base64 attachment `content` with camelCase `contentType`).

`tests/test_mailkite_integration.py` adds self-skipping live tests gated on `ANYMAIL_TEST_MAILKITE_API_KEY` / `ANYMAIL_TEST_MAILKITE_DOMAIN`, and the CI matrix + secret wiring are in place — you'd just add the secrets when you have a test account.

## Scope & roadmap

This is **send-only**, intentionally. MailKite's headline capability is *inbound* (parsed body + auth verdict as one signed webhook) and delivery-status tracking — adding Anymail inbound (`AnymailInboundEvent`) and tracking (`AnymailTrackingEvent`) webhook handling is the natural follow-up. I've marked both "Not yet" in the feature matrix and noted it in `docs/esps/mailkite.rst`. Happy to tackle inbound next if there's interest.

MailKite has a free tier, so live integration testing is straightforward.

## Maintenance

I'm with the MailKite team and can maintain this backend going forward — keeping it current with MailKite API changes, adding inbound/tracking support, and responding to issues.

---

*This contribution was prepared by MailKite's development team (with AI assistance, as disclosed in the commit trailer). No promotional or referral content is included in the code or docs.*
