### PR TITLE
Inbound streaming

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,9 @@ Features
   Postmark message stream used for sending. With Django 6.1 ``MAILERS`` you can
   use a different ``message_stream`` for each configured mailer.
 
+* **Resend:** Large inbound messages are now downloaded and parsed
+  incrementally to reduce memory usage.
+
 Fixes
 ~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,9 @@ Features
 Fixes
 ~~~~~
 
+* **Amazon SES:** Avoid a Python bug that could corrupt images and attachments
+  in inbound messages.
+
 * **Inbound:** ``AnymailInboundMessage``'s ``text`` and ``html`` attributes
   and ``get_content_text()`` method now normalize line endings to ``\n``.
   In earlier releases, either ``\n`` or ``\r\n`` could be returned,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,14 @@ Features
   Postmark message stream used for sending. With Django 6.1 ``MAILERS`` you can
   use a different ``message_stream`` for each configured mailer.
 
+Fixes
+~~~~~
+
+* **Inbound:** ``AnymailInboundMessage``'s ``text`` and ``html`` attributes
+  and ``get_content_text()`` method now normalize line endings to ``\n``.
+  In earlier releases, either ``\n`` or ``\r\n`` could be returned,
+  inconsistently and somewhat unpredictably.
+
 
 v15.1
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,9 @@ Features
   This requires the :pypi:`amazon-s3-encryption-client-python` package, which
   is now included when installing with the ``django-anymail[amazon-ses]`` extra.
 
+* **Amazon SES:** When using the S3 receipt action for inbound email, large
+  messages are now downloaded and parsed incrementally to reduce memory usage.
+
 * **Mailtrap:** Support signature verification for tracking event webhooks.
 
 * **Mailtrap:** Add support for inbound email. See

--- a/anymail/inbound.py
+++ b/anymail/inbound.py
@@ -255,14 +255,6 @@ class AnymailInboundMessage(EmailMessage):
         return BytesParser(cls, policy=default_policy).parsebytes(b)
 
     @classmethod
-    def parse_raw_mime_file(cls, fp):
-        """Returns a new AnymailInboundMessage parsed from file-like object fp"""
-        if isinstance(fp.read(0), bytes):
-            return BytesParser(cls, policy=default_policy).parse(fp)
-        else:
-            return Parser(cls, policy=default_policy).parse(fp)
-
-    @classmethod
     def parse_raw_mime_chunks(cls, chunks):
         """Returns a new AnymailInboundMessage parsed from (streamed) chunks"""
         parser = BytesFeedParser(cls, policy=default_policy)

--- a/anymail/inbound.py
+++ b/anymail/inbound.py
@@ -220,7 +220,10 @@ class AnymailInboundMessage(EmailMessage):
                 return payload
             charset = charset or self.get_content_charset("US-ASCII")
             errors = errors or "replace"
-            return payload.decode(charset, errors=errors)
+            text = payload.decode(charset, errors=errors)
+            # ByteParser/ByteFeedParser inconsistently handle line endings
+            # in text parts, depending on how they are called. Normalize to \n.
+            return re.sub(r"\r\n|\r", "\n", text)
 
     def as_uploaded_file(self):
         """Return the attachment converted to a Django UploadedFile"""

--- a/anymail/utils.py
+++ b/anymail/utils.py
@@ -41,6 +41,9 @@ UNSET = type("UNSET", (object,), {})  # Used as non-None default value
 SMTP7BIT = email.policy.SMTP.clone(cte_type="7bit")
 
 
+DEFAULT_DOWNLOAD_CHUNK_SIZE = 64 * 1024  # For streaming downloads (e.g., inbound)
+
+
 def concat_lists(*args):
     """
     Combines all non-UNSET args, by concatenating lists (or sequence-like types).

--- a/anymail/webhooks/amazon_ses.py
+++ b/anymail/webhooks/amazon_ses.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import io
 import json
-import typing
 from base64 import b64decode
+from collections.abc import Iterator
 
 from django.http import HttpResponse
 from django.utils.dateparse import parse_datetime
@@ -24,7 +23,7 @@ from ..signals import (
     inbound,
     tracking,
 )
-from ..utils import get_anymail_setting, getfirst
+from ..utils import DEFAULT_DOWNLOAD_CHUNK_SIZE, get_anymail_setting, getfirst
 from .base import AnymailBaseWebhookView
 
 try:
@@ -391,6 +390,12 @@ class AmazonSESInboundWebhookView(AmazonSESBaseWebhookView):
             kwargs=kwargs,
             default=None,
         )
+        self.chunk_size = get_anymail_setting(
+            "download_chunk_size",
+            esp_name=self.esp_name,
+            kwargs=kwargs,
+            default=DEFAULT_DOWNLOAD_CHUNK_SIZE,
+        )
         super().__init__(**kwargs)
 
     def esp_to_anymail_events(self, ses_event, sns_message):
@@ -416,21 +421,12 @@ class AmazonSESInboundWebhookView(AmazonSESBaseWebhookView):
             else:
                 message = AnymailInboundMessage.parse_raw_mime(content)
         elif action_type == "S3":
-            # Download message from s3 and parse. (SNS has 15s limit
+            # Stream and parse message from s3. (SNS has 15s limit
             # for an http response; hope download doesn't take that long)
-            bucket_name = action_object["bucketName"]
-            object_key = action_object["objectKey"]
-            if self.kms_key_id:
-                # This assumes all inbound messages are encrypted. If we needed
-                # to support mixed encrypted/unencrypted, we could check the
-                # object's x-amz-key-v2 / x-amz-key metadata first.
-                fp = self.download_encrypted_s3_object(bucket_name, object_key)
-            else:
-                fp = self.download_s3_object(bucket_name, object_key)
-            try:
-                message = AnymailInboundMessage.parse_raw_mime_file(fp)
-            finally:
-                fp.close()
+            chunks = self.fetch_s3_chunks(
+                action_object["bucketName"], action_object["objectKey"]
+            )
+            message = AnymailInboundMessage.parse_raw_mime_chunks(chunks)
         else:
             raise AnymailConfigurationError(
                 "Anymail's Amazon SES inbound webhook works only with 'SNS' or 'S3'"
@@ -470,52 +466,35 @@ class AmazonSESInboundWebhookView(AmazonSESBaseWebhookView):
             )
         ]
 
-    def download_s3_object(self, bucket_name: str, object_key: str) -> typing.IO:
-        """
-        Download bucket_name/object_key from S3. Must return a file-like object
-        (bytes or text) opened for reading. Caller is responsible for closing it.
-        """
-        s3_client = self.get_boto_client("s3")
-        bytesio = io.BytesIO()
+    def fetch_s3_chunks(self, bucket_name: str, object_key: str) -> Iterator[bytes]:
+        s3_client = kms_client = stream = None
         try:
-            s3_client.download_fileobj(bucket_name, object_key, bytesio)
-        except ClientError as err:
-            bytesio.close()
-            # improve the botocore error message
-            raise AnymailBotoClientAPIError(
-                "Anymail AmazonSESInboundWebhookView couldn't download"
-                " S3 object '{bucket_name}:{object_key}'"
-                "".format(bucket_name=bucket_name, object_key=object_key),
-                client_error=err,
-            ) from err
-        else:
-            bytesio.seek(0)
-            return bytesio
-        finally:
-            s3_client.close()
+            s3_client = self.get_boto_client("s3")
+            if self.kms_key_id:
+                # SES uses AES-GCM without key commitment, so we must enable legacy
+                # algorithms and use a policy that doesn't require key commitment.
+                kms_client = self.get_boto_client("kms")
+                keyring = KmsKeyring(
+                    kms_client,
+                    self.kms_key_id,
+                    enable_legacy_wrapping_algorithms=True,
+                )
+                config = S3EncryptionClientConfig(
+                    keyring,
+                    commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT,
+                    enable_delayed_authentication=True,
+                )
+                encryption_client = S3EncryptionClient(s3_client, config)
+                response = encryption_client.get_object(
+                    Bucket=bucket_name, Key=object_key
+                )
+            else:
+                response = s3_client.get_object(Bucket=bucket_name, Key=object_key)
 
-    def download_encrypted_s3_object(
-        self, bucket_name: str, object_key: str
-    ) -> typing.IO:
-        """Return verified plaintext for an encrypted SES S3 receipt object."""
-        s3_client = self.get_boto_client("s3")
-        kms_client = self.get_boto_client("kms")
-        body = None
-        try:
-            # SES uses AES-GCM without key commitment, so we must enable legacy
-            # algorithms and use a policy that doesn't require key commitment.
-            keyring = KmsKeyring(
-                kms_client,
-                self.kms_key_id,
-                enable_legacy_wrapping_algorithms=True,
-            )
-            config = S3EncryptionClientConfig(
-                keyring,
-                commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT,
-            )
-            encryption_client = S3EncryptionClient(s3_client, config)
-            response = encryption_client.get_object(Bucket=bucket_name, Key=object_key)
-            body = response["Body"]
+            stream = response["Body"]
+            for chunk in stream.iter_chunks(self.chunk_size):
+                yield chunk
+
         except ClientError as err:
             # improve the botocore error message
             raise AnymailBotoClientAPIError(
@@ -529,15 +508,13 @@ class AmazonSESInboundWebhookView(AmazonSESBaseWebhookView):
                 f" S3 object '{bucket_name}:{object_key}'",
                 client_error=err,
             ) from err
-        else:
-            bytesio = io.BytesIO(body.read())
-            bytesio.seek(0)
-            return bytesio
         finally:
-            if body is not None:
-                body.close()
-            kms_client.close()
-            s3_client.close()
+            if stream:
+                stream.close()
+            if kms_client:
+                kms_client.close()
+            if s3_client:
+                s3_client.close()
 
 
 class AnymailBotoClientAPIError(AnymailAPIError, ClientError):

--- a/anymail/webhooks/mailtrap.py
+++ b/anymail/webhooks/mailtrap.py
@@ -19,7 +19,7 @@ from ..signals import (
     inbound,
     tracking,
 )
-from ..utils import get_anymail_setting
+from ..utils import DEFAULT_DOWNLOAD_CHUNK_SIZE, get_anymail_setting
 from .base import AnymailBaseWebhookView
 
 if sys.version_info < (3, 11):
@@ -196,8 +196,6 @@ class MailtrapInboundWebhookView(MailtrapWebhookView):
 
     signal = inbound
 
-    RAW_MIME_DOWNLOAD_CHUNK_SIZE = 16 * 1024
-
     # (Declaring class attr allows override by kwargs in View.as_view.)
     api_token = None
     api_url = None
@@ -215,6 +213,12 @@ class MailtrapInboundWebhookView(MailtrapWebhookView):
         )
         if not self.api_url.endswith("/"):
             self.api_url += "/"
+        self.chunk_size = get_anymail_setting(
+            "download_chunk_size",
+            esp_name=self.esp_name,
+            kwargs=kwargs,
+            default=DEFAULT_DOWNLOAD_CHUNK_SIZE,
+        )
         super().__init__(_secret_name="inbound_secret", **kwargs)
 
     def parse_events(self, request):
@@ -300,6 +304,4 @@ class MailtrapInboundWebhookView(MailtrapWebhookView):
         # The raw_message_url is a signed S3 URL -- no auth required.
         with requests.get(raw_message_url, stream=True) as response:
             response.raise_for_status()
-            yield from response.iter_content(
-                chunk_size=self.RAW_MIME_DOWNLOAD_CHUNK_SIZE
-            )
+            yield from response.iter_content(chunk_size=self.chunk_size)

--- a/anymail/webhooks/resend.py
+++ b/anymail/webhooks/resend.py
@@ -20,7 +20,11 @@ from ..signals import (
     inbound,
     tracking,
 )
-from ..utils import get_anymail_setting, parse_single_address
+from ..utils import (
+    DEFAULT_DOWNLOAD_CHUNK_SIZE,
+    get_anymail_setting,
+    parse_single_address,
+)
 from .base import AnymailBaseWebhookView, AnymailCoreWebhookView
 
 try:
@@ -218,7 +222,6 @@ class ResendInboundWebhookView(SvixWebhookValidationMixin, AnymailBaseWebhookVie
     _secret_setting_name = "inbound_secret"
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
         self.api_key = get_anymail_setting(
             "api_key",
             esp_name=self.esp_name,
@@ -233,6 +236,13 @@ class ResendInboundWebhookView(SvixWebhookValidationMixin, AnymailBaseWebhookVie
         )
         if not self.api_url.endswith("/"):
             self.api_url += "/"
+        self.chunk_size = get_anymail_setting(
+            "download_chunk_size",
+            esp_name=self.esp_name,
+            kwargs=kwargs,
+            default=DEFAULT_DOWNLOAD_CHUNK_SIZE,
+        )
+        super().__init__(**kwargs)
 
     def parse_events(self, request):
         esp_event = json.loads(request.body.decode("utf-8"))
@@ -284,9 +294,11 @@ class ResendInboundWebhookView(SvixWebhookValidationMixin, AnymailBaseWebhookVie
         raw = data.get("raw") or {}
         raw_url = raw.get("download_url")
         if raw_url:
-            raw_response = requests.get(raw_url)
-            raw_response.raise_for_status()
-            return AnymailInboundMessage.parse_raw_mime_bytes(raw_response.content)
+            with requests.get(raw_url, stream=True) as raw_response:
+                raw_response.raise_for_status()
+                return AnymailInboundMessage.parse_raw_mime_chunks(
+                    raw_response.iter_content(self.chunk_size)
+                )
 
         # Fall back to constructing from parsed fields
         headers = []

--- a/docs/inbound.rst
+++ b/docs/inbound.rst
@@ -232,10 +232,16 @@ Normalized inbound message
         (such as those sometimes composed by the Apple Mail app), this will
         include only the text before the first inline image.
 
+        .. versionchanged:: vNext
+            Line endings are normalized to ``\n``.
+
     .. attribute:: html
 
         The message's HTML message body as a `str`, or `None` if the
         message doesn't include an HTML body.
+
+        .. versionchanged:: vNext
+            Line endings are normalized to ``\n``.
 
     .. attribute:: attachments
 
@@ -406,6 +412,9 @@ have these methods:
 
         The errors param is as in :meth:`~bytes.decode`. The default "replace" substitutes the
         Unicode "replacement character" for any illegal characters in the text.
+
+        .. versionchanged:: vNext
+            Line endings are normalized to ``\n``.
 
     .. method:: get_content_bytes()
 

--- a/tests/test_amazon_ses_inbound.py
+++ b/tests/test_amazon_ses_inbound.py
@@ -208,10 +208,10 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
             ["Recipient <inbound@example.com>", "someone-else@example.org"],
         )
         self.assertEqual(message.subject, "Test inbound message")
-        self.assertEqual(message.text, "It's a body\N{HORIZONTAL ELLIPSIS}\r\n")
+        self.assertEqual(message.text, "It's a body\N{HORIZONTAL ELLIPSIS}\n")
         self.assertEqual(
             message.html,
-            """<div dir="ltr">It's a body\N{HORIZONTAL ELLIPSIS}</div>\r\n""",
+            """<div dir="ltr">It's a body\N{HORIZONTAL ELLIPSIS}</div>\n""",
         )
         self.assertIs(message.spam_detected, False)
 
@@ -277,10 +277,10 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
             ["Recipient <inbound@example.com>", "someone-else@example.org"],
         )
         self.assertEqual(message.subject, "Test inbound message")
-        self.assertEqual(message.text, "It's a body\N{HORIZONTAL ELLIPSIS}\r\n")
+        self.assertEqual(message.text, "It's a body\N{HORIZONTAL ELLIPSIS}\n")
         self.assertEqual(
             message.html,
-            """<div dir="ltr">It's a body\N{HORIZONTAL ELLIPSIS}</div>\r\n""",
+            """<div dir="ltr">It's a body\N{HORIZONTAL ELLIPSIS}</div>\n""",
         )
         self.assertIs(message.spam_detected, True)
 

--- a/tests/test_amazon_ses_inbound.py
+++ b/tests/test_amazon_ses_inbound.py
@@ -9,6 +9,7 @@ from django.test import override_settings, tag
 from anymail.exceptions import AnymailAPIError, AnymailConfigurationError
 from anymail.inbound import AnymailInboundMessage
 from anymail.signals import AnymailInboundEvent
+from anymail.utils import DEFAULT_DOWNLOAD_CHUNK_SIZE
 from anymail.webhooks.amazon_ses import AmazonSESInboundWebhookView
 
 from .test_amazon_ses_webhooks import AmazonSESWebhookTestsMixin
@@ -19,7 +20,7 @@ from .webhook_cases import WebhookTestCase
 class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
     def setUp(self):
         super().setUp()
-        # Mock boto3.session.Session().client('s3').download_fileobj. (We could also
+        # Mock boto3.session.Session().client('s3').get_object. (We could also
         # use botocore.stub.Stubber, but mock works well with our test structure.)
         self.patch_boto3_session = patch(
             "anymail.webhooks.amazon_ses.boto3.session.Session", autospec=True
@@ -27,10 +28,16 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
         self.mock_session = self.patch_boto3_session.start()  # boto3.session.Session
         self.addCleanup(self.patch_boto3_session.stop)
 
-        def mock_download_fileobj(bucket, key, fileobj):
-            fileobj.write(self.mock_s3_downloadables[bucket][key])
+        def mock_get_object(*, Bucket, Key):
+            stream = MagicMock()
+            stream.iter_chunks.return_value = iter(
+                [self.mock_s3_downloadables[Bucket][Key]]
+            )
+            self.mock_s3_streams.append(stream)
+            return {"Body": stream}
 
         self.mock_s3_downloadables = {}  #: bucket: key: bytes
+        self.mock_s3_streams = []
         #: boto3.session.Session().client
         self.mock_client = self.mock_session.return_value.client
         #: boto3.session.Session().client('s3', ...)
@@ -42,7 +49,7 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
             return {"s3": self.mock_s3, "kms": self.mock_kms}[service_name]
 
         self.mock_client.side_effect = mock_get_boto_client
-        self.mock_s3.download_fileobj.side_effect = mock_download_fileobj
+        self.mock_s3.get_object.side_effect = mock_get_object
 
         self.patch_encryption_client = patch(
             "anymail.webhooks.amazon_ses.S3EncryptionClient", autospec=True
@@ -325,11 +332,15 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
         self.assertEqual(response.status_code, 200)
 
         self.mock_client.assert_called_once_with("s3", config=ANY)
-        self.mock_s3.download_fileobj.assert_called_once_with(
-            "InboundEmailBucket-KeepPrivate",
-            "inbound/fqef5sop459utgdf4o9lqbsv7jeo73pejig34301",
-            ANY,
+        self.mock_s3.get_object.assert_called_once_with(
+            Bucket="InboundEmailBucket-KeepPrivate",
+            Key="inbound/fqef5sop459utgdf4o9lqbsv7jeo73pejig34301",
         )
+        self.mock_s3_streams[0].iter_chunks.assert_called_once_with(
+            DEFAULT_DOWNLOAD_CHUNK_SIZE
+        )
+        self.mock_s3_streams[0].close.assert_called_once_with()
+        self.mock_s3.close.assert_called_once_with()
 
         kwargs = self.assert_handler_called_once_with(
             self.inbound_handler,
@@ -371,7 +382,7 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
         # "An error occurred (403) when calling the HeadObject operation: Forbidden"
         from botocore.exceptions import ClientError
 
-        self.mock_s3.download_fileobj.side_effect = ClientError(
+        self.mock_s3.get_object.side_effect = ClientError(
             {"Error": {"Code": 403, "Message": "Forbidden"}},
             operation_name="HeadObject",
         )
@@ -406,6 +417,7 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
             " the HeadObject operation: Forbidden",
             str(cm.exception),
         )
+        self.mock_s3.close.assert_called_once_with()
 
     @override_settings(
         ANYMAIL_AMAZON_SES_INBOUND_KMS_KEY_ID="arn:aws:kms:us-east-1:111111111111:alias/aws/ses"
@@ -415,7 +427,9 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
         decrypted_body = (
             self.mock_encryption_client.return_value.get_object.return_value["Body"]
         )
-        decrypted_body.read.return_value = self.TEST_MIME_MESSAGE.encode("ascii")
+        decrypted_body.iter_chunks.return_value = iter(
+            [self.TEST_MIME_MESSAGE.encode("ascii")]
+        )
 
         raw_ses_event = {
             "notificationType": "Received",
@@ -453,6 +467,7 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
         self.mock_encryption_config.assert_called_once_with(
             self.mock_keyring.return_value,
             commitment_policy=self.mock_commitment_policy.REQUIRE_ENCRYPT_ALLOW_DECRYPT,
+            enable_delayed_authentication=True,
         )
         self.mock_encryption_client.assert_called_once_with(
             self.mock_s3, self.mock_encryption_config.return_value
@@ -460,6 +475,7 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
         self.mock_encryption_client.return_value.get_object.assert_called_once_with(
             Bucket="InboundEmailBucket-KeepPrivate", Key="inbound/encrypted-message-id"
         )
+        decrypted_body.iter_chunks.assert_called_once_with(DEFAULT_DOWNLOAD_CHUNK_SIZE)
         decrypted_body.close.assert_called_once_with()
         self.mock_s3.close.assert_called_once_with()
         self.mock_kms.close.assert_called_once_with()
@@ -492,7 +508,7 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
             "Anymail AmazonSESInboundWebhookView couldn't download"
             " S3 object 'YourBucket:inbound/the_object_key'",
         ) as cm:
-            view.download_encrypted_s3_object("YourBucket", "inbound/the_object_key")
+            list(view.fetch_s3_chunks("YourBucket", "inbound/the_object_key"))
 
         self.assertIsInstance(cm.exception, ClientError)
         self.assertIn(
@@ -510,9 +526,18 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
         """Issue a helpful error when encrypted S3 object verification fails"""
         from s3_encryption.exceptions import S3EncryptionClientSecurityError
 
-        self.mock_encryption_client.return_value.get_object.side_effect = (
-            S3EncryptionClientSecurityError("Authentication tag verification failed")
+        def mock_iter_chunks(chunk_size):
+            # Delayed authentication yields unverified plaintext, then reports an
+            # invalid authentication tag when the stream is read to completion.
+            yield b"unverified plaintext"
+            raise S3EncryptionClientSecurityError(
+                "Authentication tag verification failed"
+            )
+
+        decrypted_body = (
+            self.mock_encryption_client.return_value.get_object.return_value["Body"]
         )
+        decrypted_body.iter_chunks.side_effect = mock_iter_chunks
 
         view = AmazonSESInboundWebhookView()
         with self.assertRaisesMessage(
@@ -520,10 +545,12 @@ class AmazonSESInboundTests(WebhookTestCase, AmazonSESWebhookTestsMixin):
             "Anymail AmazonSESInboundWebhookView failed decrypting"
             " S3 object 'YourBucket:inbound/the_object_key'",
         ) as cm:
-            view.download_encrypted_s3_object("YourBucket", "inbound/the_object_key")
+            list(view.fetch_s3_chunks("YourBucket", "inbound/the_object_key"))
 
         self.assertIsInstance(cm.exception, S3EncryptionClientSecurityError)
         self.assertIn("Authentication tag verification failed", str(cm.exception))
+        decrypted_body.iter_chunks.assert_called_once_with(DEFAULT_DOWNLOAD_CHUNK_SIZE)
+        decrypted_body.close.assert_called_once_with()
         self.mock_s3.close.assert_called_once_with()
         self.mock_kms.close.assert_called_once_with()
 

--- a/tests/test_brevo_inbound.py
+++ b/tests/test_brevo_inbound.py
@@ -87,10 +87,10 @@ class BrevoInboundTestCase(WebhookTestCase):
         self.assertEqual([str(e) for e in message.cc], ["test+cc@anymail.dev"])
         self.assertEqual(message.subject, "Testing Brevo inbound")
         self.assertEqual(message.date.isoformat(" "), "2023-07-17 11:11:22-07:00")
-        self.assertEqual(message.text, "This is a *test message*.\r\n\n- Sender\r\n")
+        self.assertEqual(message.text, "This is a *test message*.\n\n- Sender\n")
         self.assertEqual(
             message.html,
-            '<div dir="ltr">This is a <u>test message</u>.<div><br></div><div>- Mike</div><div><br></div></div>\r\n',  # NOQA: E501
+            '<div dir="ltr">This is a <u>test message</u>.<div><br></div><div>- Mike</div><div><br></div></div>\n',  # NOQA: E501
         )
 
         self.assertIsNone(message.envelope_sender)

--- a/tests/test_inbound.py
+++ b/tests/test_inbound.py
@@ -1,7 +1,6 @@
 import quopri
 from base64 import b64encode
 from email.utils import collapse_rfc2231_value
-from io import BytesIO
 from textwrap import dedent
 
 from django.test import SimpleTestCase
@@ -9,7 +8,7 @@ from django.test import SimpleTestCase
 from anymail.exceptions import AnymailDeprecationWarning
 from anymail.inbound import AnymailInboundMessage
 
-from .utils import SAMPLE_IMAGE_FILENAME, sample_email_path, sample_image_content
+from .utils import SAMPLE_IMAGE_FILENAME, sample_image_content
 
 SAMPLE_IMAGE_CONTENT = sample_image_content()
 
@@ -269,32 +268,6 @@ class AnymailInboundMessageConstructionTests(SimpleTestCase):
         msg = AnymailInboundMessage.parse_raw_mime(raw)
         self.assertEqual(msg.text, "Unicode ✓")  # *not* "Unicode \\u2713"
 
-    def test_parse_raw_mime_file_text(self):
-        with open(sample_email_path()) as fp:
-            msg = AnymailInboundMessage.parse_raw_mime_file(fp)
-        self.assertEqual(msg["Subject"], "Test email")
-        self.assertEqual(msg.text, "Hi Bob, This is a message. Thanks!\n")
-        self.assertEqual(
-            msg.get_all("Received"),
-            [  # this is the first line in the sample email file
-                "by luna.mailgun.net with SMTP mgrt 8734663311733;"
-                " Fri, 03 May 2013 18:26:27 +0000"
-            ],
-        )
-
-    def test_parse_raw_mime_file_bytes(self):
-        with open(sample_email_path(), mode="rb") as fp:
-            msg = AnymailInboundMessage.parse_raw_mime_file(fp)
-        self.assertEqual(msg["Subject"], "Test email")
-        self.assertEqual(msg.text, "Hi Bob, This is a message. Thanks!\n")
-        self.assertEqual(
-            msg.get_all("Received"),
-            [  # this is the first line in the sample email file
-                "by luna.mailgun.net with SMTP mgrt 8734663311733;"
-                " Fri, 03 May 2013 18:26:27 +0000"
-            ],
-        )
-
     def test_all_parsers_remove_cr_from_text_parts(self):
         raw = dedent("""\
             Subject: test
@@ -304,9 +277,6 @@ class AnymailInboundMessageConstructionTests(SimpleTestCase):
             """).replace("\n", "\r\n").encode()
         with self.subTest("parse_raw_mime_bytes"):
             msg = AnymailInboundMessage.parse_raw_mime_bytes(raw)
-            self.assertEqual(msg.text, "Line 1\nLine 2\n")
-        with self.subTest("parse_raw_mime_file"):
-            msg = AnymailInboundMessage.parse_raw_mime_file(BytesIO(raw))
             self.assertEqual(msg.text, "Line 1\nLine 2\n")
         with self.subTest("parse_raw_mime_chunks"):
             msg = AnymailInboundMessage.parse_raw_mime_chunks([raw])

--- a/tests/test_inbound.py
+++ b/tests/test_inbound.py
@@ -1,6 +1,7 @@
 import quopri
 from base64 import b64encode
 from email.utils import collapse_rfc2231_value
+from io import BytesIO
 from textwrap import dedent
 
 from django.test import SimpleTestCase
@@ -242,7 +243,7 @@ class AnymailInboundMessageConstructionTests(SimpleTestCase):
         )
         msg = AnymailInboundMessage.parse_raw_mime_bytes(raw)
         self.assertEqual(msg["Subject"], "Test bytes")
-        self.assertEqual(msg.get_content_text(), "Ĝi estas retpoŝto.\r\n")
+        self.assertEqual(msg.get_content_text(), "Ĝi estas retpoŝto.\n")
         self.assertEqual(msg.get_content_bytes(), b"\xd8i estas retpo\xfeto.\r\n")
         self.assertEqual(msg.defects, [])
 
@@ -293,6 +294,23 @@ class AnymailInboundMessageConstructionTests(SimpleTestCase):
                 " Fri, 03 May 2013 18:26:27 +0000"
             ],
         )
+
+    def test_all_parsers_remove_cr_from_text_parts(self):
+        raw = dedent("""\
+            Subject: test
+
+            Line 1
+            Line 2
+            """).replace("\n", "\r\n").encode()
+        with self.subTest("parse_raw_mime_bytes"):
+            msg = AnymailInboundMessage.parse_raw_mime_bytes(raw)
+            self.assertEqual(msg.text, "Line 1\nLine 2\n")
+        with self.subTest("parse_raw_mime_file"):
+            msg = AnymailInboundMessage.parse_raw_mime_file(BytesIO(raw))
+            self.assertEqual(msg.text, "Line 1\nLine 2\n")
+        with self.subTest("parse_raw_mime_chunks"):
+            msg = AnymailInboundMessage.parse_raw_mime_chunks([raw])
+            self.assertEqual(msg.text, "Line 1\nLine 2\n")
 
 
 class AnymailInboundMessageConveniencePropTests(SimpleTestCase):
@@ -727,9 +745,7 @@ class EmailParserBehaviorTests(SimpleTestCase):
             )
             self.assertEqual(
                 msg.get_content_text(),
-                "Not-A-Header: This is the body.{end} It is not folded.{end}".format(
-                    end=end
-                ),
+                "Not-A-Header: This is the body.\n It is not folded.\n",
             )
             self.assertEqual(msg.defects, [])
 

--- a/tests/test_mailersend_inbound.py
+++ b/tests/test_mailersend_inbound.py
@@ -292,7 +292,7 @@ class MailerSendInboundTestCase(MailerSendWebhookTestCase):
         self.assertEqual(message.subject, "Testing inbound 🌎")
         self.assertEqual(message.date.isoformat(" "), "2023-03-03 18:22:03-08:00")
         self.assertEqual(
-            message.text, "This is a *test*!\r\n\r\n[image: sample_image.png]\r\n"
+            message.text, "This is a *test*!\n\n[image: sample_image.png]\n"
         )
         self.assertHTMLEqual(
             message.html,
@@ -333,7 +333,7 @@ class MailerSendInboundTestCase(MailerSendWebhookTestCase):
         self.assertEqual(attachments[0].get_filename(), "sample_data.csv")
         self.assertEqual(attachments[0].get_content_type(), "text/csv")
         self.assertEqual(
-            attachments[0].get_content_text(), "Product,Price\r\nWidget,33.20"
+            attachments[0].get_content_text(), "Product,Price\nWidget,33.20"
         )
 
     def test_misconfigured_inbound(self):

--- a/tests/test_mailtrap_inbound.py
+++ b/tests/test_mailtrap_inbound.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY
 
 import responses
 from django.test import override_settings, tag
-from responses.matchers import header_matcher
+from responses.matchers import header_matcher, request_kwargs_matcher
 
 from anymail.exceptions import AnymailConfigurationError
 from anymail.inbound import AnymailInboundMessage
@@ -152,7 +152,11 @@ class MailtrapInboundTestCase(MailtrapWebhookTestCase):
 
         # Mock: download raw MIME
         responses.add(
-            responses.GET, raw_message_url, content_type="message/rfc822", body=raw_mime
+            responses.GET,
+            raw_message_url,
+            content_type="message/rfc822",
+            body=raw_mime,
+            match=[request_kwargs_matcher({"stream": True})],
         )
 
         response = self.client.post(

--- a/tests/test_resend_inbound.py
+++ b/tests/test_resend_inbound.py
@@ -5,7 +5,7 @@ from unittest.mock import ANY
 
 import responses
 from django.test import override_settings, tag
-from responses.matchers import header_matcher
+from responses.matchers import header_matcher, request_kwargs_matcher
 
 from anymail.exceptions import (
     AnymailConfigurationError,
@@ -101,12 +101,13 @@ class ResendInboundTestCase(ResendWebhookTestCase):
             },
         )
 
-        # Mock: download raw MIME
+        # Mock: stream raw MIME
         responses.add(
             responses.GET,
             raw_mime_url,
             content_type="message/rfc822",
             body=raw_mime.encode("utf-8"),
+            match=[request_kwargs_matcher({"stream": True})],
         )
 
         response = self.client_post_signed("/anymail/resend/inbound/", raw_event)


### PR DESCRIPTION
Change Amazon SES inbound (S3) and Resend inbound to use incremental downloads on raw messages (like in the recent Mailtrap inbound feature).

Add an undocumented setting for download chunk size, and use it in all three streaming inbound handlers.

Fix some inconsistencies in inbound text handling uncovered by the changes.
