### PR TITLE
Amazon SES: Support inbound S3 encryption

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,10 @@ vNext
 Features
 ~~~~~~~~
 
+* **Amazon SES:** Add support for inbound messages using S3 encryption.
+  This requires the :pypi:`amazon-s3-encryption-client-python` package, which
+  is now included when installing with the ``django-anymail[amazon-ses]`` extra.
+
 * **Mailtrap:** Support signature verification for tracking event webhooks.
 
 * **Mailtrap:** Add support for inbound email. See

--- a/anymail/webhooks/amazon_ses.py
+++ b/anymail/webhooks/amazon_ses.py
@@ -43,6 +43,27 @@ except ImportError:
         AnymailImproperlyInstalled(missing_package="boto3", install_extra="amazon-ses")
     )
 
+try:
+    from s3_encryption import (
+        CommitmentPolicy,
+        S3EncryptionClient,
+        S3EncryptionClientConfig,
+    )
+    from s3_encryption.exceptions import S3EncryptionClientSecurityError
+    from s3_encryption.materials.kms_keyring import KmsKeyring
+except ImportError:
+    # The encryption client is required only for inbound S3 encrypted messages.
+    S3EncryptionClient = _LazyError(
+        AnymailImproperlyInstalled(
+            missing_package="amazon-s3-encryption-client-python",
+            install_extra="amazon-ses",
+        )
+    )
+    S3EncryptionClientConfig = S3EncryptionClient
+    CommitmentPolicy = S3EncryptionClient
+    KmsKeyring = S3EncryptionClient
+    S3EncryptionClientSecurityError = object
+
 
 class AmazonSESBaseWebhookView(AnymailBaseWebhookView):
     """Base view class for Amazon SES webhooks (SNS Notifications)"""
@@ -363,6 +384,15 @@ class AmazonSESInboundWebhookView(AmazonSESBaseWebhookView):
 
     signal = inbound
 
+    def __init__(self, **kwargs):
+        self.kms_key_id = get_anymail_setting(
+            "inbound_kms_key_id",
+            esp_name=self.esp_name,
+            kwargs=kwargs,
+            default=None,
+        )
+        super().__init__(**kwargs)
+
     def esp_to_anymail_events(self, ses_event, sns_message):
         ses_event_type = ses_event.get("notificationType")
         if ses_event_type != "Received":
@@ -388,10 +418,15 @@ class AmazonSESInboundWebhookView(AmazonSESBaseWebhookView):
         elif action_type == "S3":
             # Download message from s3 and parse. (SNS has 15s limit
             # for an http response; hope download doesn't take that long)
-            fp = self.download_s3_object(
-                bucket_name=action_object["bucketName"],
-                object_key=action_object["objectKey"],
-            )
+            bucket_name = action_object["bucketName"]
+            object_key = action_object["objectKey"]
+            if self.kms_key_id:
+                # This assumes all inbound messages are encrypted. If we needed
+                # to support mixed encrypted/unencrypted, we could check the
+                # object's x-amz-key-v2 / x-amz-key metadata first.
+                fp = self.download_encrypted_s3_object(bucket_name, object_key)
+            else:
+                fp = self.download_s3_object(bucket_name, object_key)
             try:
                 message = AnymailInboundMessage.parse_raw_mime_file(fp)
             finally:
@@ -459,6 +494,51 @@ class AmazonSESInboundWebhookView(AmazonSESBaseWebhookView):
         finally:
             s3_client.close()
 
+    def download_encrypted_s3_object(
+        self, bucket_name: str, object_key: str
+    ) -> typing.IO:
+        """Return verified plaintext for an encrypted SES S3 receipt object."""
+        s3_client = self.get_boto_client("s3")
+        kms_client = self.get_boto_client("kms")
+        body = None
+        try:
+            # SES uses AES-GCM without key commitment, so we must enable legacy
+            # algorithms and use a policy that doesn't require key commitment.
+            keyring = KmsKeyring(
+                kms_client,
+                self.kms_key_id,
+                enable_legacy_wrapping_algorithms=True,
+            )
+            config = S3EncryptionClientConfig(
+                keyring,
+                commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT,
+            )
+            encryption_client = S3EncryptionClient(s3_client, config)
+            response = encryption_client.get_object(Bucket=bucket_name, Key=object_key)
+            body = response["Body"]
+        except ClientError as err:
+            # improve the botocore error message
+            raise AnymailBotoClientAPIError(
+                "Anymail AmazonSESInboundWebhookView couldn't download"
+                f" S3 object '{bucket_name}:{object_key}'",
+                client_error=err,
+            ) from err
+        except S3EncryptionClientSecurityError as err:
+            raise AnymailBotoClientSecurityError(
+                "Anymail AmazonSESInboundWebhookView failed decrypting"
+                f" S3 object '{bucket_name}:{object_key}'",
+                client_error=err,
+            ) from err
+        else:
+            bytesio = io.BytesIO(body.read())
+            bytesio.seek(0)
+            return bytesio
+        finally:
+            if body is not None:
+                body.close()
+            kms_client.close()
+            s3_client.close()
+
 
 class AnymailBotoClientAPIError(AnymailAPIError, ClientError):
     """An AnymailAPIError that is also a Boto ClientError"""
@@ -471,4 +551,16 @@ class AnymailBotoClientAPIError(AnymailAPIError, ClientError):
             operation_name=client_error.operation_name,
         )
         # emulate AnymailError init:
+        self.args = args
+
+
+class AnymailBotoClientSecurityError(AnymailAPIError, S3EncryptionClientSecurityError):
+    """An AnymailAPIError that is also a Boto S3EncryptionClientSecurityError"""
+
+    def __init__(self, *args, client_error):
+        assert isinstance(client_error, S3EncryptionClientSecurityError)
+        AnymailAPIError.__init__(self, *args)
+        S3EncryptionClientSecurityError.__init__(
+            self, getattr(client_error, "kwargs", {}).get("msg") or str(client_error)
+        )
         self.args = args

--- a/docs/esps/amazon_ses.rst
+++ b/docs/esps/amazon_ses.rst
@@ -27,21 +27,32 @@ AWS SDK for Python, and supports sending, tracking, and inbound receiving capabi
 Installation
 ------------
 
-You must ensure the :pypi:`boto3` package is installed to use Anymail's Amazon SES
-backend. Either include the ``amazon-ses`` option when you install Anymail:
+You must ensure the :pypi:`boto3` package is installed to use Anymail's Amazon
+SES backend. If you are using Amazon SES inbound email with S3 encryption, you
+will also need the :pypi:`amazon-s3-encryption-client-python` package.
+
+Either include the ``amazon-ses`` option when you install Anymail (it installs
+both additional dependencies):
 
     .. code-block:: console
 
         $ pip install "django-anymail[amazon-ses]"
 
-or separately run ``pip install boto3``.
+or separately run ``pip install boto3`` and (if needed) ``pip install
+amazon-s3-encryption-client-python``.
 
 .. versionchanged:: 10.0
 
     In earlier releases, the "extra name" could use an underscore
     (``django-anymail[amazon_ses]``). That now causes pip to warn
     that "django-anymail does not provide the extra 'amazon_ses',"
-    and may result in a broken installation that is missing boto3.
+    and may result in a broken installation that is missing required
+    dependencies.
+
+.. versionchanged:: vNext
+
+    The ``django-anymail[amazon-ses]`` installation extra now includes
+    the :pypi:`amazon-s3-encryption-client-python` package.
 
 To send mail with Anymail's Amazon SES backend, set:
 
@@ -517,8 +528,17 @@ To use Anymail's inbound webhook with Amazon SES:
 
    * **For the S3 action:** choose or create any S3 bucket that Boto will be able to read.
      (See :ref:`amazon-ses-iam-permissions`; *don't* use a world-readable bucket!)
-     "Object key prefix" is optional. Anymail does *not* currently support the
-     "Encrypt message" option. Finally, choose the SNS Topic you created in step 2.
+     "Object key prefix" is optional.
+
+     Anymail supports (but doesn't require) the "Encrypt message" option. If
+     you enable it, you must also set :setting:`AMAZON_SES_INBOUND_KMS_KEY_ID
+     <ANYMAIL_AMAZON_SES_INBOUND_KMS_KEY_ID>` to the selected KMS key id.
+
+     Finally, choose the SNS Topic you created in step 2.
+
+     .. versionadded:: vNext
+
+        Support for encrypted messages in the S3 receipt action.
 
 Amazon SES will likely deliver a test message to your Anymail inbound handler immediately
 after you complete the last step.
@@ -693,6 +713,32 @@ accepting Amazon SNS subscription confirmation requests.
 See :ref:`amazon-ses-confirm-sns-subscriptions` above.
 
 
+.. setting:: ANYMAIL_AMAZON_SES_INBOUND_KMS_KEY_ID
+
+.. rubric:: AMAZON_SES_INBOUND_KMS_KEY_ID
+
+.. versionadded:: vNext
+
+Required only for Amazon SES inbound email using the S3 receipt action with the
+"encrypt message" option enabled. action. The KMS key ID or ARN configured for
+the S3 encryption. The credentials Anymail uses must have ``kms:Decrypt``
+permission for this key.
+
+  .. code-block:: python
+
+      ANYMAIL = {
+          ...
+          "AMAZON_SES_INBOUND_KMS_KEY_ID": "arn:aws:kms:...:key/MY-KEY-ID",
+      }
+
+You can use the exact ARN or a key alias. E.g., for the default AWS-managed key
+you can use ``"arn:aws:kms:REGION:AWSACCOUNTID:alias/aws/ses"`` with your
+12-digit account ID and the AWS region where you are receiving inbound email.
+
+Setting this without enabling "encrypt message" in the inbound S3 receipt
+action will result in the error "S3EncryptionClientError: Instruction file body
+is empty for key" when Anymail tries to decrypt an inbound message.
+
 .. _amazon-ses-iam-permissions:
 
 IAM permissions
@@ -716,6 +762,9 @@ Anymail requires IAM permissions that will allow it to use these actions:
   * With an "S3 action" receipt rule: ``s3:GetObject`` on the S3 bucket
     and prefix used (or S3 Access Control List read access for inbound
     messages in that bucket)
+  * If encryption is enabled on the S3 receipt rule: also ``kms:Decrypt`` on
+    the KMS key configured for the S3 action (key aliases are *not* supported
+    in the example policy below; you must use the actual key ARN.)
 
 
 This IAM policy covers all of those:
@@ -741,6 +790,10 @@ This IAM policy covers all of those:
             "Effect": "Allow",
             "Action": ["s3:GetObject"],
             "Resource": ["arn:aws:s3:::MY-PRIVATE-BUCKET-NAME/MY-INBOUND-PREFIX/*"]
+          }, {
+            "Effect": "Allow",
+            "Action": ["kms:Decrypt"],
+            "Resource": ["arn:aws:kms:MY-REGION:MY-ACCOUNT-ID:key/MY-KMS-KEY-ID"]
           }]
         }
 
@@ -787,10 +840,11 @@ for any features you aren't using, and you may want to add additional restrictio
 
 * For inbound S3 delivery, there are multiple ways to control S3 access and data
   retention. See Amazon's `Managing access permissions to your Amazon S3 resources`_.
-  (And obviously, you should *never store incoming emails to a public bucket!*)
+  (And of course, you should *never store incoming emails to a public bucket!*)
 
   Also, you may need to grant Amazon SES (but *not* Anymail) permission to *write*
-  to your inbound bucket. See Amazon's `Giving permissions to Amazon SES for email receiving`_.
+  to your inbound bucket and (if encryption is enabled on the S3 receipt rule) to
+  encrypt the message. See Amazon's `Giving permissions to Amazon SES for email receiving`_.
 
 * For all operations, you can limit source IP, allowable times, user agent, and more.
   (Requests from Anymail will include "django-anymail/*version*" along with Boto's user-agent.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
 # ESP-specific additional dependencies.
 # (For simplicity, requests is included in the base dependencies.)
 # (Do not use underscores in extra names: they get normalized to hyphens.)
-amazon-ses = ["boto3>=1.24.6"]
+amazon-ses = ["boto3>=1.43.6", "amazon-s3-encryption-client-python"]
 brevo = []
 mailersend = []
 mailgun = []

--- a/tests/test_amazon_ses_inbound.py
+++ b/tests/test_amazon_ses_inbound.py
@@ -2,9 +2,9 @@ import json
 from base64 import b64encode
 from datetime import datetime, timezone
 from textwrap import dedent
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
-from django.test import tag
+from django.test import override_settings, tag
 
 from anymail.exceptions import AnymailAPIError, AnymailConfigurationError
 from anymail.inbound import AnymailInboundMessage
@@ -35,7 +35,35 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
         self.mock_client = self.mock_session.return_value.client
         #: boto3.session.Session().client('s3', ...)
         self.mock_s3 = self.mock_client.return_value
+        #: boto3.session.Session().client('kms', ...)
+        self.mock_kms = MagicMock()
+
+        def mock_get_boto_client(service_name, **kwargs):
+            return {"s3": self.mock_s3, "kms": self.mock_kms}[service_name]
+
+        self.mock_client.side_effect = mock_get_boto_client
         self.mock_s3.download_fileobj.side_effect = mock_download_fileobj
+
+        self.patch_encryption_client = patch(
+            "anymail.webhooks.amazon_ses.S3EncryptionClient", autospec=True
+        )
+        self.mock_encryption_client = self.patch_encryption_client.start()
+        self.addCleanup(self.patch_encryption_client.stop)
+        self.patch_encryption_config = patch(
+            "anymail.webhooks.amazon_ses.S3EncryptionClientConfig", autospec=True
+        )
+        self.mock_encryption_config = self.patch_encryption_config.start()
+        self.addCleanup(self.patch_encryption_config.stop)
+        self.patch_keyring = patch(
+            "anymail.webhooks.amazon_ses.KmsKeyring", autospec=True
+        )
+        self.mock_keyring = self.patch_keyring.start()
+        self.addCleanup(self.patch_keyring.stop)
+        self.patch_commitment_policy = patch(
+            "anymail.webhooks.amazon_ses.CommitmentPolicy", autospec=True
+        )
+        self.mock_commitment_policy = self.patch_commitment_policy.start()
+        self.addCleanup(self.patch_commitment_policy.stop)
 
     TEST_MIME_MESSAGE = dedent("""\
         Return-Path: <bounce-handler@mail.example.org>
@@ -378,6 +406,126 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
             " the HeadObject operation: Forbidden",
             str(cm.exception),
         )
+
+    @override_settings(
+        ANYMAIL_AMAZON_SES_INBOUND_KMS_KEY_ID="arn:aws:kms:us-east-1:111111111111:alias/aws/ses"
+    )
+    def test_inbound_s3_encrypted(self):
+        """Should decrypt an encrypted S3 receipt object before parsing it"""
+        decrypted_body = (
+            self.mock_encryption_client.return_value.get_object.return_value["Body"]
+        )
+        decrypted_body.read.return_value = self.TEST_MIME_MESSAGE.encode("ascii")
+
+        raw_ses_event = {
+            "notificationType": "Received",
+            "mail": {
+                "source": "envelope-from@example.org",
+                "timestamp": "2018-03-30T17:21:51.636Z",
+                "messageId": "encrypted-message-id",
+            },
+            "receipt": {
+                "recipients": ["inbound@example.com"],
+                "action": {
+                    "type": "S3",
+                    "bucketName": "InboundEmailBucket-KeepPrivate",
+                    "objectKey": "inbound/encrypted-message-id",
+                },
+            },
+        }
+        raw_sns_message = {
+            "Type": "Notification",
+            "MessageId": "8f6dee70-c885-558a-be7d-bd48bbf5335e",
+            "TopicArn": "arn:aws:sns:us-east-1:111111111111:SES_Inbound",
+            "Message": json.dumps(raw_ses_event),
+        }
+
+        response = self.post_from_sns("/anymail/amazon_ses/inbound/", raw_sns_message)
+        self.assertEqual(response.status_code, 200)
+        self.mock_client.assert_has_calls(
+            [call("s3", config=ANY), call("kms", config=ANY)]
+        )
+        self.mock_keyring.assert_called_once_with(
+            self.mock_kms,
+            "arn:aws:kms:us-east-1:111111111111:alias/aws/ses",
+            enable_legacy_wrapping_algorithms=True,
+        )
+        self.mock_encryption_config.assert_called_once_with(
+            self.mock_keyring.return_value,
+            commitment_policy=self.mock_commitment_policy.REQUIRE_ENCRYPT_ALLOW_DECRYPT,
+        )
+        self.mock_encryption_client.assert_called_once_with(
+            self.mock_s3, self.mock_encryption_config.return_value
+        )
+        self.mock_encryption_client.return_value.get_object.assert_called_once_with(
+            Bucket="InboundEmailBucket-KeepPrivate", Key="inbound/encrypted-message-id"
+        )
+        decrypted_body.close.assert_called_once_with()
+        self.mock_s3.close.assert_called_once_with()
+        self.mock_kms.close.assert_called_once_with()
+
+        kwargs = self.assert_handler_called_once_with(
+            self.inbound_handler,
+            sender=AmazonSESInboundWebhookView,
+            event=ANY,
+            esp_name="Amazon SES",
+        )
+        message = kwargs["event"].message
+        self.assertEqual(message.subject, "Test inbound message")
+        self.assertEqual(message.text, "It's a body\N{HORIZONTAL ELLIPSIS}\n")
+
+    @override_settings(
+        ANYMAIL_AMAZON_SES_INBOUND_KMS_KEY_ID="arn:aws:kms:us-east-1:111111111111:alias/aws/ses"
+    )
+    def test_inbound_s3_encrypted_client_error(self):
+        """Issue a helpful error when encrypted S3 download fails"""
+        from botocore.exceptions import ClientError
+
+        self.mock_encryption_client.return_value.get_object.side_effect = ClientError(
+            {"Error": {"Code": 403, "Message": "Forbidden"}},
+            operation_name="GetObject",
+        )
+
+        view = AmazonSESInboundWebhookView()
+        with self.assertRaisesMessage(
+            AnymailAPIError,
+            "Anymail AmazonSESInboundWebhookView couldn't download"
+            " S3 object 'YourBucket:inbound/the_object_key'",
+        ) as cm:
+            view.download_encrypted_s3_object("YourBucket", "inbound/the_object_key")
+
+        self.assertIsInstance(cm.exception, ClientError)
+        self.assertIn(
+            "ClientError: An error occurred (403) when calling"
+            " the GetObject operation: Forbidden",
+            str(cm.exception),
+        )
+        self.mock_s3.close.assert_called_once_with()
+        self.mock_kms.close.assert_called_once_with()
+
+    @override_settings(
+        ANYMAIL_AMAZON_SES_INBOUND_KMS_KEY_ID="arn:aws:kms:us-east-1:111111111111:alias/aws/ses"
+    )
+    def test_inbound_s3_encrypted_decryption_error(self):
+        """Issue a helpful error when encrypted S3 object verification fails"""
+        from s3_encryption.exceptions import S3EncryptionClientSecurityError
+
+        self.mock_encryption_client.return_value.get_object.side_effect = (
+            S3EncryptionClientSecurityError("Authentication tag verification failed")
+        )
+
+        view = AmazonSESInboundWebhookView()
+        with self.assertRaisesMessage(
+            AnymailAPIError,
+            "Anymail AmazonSESInboundWebhookView failed decrypting"
+            " S3 object 'YourBucket:inbound/the_object_key'",
+        ) as cm:
+            view.download_encrypted_s3_object("YourBucket", "inbound/the_object_key")
+
+        self.assertIsInstance(cm.exception, S3EncryptionClientSecurityError)
+        self.assertIn("Authentication tag verification failed", str(cm.exception))
+        self.mock_s3.close.assert_called_once_with()
+        self.mock_kms.close.assert_called_once_with()
 
     def test_incorrect_tracking_event(self):
         """The inbound webhook should warn if it receives tracking events"""


### PR DESCRIPTION
Add support for "encrypt message" in the Amazon SES inbound S3 receipt action, using AWS's official amazon-s3-encryption-client-python package.

Closes #471.