### PR TITLE
Docs: remove Brevo's "html body required" quirk section

### DIFF
--- a/docs/esps/brevo.rst
+++ b/docs/esps/brevo.rst
@@ -130,15 +130,6 @@ override this by enabling the :setting:`ANYMAIL_IGNORE_UNSUPPORTED_FEATURES`
 setting, and Anymail will try to limit the API request to features
 Brevo can handle.
 
-**HTML body required**
-  Brevo's API returns an error if you attempt to send a message with
-  only a plain-text body. Be sure to :ref:`include HTML <sending-html>`
-  content for your messages if you are not using a template.
-
-  (Brevo *does* allow HTML without a plain-text body. This is generally
-  not recommended, though, as some email systems treat HTML-only content as a
-  spam signal.)
-
 **Inline images**
   Brevo's v3 API doesn't support inline images, at all.
   (Confirmed with Brevo support Feb 2018.)


### PR DESCRIPTION
Hello.
I am migrating one of our project to Brevo, one of our requirements was to test that Brevo does accept text-only email (because that's what we send), so I tested, and it does. So I do this PR to update django-anymail's documentation. The quirk paragraph was added 8 years ago in 4b28760a, I guess things changed meanwhile. It was tested with a 

```shell
curl -s https://api.brevo.com/v3/smtp/email \
  -H "api-key: $MAIL_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "sender": {"email": "$SENDER"},
    "to": [{"email": "$TO"}],
    "subject": "Test text-only Brevo",
    "textContent": "Hello, this an HTML-less email"
  }'
```

The API returned a 201 with the expected `message-id` reply. And mails where delivered.
For information, the text-only email was turned into an HTML-only email, with Brevo's tracking pixel included. The un-asked for conversion wasprobably for the tracking pixel. When the mail sending query is made with both text and html content, no change/conversion happens.

I have no hard-stance on how the section should be changed, maybe you want to keep the warning.

EDIT: wait, it's slightly more complicated : Brevo silently turns the text-only mail into an html-only one. It deserves to be thoroughly documented. I will come back to add more context.
