### PR TITLE
Add Postmark bulk API support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,19 @@ Release history
 ^^^^^^^^^^^^^^^
     ..  This extra heading level keeps the ToC from becoming unmanageably long
 
+vNext
+-----
+
+*Unreleased changes*
+
+Features
+~~~~~~~~
+
+* **Postmark:** Add a ``POSTMARK_MESSAGE_STREAM`` option that controls the
+  Postmark message stream used for sending. With Django 6.1 ``MAILERS`` you can
+  specify a different ``message_stream`` for each configured mailer.
+
+
 v15.1
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,9 +33,13 @@ vNext
 Features
 ~~~~~~~~
 
-* **Postmark:** Add a ``POSTMARK_MESSAGE_STREAM`` option that controls the
+* **Postmark:** Add support for Postmark's bulk API. See
+  `Using Postmark's bulk API
+  <https://anymail.dev/en/latest/esps/postmark/#using-postmark-s-bulk-api>`_.
+
+  Also add a ``POSTMARK_MESSAGE_STREAM`` option to specify the id of the
   Postmark message stream used for sending. With Django 6.1 ``MAILERS`` you can
-  specify a different ``message_stream`` for each configured mailer.
+  use a different ``message_stream`` for each configured mailer.
 
 
 v15.1

--- a/anymail/backends/postmark.py
+++ b/anymail/backends/postmark.py
@@ -25,6 +25,9 @@ class EmailBackend(AnymailRequestsBackend):
         self.server_token = get_anymail_setting(
             "server_token", esp_name=esp_name, kwargs=kwargs, allow_bare=True
         )
+        self.message_stream = get_anymail_setting(
+            "message_stream", esp_name=esp_name, kwargs=kwargs, default=None
+        )
         api_url = get_anymail_setting(
             "api_url",
             esp_name=esp_name,
@@ -304,6 +307,8 @@ class PostmarkPayload(RequestsPayload):
 
     def init_payload(self):
         self.data = {}  # becomes json
+        if self.backend.message_stream is not None:
+            self.data["MessageStream"] = self.backend.message_stream
 
     def set_from_email_list(self, emails):
         # Postmark accepts multiple From email addresses

--- a/anymail/backends/postmark.py
+++ b/anymail/backends/postmark.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 
 from requests.structures import CaseInsensitiveDict
 
@@ -27,6 +28,16 @@ class EmailBackend(AnymailRequestsBackend):
         )
         self.message_stream = get_anymail_setting(
             "message_stream", esp_name=esp_name, kwargs=kwargs, default=None
+        )
+        self.use_bulk_api = get_anymail_setting(
+            "use_bulk_api", esp_name=esp_name, kwargs=kwargs, default=False
+        )
+        # Anymail-generated message IDs are currently used only for Postmark's bulk API.
+        self.generate_message_id = get_anymail_setting(
+            "generate_message_id",
+            esp_name=esp_name,
+            kwargs=kwargs,
+            default=self.use_bulk_api,
         )
         api_url = get_anymail_setting(
             "api_url",
@@ -60,6 +71,10 @@ class EmailBackend(AnymailRequestsBackend):
         )
 
         parsed_response = self.deserialize_json_response(response, payload, message)
+        if "PercentageCompleted" in parsed_response:
+            return self.parse_bulk_recipient_status(
+                response, payload, message, recipient_status, parsed_response
+            )
         if not isinstance(parsed_response, list):
             # non-batch calls return a single response object
             parsed_response = [parsed_response]
@@ -193,6 +208,15 @@ class EmailBackend(AnymailRequestsBackend):
 
         return dict(recipient_status)
 
+    def parse_bulk_recipient_status(
+        self, response, payload, message, recipient_status, parsed_response
+    ):
+        for addr_spec, message_id in payload.generated_message_ids.items():
+            recipient_status[addr_spec] = AnymailRecipientStatus(
+                message_id=message_id, status="queued"
+            )
+        return recipient_status
+
     @staticmethod
     def _addr_specs_from_error_msg(error_msg, pattern):
         """Extract a list of email addr_specs from Postmark error_msg.
@@ -221,9 +245,12 @@ class PostmarkPayload(RequestsPayload):
         self.merge_data = None
         self.merge_metadata = None
         self.merge_headers = {}
+        self.generated_message_ids = {}
         super().__init__(message, defaults, backend, headers=headers, *args, **kwargs)
 
     def get_api_endpoint(self):
+        if self.backend.use_bulk_api:
+            return "email/bulk"
         batch_send = self.is_batch()
         if "TemplateAlias" in self.data or "TemplateId" in self.data:
             if batch_send:
@@ -249,6 +276,10 @@ class PostmarkPayload(RequestsPayload):
         return params
 
     def serialize_data(self):
+        if self.backend.generate_message_id:
+            self.generated_message_ids = {
+                to.addr_spec: str(uuid.uuid4()) for to in self.to_emails
+            }
         api_endpoint = self.get_api_endpoint()
         if api_endpoint == "email":
             data = self.data
@@ -260,6 +291,9 @@ class PostmarkPayload(RequestsPayload):
             assert (
                 self.merge_data is None and self.merge_metadata is None
             )  # else it's a batch send
+            data = self.data
+        elif api_endpoint == "email/bulk":
+            self.update_data_for_bulk_api()
             data = self.data
         else:
             raise AssertionError(
@@ -300,6 +334,54 @@ class PostmarkPayload(RequestsPayload):
                 {"Name": name, "Value": value} for name, value in headers.items()
             ]
         return data
+
+    def update_data_for_bulk_api(self):
+        self.data.pop("To", None)
+        cc = self.data.pop("Cc", None)
+        bcc = self.data.pop("Bcc", None)
+        base_metadata = self.data.pop("Metadata", {})
+        base_template_model = self.data.pop("TemplateModel", {})
+
+        messages = []
+        self.data["Messages"] = messages
+        for to in self.to_emails:
+            message = {"To": to.format(idna_encode=self.backend.idna_encode)}
+            if cc is not None:
+                message["Cc"] = cc
+            if bcc is not None:
+                message["Bcc"] = bcc
+
+            if self.merge_data and to.addr_spec in self.merge_data:
+                template_model = base_template_model | self.merge_data[to.addr_spec]
+            else:
+                template_model = base_template_model
+            if template_model:
+                message["TemplateModel"] = template_model
+
+            metadata = base_metadata
+            if self.merge_metadata and to.addr_spec in self.merge_metadata:
+                metadata = metadata | self.merge_metadata[to.addr_spec]
+            try:
+                metadata["anymail_id"] = self.generated_message_ids[to.addr_spec]
+            except KeyError:
+                pass
+            if metadata:
+                message["Metadata"] = metadata
+
+            if to.addr_spec in self.merge_headers:
+                if "Headers" in self.data:
+                    # merge global and recipient headers
+                    headers = CaseInsensitiveDict(
+                        (item["Name"], item["Value"]) for item in self.data["Headers"]
+                    )
+                    headers.update(self.merge_headers[to.addr_spec])
+                else:
+                    headers = self.merge_headers[to.addr_spec]
+                message["Headers"] = [
+                    {"Name": name, "Value": value} for name, value in headers.items()
+                ]
+
+            messages.append(message)
 
     #
     # Payload construction

--- a/anymail/webhooks/postmark.py
+++ b/anymail/webhooks/postmark.py
@@ -138,12 +138,18 @@ class PostmarkTrackingWebhookView(PostmarkBaseWebhookView):
         except KeyError:
             tags = []
 
+        # Anymail-generated Message ID takes precedence (see bulk API sends).
+        try:
+            message_id = metadata["anymail_id"]
+        except KeyError:
+            message_id = esp_event.get("MessageID", None)
+
         return AnymailTrackingEvent(
             description=esp_event.get("Description", None),
             esp_event=esp_event,
             event_id=event_id,
             event_type=event_type,
-            message_id=esp_event.get("MessageID", None),
+            message_id=message_id,
             metadata=metadata,
             mta_response=esp_event.get("Details", None),
             recipient=recipient,

--- a/docs/esps/postmark.rst
+++ b/docs/esps/postmark.rst
@@ -50,6 +50,14 @@ nor ``ANYMAIL_POSTMARK_SERVER_TOKEN`` is set.
 You can override the server token for an individual message in
 its :ref:`esp_extra <postmark-esp-extra>`.
 
+.. setting:: ANYMAIL_POSTMARK_USE_BULK_API
+
+.. rubric:: POSTMARK_USE_BULK_API
+
+.. versionadded:: vNext
+
+Set ``True`` to use Postmark's bulk API for all sending. See :ref:`postmark-bulk-api`.
+
 .. setting:: ANYMAIL_POSTMARK_MESSAGE_STREAM
 
 .. rubric:: POSTMARK_MESSAGE_STREAM
@@ -217,17 +225,87 @@ duplicated for *every* to-recipient.)
 If you want to use batch sending with a regular message (without a template), set
 merge data to an empty dict: `message.merge_data = {}`.
 
-Postmark only applies merge data through its template APIs, so non-empty
-:attr:`~anymail.message.AnymailMessage.merge_data` or
+Postmark only applies merge data through its template APIs or with the bulk API,
+so non-empty :attr:`~anymail.message.AnymailMessage.merge_data` or
 :attr:`~anymail.message.AnymailMessage.merge_global_data` requires a
-:attr:`~anymail.message.AnymailMessage.template_id`. Anymail raises an
-:exc:`~anymail.exceptions.AnymailUnsupportedFeature` error otherwise, rather
-than sending a message where the merge data would be silently ignored.
+:attr:`~anymail.message.AnymailMessage.template_id` (or enabling the bulk API).
+Anymail raises an :exc:`~anymail.exceptions.AnymailUnsupportedFeature` error otherwise,
+rather than sending a message where the merge data would be silently ignored.
 
 See this `Postmark blog post on templates`_ for more information.
 
 .. _Postmark blog post on templates:
     https://postmarkapp.com/blog/special-delivery-postmark-templates
+
+
+.. _postmark-bulk-api:
+
+Using Postmark's bulk API
+-------------------------
+
+.. versionadded:: vNext
+
+Postmark supports a separate `bulk API`_ which is optimized for large-volume
+broadcast sending. By default, Anymail uses one of Postmark's transactional
+sending APIs. You can enable bulk sending with the ``ANYMAIL`` configuration
+option :setting:`POSTMARK_USE_BULK_API <ANYMAIL_POSTMARK_USE_BULK_API>`.
+
+Postmark currently requires customers to request approval for the bulk API.
+Trying to send without that approval will result in a 422 error.
+
+When the bulk API is used, Anymail treats *all* sends as :ref:`batch sending
+<batch-send>` (whether or not :attr:`.merge_data` or some other batch attribute
+is used). That is, each ``to`` address results in a separate message, and
+multiple ``to`` recipients do not see the other ``to`` addresses. (``cc`` and
+``bcc`` are duplicated to each ``to`` recipient.)
+
+Postmark's bulk API allows customizing the message for each recipient, either
+with a :attr:`.template_id` or using inline `{{ variable }}` substitutions
+in the body and subject. In either case, use Anymail's :attr:`.merge_data` and
+:attr:`.merge_global_data` to supply the substitutions.
+
+The bulk API may delay sending, so is not suitable for high-priority
+transactional emails like password resets or order confirmations. It's best to
+direct different types of email to the appropriate API. Using
+:ref:`multiple mailer configurations <topic-email-configuration>` (available
+starting in Django 6.1) is recommended for this. For example:
+
+.. code-block:: python
+
+    MAILERS = {
+        # Configure the default mailer for transactional sending:
+        "default": {
+            "BACKEND": "anymail.backends.postmark.EmailBackend",
+            "OPTIONS": {
+                "server_token": ...,
+            },
+        },
+        # Create a second mailer for broadcast sending with the bulk API:
+        "announcements": {
+            "BACKEND": "anymail.backends.postmark.EmailBackend",
+            "OPTIONS": {
+                "server_token": ...,
+                "use_bulk_api": True,
+                # Set the Postmark message stream ID if needed. If not set,
+                # Postmark's bulk API will use your default broadcast stream.
+                "message_stream": "broadcast-announcements",
+            },
+        },
+    }
+
+With that configuration, you can direct particular emails to the bulk API with
+``using="announcements"`` in the send call.
+
+Because the bulk API may defer sending, Postmark's *Message-ID* is not
+available at send time. To facilitate status tracking, Anymail will generate a
+unique ID for each ``to`` recipient in a bulk send and include it as
+per-recipient metadata (the ``"anymail_id"`` :attr:`~.AnymailMessage.metadata`
+field is reserved for this purpose). The generated IDs are available in the
+:attr:`message.anymail_status.recipients <.AnymailStatus.recipients>` dict
+after sending and in tracking webhooks as :attr:`event.message_id
+<.AnymailTrackingEvent.message_id>`.
+
+.. _bulk API: https://postmarkapp.com/developer/api/bulk-email
 
 
 .. _postmark-webhooks:

--- a/docs/esps/postmark.rst
+++ b/docs/esps/postmark.rst
@@ -50,6 +50,15 @@ nor ``ANYMAIL_POSTMARK_SERVER_TOKEN`` is set.
 You can override the server token for an individual message in
 its :ref:`esp_extra <postmark-esp-extra>`.
 
+.. setting:: ANYMAIL_POSTMARK_MESSAGE_STREAM
+
+.. rubric:: POSTMARK_MESSAGE_STREAM
+
+.. versionadded:: vNext
+
+The Postmark message stream ID to use for sending. If not set, Postmark will
+use the default transactional message stream for most sends, or the default
+broadcast message stream for bulk API sends.
 
 .. setting:: ANYMAIL_POSTMARK_API_URL
 
@@ -76,7 +85,7 @@ Example:
     .. code-block:: python
 
         message.esp_extra = {
-            'MessageStream': 'marketing',  # send using specific message stream ID
+            'FuturePostmarkOption': 'value',
             'server_token': '<API server token for just this message>',
         }
 

--- a/tests/test_postmark_backend.py
+++ b/tests/test_postmark_backend.py
@@ -1,5 +1,6 @@
 import json
 from decimal import Decimal
+from unittest.mock import patch
 
 from django.core import mail
 from django.test import SimpleTestCase, tag
@@ -907,6 +908,183 @@ class PostmarkBackendAnymailFeatureTests(PostmarkBackendMockAPITestCase):
         self.assertIn("Don't know how to send this data to Postmark", str(err))
         # original message:
         self.assertRegex(str(err), r"Decimal.*is not JSON serializable")
+
+
+@tag("postmark")
+@override_settings(
+    MAILERS={
+        "default": {
+            "BACKEND": "anymail.backends.postmark.EmailBackend",
+            "OPTIONS": {
+                "server_token": "test_server_token",
+                "use_bulk_api": True,
+            },
+        },
+    }
+)
+class PostmarkBulkApiTests(PostmarkBackendMockAPITestCase):
+    DEFAULT_RAW_RESPONSE = json.dumps(
+        {
+            "Id": "238848c1-57c7-4811-9e22-6dbcd7f9f239",
+            "SubmittedAt": "2026-08-27T18:13:28.1768928Z",
+            "TotalMessages": 1,
+            "PercentageCompleted": 0,
+            "Status": "Accepted",
+            "Subject": "Subject",
+            "ReleasedCount": 0,
+            "FailedCount": 0,
+        }
+    ).encode()
+
+    def setUp(self):
+        super().setUp()
+
+        # Patch uuid4 to generate predictable message_ids for testing
+        patch_uuid4 = patch(
+            "anymail.backends.postmark.uuid.uuid4",
+            side_effect=[f"mocked-uuid-{n:d}" for n in range(1, 10)],
+        )
+        patch_uuid4.start()
+        self.addCleanup(patch_uuid4.stop)
+
+    def test_uses_bulk_api(self):
+        self.message.send()
+        self.assert_esp_called("/email/bulk")
+        data = self.get_api_call_json()
+        self.assertEqual(data["Subject"], "Subject")
+        self.assertEqual(data["TextBody"], "Text Body")
+        self.assertEqual(data["From"], "from@example.com")
+        self.assertEqual(
+            data["Messages"],
+            [
+                {
+                    "To": "to@example.com",
+                    "Metadata": {"anymail_id": "mocked-uuid-1"},
+                }
+            ],
+        )
+        status = self.message.anymail_status
+        self.assertEqual(
+            status.recipients["to@example.com"].message_id, "mocked-uuid-1"
+        )
+        self.assertEqual(status.recipients["to@example.com"].status, "queued")
+
+    def test_all_options(self):
+        message = AnymailMessage(
+            from_email="from@example.com",
+            to=["one@example.com", "Second Recipient <two@example.com>"],
+            cc=["cc@example.com"],
+            bcc=["bcc@example.com"],
+            subject="Newsletter {{issue_date}}",
+            body="Newsletter for {{name}}...",
+            merge_global_data={"issue_date": "2026 Aug 29"},
+            merge_data={
+                "one@example.com": {"name": "One"},
+                "two@example.com": {"name": "Two"},
+            },
+            headers={"X-Custom": "header"},
+            merge_headers={
+                "two@example.com": {"List-Unsubscribe": "mailto:unsub+2@example.com"},
+            },
+            metadata={"issue_id": "12345"},
+            merge_metadata={
+                "one@example.com": {"first_issue": "yes"},
+            },
+        )
+        message.attach_alternative("<b>Newsletter for {{name}}...</b>", "text/html")
+        # Postmark's bulk API sends the same attachments to all recipients
+        message.attach("newsletter.txt", "Newsletter", "text/plain")
+
+        message.send()
+        data = self.get_api_call_json()
+        self.maxDiff = None
+        self.assertEqual(
+            data,
+            {
+                "From": "from@example.com",
+                "Subject": "Newsletter {{issue_date}}",
+                "TextBody": "Newsletter for {{name}}...",
+                "HtmlBody": "<b>Newsletter for {{name}}...</b>",
+                "Attachments": [
+                    {
+                        "Name": "newsletter.txt",
+                        "Content": "TmV3c2xldHRlcg==",
+                        "ContentType": 'text/plain; charset="utf-8"',
+                    }
+                ],
+                "Headers": [{"Name": "X-Custom", "Value": "header"}],
+                "Messages": [
+                    {
+                        "To": "one@example.com",
+                        "Cc": "cc@example.com",
+                        "Bcc": "bcc@example.com",
+                        "TemplateModel": {
+                            "issue_date": "2026 Aug 29",
+                            "name": "One",
+                        },
+                        "Metadata": {
+                            "anymail_id": "mocked-uuid-1",
+                            "issue_id": "12345",
+                            "first_issue": "yes",
+                        },
+                    },
+                    {
+                        "To": "Second Recipient <two@example.com>",
+                        "Cc": "cc@example.com",
+                        "Bcc": "bcc@example.com",
+                        "TemplateModel": {
+                            "issue_date": "2026 Aug 29",
+                            "name": "Two",
+                        },
+                        "Headers": [
+                            {"Name": "X-Custom", "Value": "header"},
+                            {
+                                "Name": "List-Unsubscribe",
+                                "Value": "mailto:unsub+2@example.com",
+                            },
+                        ],
+                        "Metadata": {
+                            "anymail_id": "mocked-uuid-2",
+                            "issue_id": "12345",
+                        },
+                    },
+                ],
+            },
+        )
+
+    def test_bulk_api_not_enabled(self):
+        self.set_mock_response(
+            status_code=422,
+            json_data={
+                "ErrorCode": 14,
+                "Message": "This endpoint requires approval to access. Contact support"
+                " to use the Bulk API postmarkapp.com/contact",
+            },
+        )
+        with self.assertRaisesMessage(
+            AnymailAPIError, "This endpoint requires approval to access."
+        ):
+            self.message.send()
+
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.postmark.EmailBackend",
+                "OPTIONS": {
+                    "server_token": "test_server_token",
+                    "use_bulk_api": True,
+                    "generate_message_id": False,
+                },
+            },
+        }
+    )
+    def test_disable_generated_message_id(self):
+        self.message.send()
+        self.assert_esp_called("/email/bulk")
+        data = self.get_api_call_json()
+        self.assertEqual(data["Messages"], [{"To": "to@example.com"}])
+        status = self.message.anymail_status
+        self.assertIsNone(status.recipients["to@example.com"].message_id)
 
 
 @tag("postmark")

--- a/tests/test_postmark_backend.py
+++ b/tests/test_postmark_backend.py
@@ -752,6 +752,7 @@ class PostmarkBackendAnymailFeatureTests(PostmarkBackendMockAPITestCase):
         """
         self.message.send()
         data = self.get_api_call_json()
+        self.assertNotIn("MessageStream", data)
         self.assertNotIn("Metadata", data)
         self.assertNotIn("Tag", data)
         self.assertNotIn("TemplateId", data)
@@ -779,6 +780,31 @@ class PostmarkBackendAnymailFeatureTests(PostmarkBackendMockAPITestCase):
         )
         data = self.get_api_call_json()
         self.assertNotIn("server_token", data)  # not in the json
+
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "anymail.backends.postmark.EmailBackend",
+                "OPTIONS": {
+                    "message_stream": "custom-message-stream",
+                    "server_token": "test_server_token",
+                },
+            },
+        },
+    )
+    def test_message_stream(self):
+        with self.subTest("default"):
+            self.message.send()
+            data = self.get_api_call_json()
+            self.assertEqual(data["MessageStream"], "custom-message-stream")
+
+        with self.subTest("esp_extra override"):
+            self.message.esp_extra = {
+                "MessageStream": "message-specific-message-stream",
+            }
+            self.message.send()
+            data = self.get_api_call_json()
+            self.assertEqual(data["MessageStream"], "message-specific-message-stream")
 
     # noinspection PyUnresolvedReferences
     def test_send_attaches_anymail_status(self):

--- a/tests/test_postmark_webhooks.py
+++ b/tests/test_postmark_webhooks.py
@@ -475,3 +475,33 @@ class PostmarkDeliveryTestCase(WebhookTestCase):
         event = kwargs["event"]
         self.assertEqual(event.event_type, "unsubscribed")
         self.assertEqual(event.message_id, "5555555-5555555-5555-5555555")
+
+    def test_bulk_api_delivery_event(self):
+        raw_event = {
+            "MessageID": "b09e614f-d179-491a-8c1d-fc5073da65a2",
+            "Recipient": "recipient@example.com",
+            "DeliveredAt": "2026-08-27T18:06:22Z",
+            "Details": "smtp;250 2.0.0 OK  ...",
+            "Tag": "",
+            "ServerID": 1773622,
+            "Metadata": {"anymail_id": "mocked-uuid-1"},
+            "RecordType": "Delivery",
+            "MessageStream": "broadcast",
+        }
+        response = self.client.post(
+            "/anymail/postmark/tracking/",
+            content_type="application/json",
+            data=json.dumps(raw_event),
+        )
+        self.assertEqual(response.status_code, 200)
+        kwargs = self.assert_handler_called_once_with(
+            self.tracking_handler,
+            sender=PostmarkTrackingWebhookView,
+            event=ANY,
+            esp_name="Postmark",
+        )
+        event = kwargs["event"]
+        self.assertIsInstance(event, AnymailTrackingEvent)
+        self.assertEqual(event.event_type, "delivered")
+        self.assertEqual(event.recipient, "recipient@example.com")
+        self.assertEqual(event.message_id, "mocked-uuid-1")


### PR DESCRIPTION
Add support for Postmark's bulk API and configuration option to specify the message stream ID.

Closes #460.